### PR TITLE
Fix projects table spacing

### DIFF
--- a/submit-web/src/components/Projects/Project.tsx
+++ b/submit-web/src/components/Projects/Project.tsx
@@ -112,7 +112,12 @@ export const Project = ({ accountProject }: ProjectParam) => {
             >
               <SubmissionTable plans={plans} />
             </CardInnerBox>
-            <Divider sx={{ mb: 0.5 }} />
+            <Divider
+              sx={{
+                mb: BCDesignTokens.layoutPaddingXsmall,
+                mt: BCDesignTokens.layoutPaddingSmall,
+              }}
+            />
             <Typography
               variant="body1"
               sx={{
@@ -122,7 +127,9 @@ export const Project = ({ accountProject }: ProjectParam) => {
             >
               Past Submissions
             </Typography>
-            <CardInnerBox sx={{ height: "100%", my: 2 }}>
+            <CardInnerBox
+              sx={{ height: "100%", py: BCDesignTokens.layoutPaddingMedium }}
+            >
               <SubmissionTable headless plans={plans} />
             </CardInnerBox>
           </Box>

--- a/submit-web/src/components/Projects/Project.tsx
+++ b/submit-web/src/components/Projects/Project.tsx
@@ -107,7 +107,9 @@ export const Project = ({ accountProject }: ProjectParam) => {
             >
               Active Submissions
             </Typography>
-            <CardInnerBox sx={{ height: "100%", py: 2 }}>
+            <CardInnerBox
+              sx={{ height: "100%", py: BCDesignTokens.layoutPaddingSmall }}
+            >
               <SubmissionTable plans={plans} />
             </CardInnerBox>
             <Divider sx={{ mb: 0.5 }} />

--- a/submit-web/src/components/Projects/Project.tsx
+++ b/submit-web/src/components/Projects/Project.tsx
@@ -78,7 +78,10 @@ export const Project = ({ accountProject }: ProjectParam) => {
           <Box
             display={"flex"}
             justifyContent={"space-between"}
-            sx={{ py: BCDesignTokens.layoutPaddingXlarge }}
+            sx={{
+              pt: BCDesignTokens.layoutPaddingMedium,
+              pb: BCDesignTokens.layoutPaddingXlarge,
+            }}
           >
             <CardInnerBox>
               <Typography variant="h4" fontWeight={400}>

--- a/submit-web/src/components/Projects/SubmissionTable.tsx
+++ b/submit-web/src/components/Projects/SubmissionTable.tsx
@@ -48,7 +48,7 @@ export default function SubmissionTable({
                 Submitted By
               </TableCell>
               <TableCell
-                align="right"
+                align="center"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
                 Status

--- a/submit-web/src/components/Projects/SubmissionTable.tsx
+++ b/submit-web/src/components/Projects/SubmissionTable.tsx
@@ -28,26 +28,29 @@ export default function SubmissionTable({
           <TableHead sx={{ border: 0 }}>
             <TableRow>
               <TableCell
+                colSpan={6}
                 sx={{
                   color: BCDesignTokens.themeGray70,
-                  width: "30%",
                 }}
               >
                 Submission Name
               </TableCell>
               <TableCell
+                colSpan={2}
                 align="right"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
                 Submitted On
               </TableCell>
               <TableCell
+                colSpan={2}
                 align="right"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
                 Submitted By
               </TableCell>
               <TableCell
+                colSpan={2}
                 align="center"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
@@ -62,6 +65,7 @@ export default function SubmissionTable({
               <TableCell
                 component="th"
                 scope="row"
+                colSpan={6}
                 sx={{
                   borderTop: "2px solid #F2F2F2",
                   borderBottom: "2px solid #F2F2F2",
@@ -69,7 +73,6 @@ export default function SubmissionTable({
                   borderTopLeftRadius: 5,
                   borderBottomLeftRadius: 5,
                   py: BCDesignTokens.layoutPaddingSmall,
-                  width: "30%",
                 }}
               >
                 <Link
@@ -92,6 +95,7 @@ export default function SubmissionTable({
                 </Link>
               </TableCell>
               <TableCell
+                colSpan={2}
                 align="right"
                 sx={{
                   borderTop: "2px solid #F2F2F2",
@@ -102,6 +106,7 @@ export default function SubmissionTable({
                 {plan.submittedDate || "--"}
               </TableCell>
               <TableCell
+                colSpan={2}
                 align="right"
                 sx={{
                   borderTop: "2px solid #F2F2F2",
@@ -112,6 +117,7 @@ export default function SubmissionTable({
                 {plan.submittedBy || "--"}
               </TableCell>
               <TableCell
+                colSpan={2}
                 align="right"
                 sx={{
                   borderTop: "2px solid #F2F2F2",

--- a/submit-web/src/components/Projects/SubmissionTable.tsx
+++ b/submit-web/src/components/Projects/SubmissionTable.tsx
@@ -27,23 +27,28 @@ export default function SubmissionTable({
         {!headless && (
           <TableHead sx={{ border: 0 }}>
             <TableRow>
-              <TableCell sx={{ color: BCDesignTokens.themeGray70 }}>
+              <TableCell
+                sx={{
+                  color: BCDesignTokens.themeGray70,
+                  width: "30%",
+                }}
+              >
                 Submission Name
               </TableCell>
               <TableCell
-                align="center"
+                align="right"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
                 Submitted On
               </TableCell>
               <TableCell
-                align="center"
+                align="right"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
                 Submitted By
               </TableCell>
               <TableCell
-                align="center"
+                align="right"
                 sx={{ color: BCDesignTokens.themeGray70 }}
               >
                 Status
@@ -63,6 +68,9 @@ export default function SubmissionTable({
                   borderLeft: "2px solid #F2F2F2",
                   borderTopLeftRadius: 5,
                   borderBottomLeftRadius: 5,
+                  py: BCDesignTokens.layoutPaddingSmall,
+                  mb: 2,
+                  width: "30%",
                 }}
               >
                 <Link
@@ -85,19 +93,21 @@ export default function SubmissionTable({
                 </Link>
               </TableCell>
               <TableCell
-                align="center"
+                align="right"
                 sx={{
                   borderTop: "2px solid #F2F2F2",
                   borderBottom: "2px solid #F2F2F2",
+                  py: BCDesignTokens.layoutPaddingSmall,
                 }}
               >
                 {plan.submittedDate || "--"}
               </TableCell>
               <TableCell
-                align="center"
+                align="right"
                 sx={{
                   borderTop: "2px solid #F2F2F2",
                   borderBottom: "2px solid #F2F2F2",
+                  py: BCDesignTokens.layoutPaddingSmall,
                 }}
               >
                 {plan.submittedBy || "--"}
@@ -110,6 +120,7 @@ export default function SubmissionTable({
                   borderBottomRightRadius: 5,
                   borderBottom: "2px solid #F2F2F2",
                   borderRight: "2px solid #F2F2F2",
+                  py: BCDesignTokens.layoutPaddingSmall,
                 }}
               >
                 <ProjectStatusChip isCompleted={plan.isCompleted} />

--- a/submit-web/src/components/Projects/SubmissionTable.tsx
+++ b/submit-web/src/components/Projects/SubmissionTable.tsx
@@ -69,7 +69,6 @@ export default function SubmissionTable({
                   borderTopLeftRadius: 5,
                   borderBottomLeftRadius: 5,
                   py: BCDesignTokens.layoutPaddingSmall,
-                  mb: 2,
                   width: "30%",
                 }}
               >


### PR DESCRIPTION
-adjusted padding to table headers

-added more width to the submission name table cell to reduce text overflow on project title(usually submission names are a bit longer)