### PR TITLE
Fix MA's styling changes

### DIFF
--- a/submit-web/package-lock.json
+++ b/submit-web/package-lock.json
@@ -18,14 +18,16 @@
         "@tanstack/react-router": "^1.45.7",
         "@tanstack/router-devtools": "^1.45.7",
         "@tanstack/router-plugin": "^1.45.7",
+        "@types/react-input-mask": "^3.0.5",
         "axios": "^1.7.2",
-        "epic.theme": "^1.0.8",
+        "epic.theme": "^1.0.11",
         "keycloak-js": "^25.0.1",
         "oidc-client-ts": "^3.0.1",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-hook-form": "^7.52.1",
         "react-if": "^4.1.5",
+        "react-input-mask": "^2.0.4",
         "react-oidc-context": "^3.1.0",
         "yup": "^1.4.0",
         "zustand": "^4.5.4"
@@ -4059,6 +4061,14 @@
         "@types/react": "*"
       }
     },
+    "node_modules/@types/react-input-mask": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/react-input-mask/-/react-input-mask-3.0.5.tgz",
+      "integrity": "sha512-vQ1x6ykwjDrDrJZq1zw5/uQ+nqGHUV6bWscsVZJ/qsNwNXWxZm7KRBHLJ5k6TQt3MHjhpoYHzPH6FwjVSZODHA==",
+      "dependencies": {
+        "@types/react": "*"
+      }
+    },
     "node_modules/@types/react-transition-group": {
       "version": "4.4.10",
       "resolved": "https://registry.npmjs.org/@types/react-transition-group/-/react-transition-group-4.4.10.tgz",
@@ -5910,9 +5920,9 @@
       }
     },
     "node_modules/epic.theme": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/epic.theme/-/epic.theme-1.0.8.tgz",
-      "integrity": "sha512-BWgvIcYrjVzeYqnuM+P5PWLjkSuk4am7dGseu5jS0aTqE6C7lAA3759xqUzGee858vQW0vRuwl/UFvcFtEBgDA==",
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/epic.theme/-/epic.theme-1.0.11.tgz",
+      "integrity": "sha512-6iTus/GGKOsahZTV2T4dKpwUlXr5H65RhVfp1bxRpVR5RkA4kJ9060obEbVA6xxIr73itRqQ/eM8ZyTTRiC4Vw==",
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
@@ -7151,6 +7161,14 @@
       "dev": true,
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/invariant": {
+      "version": "2.2.4",
+      "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/is-arrayish": {
@@ -9170,6 +9188,19 @@
         "react": "^16.x || ^17.x || ^18.x"
       }
     },
+    "node_modules/react-input-mask": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/react-input-mask/-/react-input-mask-2.0.4.tgz",
+      "integrity": "sha512-1hwzMr/aO9tXfiroiVCx5EtKohKwLk/NT8QlJXHQ4N+yJJFyUuMT+zfTpLBwX/lK3PkuMlievIffncpMZ3HGRQ==",
+      "dependencies": {
+        "invariant": "^2.2.4",
+        "warning": "^4.0.2"
+      },
+      "peerDependencies": {
+        "react": ">=0.14.0",
+        "react-dom": ">=0.14.0"
+      }
+    },
     "node_modules/react-is": {
       "version": "18.3.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.3.1.tgz",
@@ -10572,6 +10603,14 @@
       },
       "engines": {
         "node": ">=10"
+      }
+    },
+    "node_modules/warning": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/warning/-/warning-4.0.3.tgz",
+      "integrity": "sha512-rpJyN222KWIvHJ/F53XSZv0Zl/accqHR8et1kpaMTD/fLCRxtV8iX8czMzY7sVZupTI3zcUTg8eycS2kNF9l6w==",
+      "dependencies": {
+        "loose-envify": "^1.0.0"
       }
     },
     "node_modules/watchpack": {

--- a/submit-web/package.json
+++ b/submit-web/package.json
@@ -24,7 +24,7 @@
     "@tanstack/router-plugin": "^1.45.7",
     "@types/react-input-mask": "^3.0.5",
     "axios": "^1.7.2",
-    "epic.theme": "^1.0.8",
+    "epic.theme": "latest",
     "keycloak-js": "^25.0.1",
     "oidc-client-ts": "^3.0.1",
     "react": "^18.2.0",

--- a/submit-web/src/components/Projects/Project.tsx
+++ b/submit-web/src/components/Projects/Project.tsx
@@ -52,7 +52,7 @@ export const Project = ({ accountProject }: ProjectParam) => {
       <Box
         sx={{
           borderRadius: "3px",
-          border: `1px solid #F2F2F2`,
+          border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
           boxShadow: "0px 1px 2px rgba(0, 0, 0, 0.1)",
         }}
       >
@@ -78,13 +78,18 @@ export const Project = ({ accountProject }: ProjectParam) => {
           </CardInnerBox>
         </Box>
         <Box height={"100%"} px={BCDesignTokens.layoutPaddingXsmall}>
-          <Divider sx={{ mb: 0.5 }} />
+          <Divider
+            sx={{
+              ml: BCDesignTokens.layoutPaddingSmall,
+              mb: BCDesignTokens.layoutPaddingXsmall,
+            }}
+          />
           <Typography
             variant="body1"
             sx={{
               fontWeight: "bold",
               backgroundColor: BCDesignTokens.themeGold10,
-              pl: BCDesignTokens.layoutPaddingSmall,
+              ml: BCDesignTokens.layoutPaddingSmall,
             }}
           >
             Active Submissions
@@ -101,6 +106,7 @@ export const Project = ({ accountProject }: ProjectParam) => {
             sx={{
               mb: BCDesignTokens.layoutPaddingXsmall,
               mt: BCDesignTokens.layoutPaddingSmall,
+              ml: BCDesignTokens.layoutPaddingSmall,
             }}
           />
           <Typography

--- a/submit-web/src/components/Projects/ProjectTableRow.tsx
+++ b/submit-web/src/components/Projects/ProjectTableRow.tsx
@@ -8,6 +8,7 @@ interface ProjectRowProps {
   subPackage: SubmissionPackage;
   onSubmissionClick: (submissionId: number) => void;
 }
+const border = `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`;
 
 export default function ProjectTableRow({
   subPackage,
@@ -21,9 +22,9 @@ export default function ProjectTableRow({
           scope="row"
           colSpan={6}
           sx={{
-            borderTop: "1px solid #F2F2F2",
-            borderBottom: "1px solid #F2F2F2",
-            borderLeft: "1px solid #F2F2F2",
+            borderTop: border,
+            borderBottom: border,
+            borderLeft: border,
             borderTopLeftRadius: 5,
             borderBottomLeftRadius: 5,
             py: BCDesignTokens.layoutPaddingXsmall,
@@ -54,8 +55,8 @@ export default function ProjectTableRow({
           colSpan={2}
           align="right"
           sx={{
-            borderTop: "1px solid #F2F2F2",
-            borderBottom: "1px solid #F2F2F2",
+            borderTop: border,
+            borderBottom: border,
             py: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
@@ -65,8 +66,8 @@ export default function ProjectTableRow({
           colSpan={2}
           align="right"
           sx={{
-            borderTop: "1px solid #F2F2F2",
-            borderBottom: "1px solid #F2F2F2",
+            borderTop: border,
+            borderBottom: border,
             py: BCDesignTokens.layoutPaddingXsmall,
           }}
         >
@@ -76,11 +77,11 @@ export default function ProjectTableRow({
           colSpan={2}
           align="right"
           sx={{
-            borderTop: "1px solid #F2F2F2",
+            borderTop: border,
             borderTopRightRadius: 5,
             borderBottomRightRadius: 5,
-            borderBottom: "1px solid #F2F2F2",
-            borderRight: "1px solid #F2F2F2",
+            borderBottom: border,
+            borderRight: border,
             py: BCDesignTokens.layoutPaddingXsmall,
           }}
         >

--- a/submit-web/src/components/Shared/ContentBox/index.tsx
+++ b/submit-web/src/components/Shared/ContentBox/index.tsx
@@ -14,7 +14,11 @@ export const ContentBox = ({
   ...rest
 }: ContentBoxProps) => {
   return (
-    <Paper elevation={2} {...rest}>
+    <Paper
+      elevation={2}
+      {...rest}
+      sx={{ boxShadow: BCDesignTokens.surfaceShadowMedium }}
+    >
       <Box
         sx={{
           display: "flex",

--- a/submit-web/src/components/Submission/ItemsTable.tsx
+++ b/submit-web/src/components/Submission/ItemsTable.tsx
@@ -16,7 +16,6 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import SubmissionItemTableRow from "./SubmissionItemTableRow";
 import { SubmissionItem } from "@/models/SubmissionItem";
 import { SubmissionItemTableRow as SubmissionItemTableRowType } from "./types";
-import { mock } from "node:test";
 
 export default function ItemsTable({
   submissionItems,
@@ -33,13 +32,15 @@ export default function ItemsTable({
     setOrderBy(property);
   };
 
-  const mockSubmissionItem = {
-    id: "1",
-    name: "Submission 1",
-    version: "1.0.0",
-    status: "NEW_SUBMISSION",
-  };
-  const sortedSubmissionItems = [mockSubmissionItem, mockSubmissionItem];
+  const sortedSubmissionItems = submissionItems
+    .map((subItem) => ({
+      id: subItem.id,
+      name: subItem.type.name,
+      status: subItem.status,
+      submitted_by: subItem.submitted_by,
+      version: subItem.version,
+    }))
+    .sort(tableSort(order, orderBy));
 
   return (
     <TableContainer component={Box} sx={{ height: "100%" }}>

--- a/submit-web/src/components/Submission/ItemsTable.tsx
+++ b/submit-web/src/components/Submission/ItemsTable.tsx
@@ -16,6 +16,7 @@ import SwapVertIcon from "@mui/icons-material/SwapVert";
 import SubmissionItemTableRow from "./SubmissionItemTableRow";
 import { SubmissionItem } from "@/models/SubmissionItem";
 import { SubmissionItemTableRow as SubmissionItemTableRowType } from "./types";
+import { mock } from "node:test";
 
 export default function ItemsTable({
   submissionItems,
@@ -31,15 +32,14 @@ export default function ItemsTable({
     setOrder(isAsc ? "desc" : "asc");
     setOrderBy(property);
   };
-  const sortedSubmissionItems = submissionItems
-    .map((subItem) => ({
-      id: subItem.id,
-      name: subItem.type.name,
-      status: subItem.status,
-      submitted_by: subItem.submitted_by,
-      version: subItem.version,
-    }))
-    .sort(tableSort(order, orderBy));
+
+  const mockSubmissionItem = {
+    id: "1",
+    name: "Submission 1",
+    version: "1.0.0",
+    status: "NEW_SUBMISSION",
+  };
+  const sortedSubmissionItems = [mockSubmissionItem, mockSubmissionItem];
 
   return (
     <TableContainer component={Box} sx={{ height: "100%" }}>

--- a/submit-web/src/components/Submission/SubmissionItemTableRow.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow.tsx
@@ -18,7 +18,7 @@ type SubmissionItemTableRowProps = {
 const StyledTableCell = styled(TableCell)(() => ({
   borderTop: `1px solid ${BCDesignTokens.themeBlue20}`,
   borderBottom: `1px solid ${BCDesignTokens.themeBlue20}`,
-  py: BCDesignTokens.layoutPaddingXsmall,
+  padding: `${BCDesignTokens.layoutPaddingSmall} !important`,
   "&:first-of-type": {
     borderLeft: `1px solid ${BCDesignTokens.themeBlue20}`,
     borderTopLeftRadius: 5,
@@ -54,10 +54,10 @@ export default function SubmissionItemTableRow({
             }}
           >
             <Typography
-              variant="h5"
+              variant="h6"
               color="inherit"
               fontWeight={900}
-              sx={{ mr: 0.5 }}
+              sx={{ mx: 0.5 }}
             >
               {item.name}
             </Typography>
@@ -65,18 +65,12 @@ export default function SubmissionItemTableRow({
         </StyledTableCell>
         <StyledTableCell align="right"></StyledTableCell>
         <StyledTableCell align="right">{item.version ?? "--"}</StyledTableCell>
-        <StyledTableCell
-          align="right"
-          sx={{ py: BCDesignTokens.layoutPaddingSmall }}
-        >
+        <StyledTableCell align="right">
           <SubmissionStatusChip
             status={SUBMISSION_STATUS.NEW_SUBMISSION.value}
           />
         </StyledTableCell>
-        <StyledTableCell
-          align="right"
-          sx={{ py: BCDesignTokens.layoutPaddingSmall }}
-        >
+        <StyledTableCell align="right">
           <Link
             style={{
               color: BCDesignTokens.typographyColorLink,

--- a/submit-web/src/components/registration/addProjects/ProjectCard/ManagementPlan.tsx
+++ b/submit-web/src/components/registration/addProjects/ProjectCard/ManagementPlan.tsx
@@ -57,7 +57,7 @@ export const ManagementPlan = ({ project }: { project: Project }) => {
           <Box
             sx={{
               borderRadius: "3px",
-              border: `1px solid #F2F2F2`,
+              border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
               boxShadow: "0px 1px 2px rgba(0, 0, 0, 0.1)",
             }}
             height={187}
@@ -73,7 +73,7 @@ export const ManagementPlan = ({ project }: { project: Project }) => {
             <Box height={"50%"}>
               <CardInnerBox
                 sx={{
-                  borderTop: `1px solid #F2F2F2`,
+                  border: `1px solid ${BCDesignTokens.surfaceColorBorderDefault}`,
                 }}
               >
                 <Typography variant="body1">


### PR DESCRIPTION
Talked to MA and there was some styling artifacts missing fixed:
-All borders should be #D8D8D8 surface.color.border.light. (I don't see that on the project cards/table, keep blue border on submission items please))

-Management plan names should be H6 (not on the MP submission)
-Left align Active and Past submission yellow headers to the rest of the content. (I don't see that)

-Rows in tables should be 40px in height and have a 4px corner radius. Border should be 1px. (np for the radius, borders are fine but the sections are still not 40px height)