### PR TITLE
Document Upload UI Tweaks

### DIFF
--- a/submit-web/src/components/FileUpload/Uploader.tsx
+++ b/submit-web/src/components/FileUpload/Uploader.tsx
@@ -1,5 +1,5 @@
-import React from "react";
-import { Grid } from "@mui/material";
+import React, { useState } from "react";
+import { FormHelperText, Grid } from "@mui/material";
 import Dropzone, { Accept } from "react-dropzone";
 import { BCDesignTokens } from "epic.theme";
 
@@ -9,7 +9,10 @@ interface UploaderProps {
   children: React.ReactNode;
   onDrop?: (acceptedFiles: File[]) => void;
   error?: boolean;
+  maxSize?: number;
 }
+const MAX_FILE_SIZE = 250 * 1024 * 1024;
+
 const Uploader = ({
   height = "10em",
   accept = {},
@@ -18,12 +21,27 @@ const Uploader = ({
   },
   error = false,
   children,
+  maxSize = MAX_FILE_SIZE,
 }: UploaderProps) => {
+  const [sizeError, setSizeError] = useState<string | null>(null);
+
   return (
     <Dropzone
-      onDrop={(acceptedFiles) => {
-        if (acceptedFiles.length === 0) return;
-        onDrop(acceptedFiles);
+      maxSize={maxSize}
+      onDrop={(acceptedFiles, rejectedFiles) => {
+        // Check if any files exceed the maximum size
+        const oversizedFiles = rejectedFiles.filter(
+          (file) => file.file.size > maxSize
+        );
+
+        if (oversizedFiles.length > 0) {
+          setSizeError(
+            `This file exceeds the ${maxSize / (1024 * 1024)} MB limit.`
+          );
+        } else {
+          setSizeError(null);
+          onDrop(acceptedFiles);
+        }
       }}
       accept={accept}
     >
@@ -50,7 +68,15 @@ const Uploader = ({
           >
             <input {...getInputProps()} multiple={false} />
             {children}
-          </Grid>
+          </Grid>{" "}
+          {sizeError && (
+            <FormHelperText
+              error
+              style={{ textAlign: "left", marginTop: "8px" }}
+            >
+              {sizeError}
+            </FormHelperText>
+          )}{" "}
         </section>
       )}
     </Dropzone>

--- a/submit-web/src/components/FileUpload/index.tsx
+++ b/submit-web/src/components/FileUpload/index.tsx
@@ -9,14 +9,17 @@ export type FileUploadProps = {
   accept?: Accept;
   onDrop: (acceptedFiles: File[]) => void;
   error?: boolean;
+  maxSize?: number;
 };
 export const FileUpload = ({
   height = "10em",
   accept = {
-    pdf: [],
-    doc: [],
-    docx: [],
-    xls: [],
+    "application/pdf": [],
+    "application/msword": [],
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document":
+      [],
+    "application/vnd.ms-excel": [],
+    "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet": [],
   },
   error = false,
   onDrop,
@@ -38,7 +41,7 @@ export const FileUpload = ({
             color: "#1A5A96",
           }}
         >
-          Select a Filea
+          Select a File
         </span>
       </Typography>
     </Uploader>

--- a/submit-web/src/components/FileUpload/index.tsx
+++ b/submit-web/src/components/FileUpload/index.tsx
@@ -31,14 +31,14 @@ export const FileUpload = ({
         fontWeight={BCDesignTokens.typographyFontWeightsBold}
         sx={{ color: BCDesignTokens.typographyColorSecondary }}
       >
-        Drag and Drop File(s) Here or{" "}
+        Drag and Drop a File Here or{" "}
         <span
           style={{
             textDecoration: "underline",
             color: "#1A5A96",
           }}
         >
-          Select File(s)
+          Select a Filea
         </span>
       </Typography>
     </Uploader>

--- a/submit-web/src/components/FileUpload/index.tsx
+++ b/submit-web/src/components/FileUpload/index.tsx
@@ -9,7 +9,6 @@ export type FileUploadProps = {
   accept?: Accept;
   onDrop: (acceptedFiles: File[]) => void;
   error?: boolean;
-  maxSize?: number;
 };
 export const FileUpload = ({
   height = "10em",

--- a/submit-web/src/components/Shared/controlled/ControlledFileUpload.tsx
+++ b/submit-web/src/components/Shared/controlled/ControlledFileUpload.tsx
@@ -2,16 +2,13 @@ import { FileUploadProps, FileUpload } from "@/components/FileUpload";
 import { FormHelperText, Stack } from "@mui/material";
 import { get } from "lodash";
 import { Controller, useFormContext } from "react-hook-form";
-import { useState } from "react";
 
 type ControlledFileUploadProps = FileUploadProps & {
   name: string;
-  maxSize?: number;
 };
 export const ControlledFileUpload = ({
   name,
   onDrop,
-  maxSize = 250 * 1024 * 1024, // Default max size of 250 MB
   ...otherProps
 }: ControlledFileUploadProps) => {
   const {
@@ -20,9 +17,9 @@ export const ControlledFileUpload = ({
     getValues,
   } = useFormContext();
 
-  const [sizeError, setSizeError] = useState<string | null>(null);
   const error = get(errors, name);
   const helperText = error?.message?.toString() ?? "";
+
   const fileUploadValues: string[] = getValues(name) ?? [];
 
   return (
@@ -34,29 +31,12 @@ export const ControlledFileUpload = ({
           <FileUpload
             {...otherProps}
             onDrop={(acceptedFiles: File[]) => {
-              const validFiles = acceptedFiles.filter((file) => {
-                return file.size <= maxSize;
-              });
-
-              if (validFiles.length < acceptedFiles.length) {
-                setSizeError(
-                  `Some files exceed the ${(maxSize / (1024 * 1024)).toFixed(2)} MB limit.`
-                );
-              } else {
-                setSizeError(null);
-              }
-
-              if (validFiles.length === 0) return;
-
-              field.onChange([
-                ...fileUploadValues,
-                ...validFiles.map((file) => file.name),
-              ]);
-              onDrop(validFiles);
+              if (acceptedFiles.length === 0) return;
+              field.onChange([...fileUploadValues, acceptedFiles[0].name]);
+              onDrop(acceptedFiles);
             }}
-            error={Boolean(error) || Boolean(sizeError)}
+            error={Boolean(error)}
           />
-          {sizeError && <FormHelperText error>{sizeError}</FormHelperText>}
           {error && <FormHelperText error>{helperText}</FormHelperText>}
         </Stack>
       )}
@@ -64,4 +44,4 @@ export const ControlledFileUpload = ({
   );
 };
 
-export default ControlledFileUpload;
+export default FileUpload;

--- a/submit-web/src/components/SubmissionItem/ConsultationRecord/DocumentUploadSection.tsx
+++ b/submit-web/src/components/SubmissionItem/ConsultationRecord/DocumentUploadSection.tsx
@@ -29,7 +29,7 @@ export const DocumentUploadSection = () => {
   const handleOnDrop = (acceptedFiles: File[]) => {
     handleAddDocuments(
       acceptedFiles[0],
-      CONSULTATION_RECORD_DOCUMENT_FOLDERS.CONSULTATION_RECORDS,
+      CONSULTATION_RECORD_DOCUMENT_FOLDERS.CONSULTATION_RECORDS
     );
   };
 
@@ -39,17 +39,17 @@ export const DocumentUploadSection = () => {
   }
 
   const documentSubmissions = submissionItem?.submissions.filter(
-    (submission) => submission.type === SUBMISSION_TYPE.DOCUMENT,
+    (submission) => submission.type === SUBMISSION_TYPE.DOCUMENT
   );
 
   const documentSubmissionIds = documentSubmissions?.map(
-    (submission) => submission.id,
+    (submission) => submission.id
   );
 
   const pendingDocuments = documents.filter(
     (document) =>
       !document.submissionId ||
-      !documentSubmissionIds?.includes(document.submissionId),
+      !documentSubmissionIds?.includes(document.submissionId)
   );
 
   return (
@@ -100,7 +100,7 @@ export const DocumentUploadSection = () => {
             color: EAOColors.ProponentDark,
           }}
         >
-          Accepted file types: pdf, doc, docx, xlsx, Max. file size: 250 MB.
+          Accepted file types: pdf, doc, docx, xlsx. Max. file size: 250 MB.
         </Typography>
       </Grid>
       <When condition={Boolean(documentSubmissions?.length)}>

--- a/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/DocumentUploadSection.tsx
+++ b/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/DocumentUploadSection.tsx
@@ -36,39 +36,39 @@ export const DocumentUploadSection = () => {
   }
 
   const documentSubmissions = submissionItem?.submissions.filter(
-    (submission) => submission.type === SUBMISSION_TYPE.DOCUMENT,
+    (submission) => submission.type === SUBMISSION_TYPE.DOCUMENT
   );
 
   const documentSubmissionIds = documentSubmissions?.map(
-    (submission) => submission.id,
+    (submission) => submission.id
   );
 
   const managementPlanDocuments = documentSubmissions?.filter(
     (submission) =>
       submission.submitted_document.folder ===
-      MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN,
+      MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN
   );
 
   const supportingDocuments = documentSubmissions?.filter(
     (submission) =>
       submission.submitted_document.folder ===
-      MANAGEMENT_PLAN_DOCUMENT_FOLDERS.SUPPORTING,
+      MANAGEMENT_PLAN_DOCUMENT_FOLDERS.SUPPORTING
   );
 
   const pendingDocuments = documents.filter(
     (document) =>
       !document.submissionId ||
-      !documentSubmissionIds?.includes(document.submissionId),
+      !documentSubmissionIds?.includes(document.submissionId)
   );
 
   const pendingManagementPlanDocuments = pendingDocuments.filter(
     (document) =>
-      document.folder === MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN,
+      document.folder === MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN
   );
 
   const pendingSupportingDocuments = pendingDocuments.filter(
     (document) =>
-      document.folder === MANAGEMENT_PLAN_DOCUMENT_FOLDERS.SUPPORTING,
+      document.folder === MANAGEMENT_PLAN_DOCUMENT_FOLDERS.SUPPORTING
   );
   return (
     <Grid container spacing={2}>
@@ -113,7 +113,7 @@ export const DocumentUploadSection = () => {
           onDrop={(acceptedFiles) =>
             handleOnDrop(
               acceptedFiles,
-              MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN,
+              MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN
             )
           }
         />
@@ -123,7 +123,7 @@ export const DocumentUploadSection = () => {
             color: EAOColors.ProponentDark,
           }}
         >
-          Accepted file types: pdf, doc, docx, xlsx, Max. file size: 250 MB.
+          Accepted file types: pdf, doc, docx, xlsx. Max. file size: 250 MB.
         </Typography>
       </Grid>
       <When condition={Boolean(documentSubmissions?.length)}>
@@ -174,7 +174,7 @@ export const DocumentUploadSection = () => {
           onDrop={(acceptedFiles) =>
             handleOnDrop(
               acceptedFiles,
-              MANAGEMENT_PLAN_DOCUMENT_FOLDERS.SUPPORTING,
+              MANAGEMENT_PLAN_DOCUMENT_FOLDERS.SUPPORTING
             )
           }
         />
@@ -184,7 +184,7 @@ export const DocumentUploadSection = () => {
             color: EAOColors.ProponentDark,
           }}
         >
-          Accepted file types: pdf, doc, docx, xlsx, Max. file size: 250 MB.
+          Accepted file types: pdf, doc, docx, xlsx. Max. file size: 250 MB.
         </Typography>
       </Grid>
       <When condition={Boolean(documentSubmissions?.length)}>


### PR DESCRIPTION
The text in this section was changed to “Drag and Drop a File Here or Select a File.”

Changed the comma at the end of the allowed files for a period. “Accepted file types: pdf, doc, docx, xlsx. Max. file size: 250 MB.”

TODO:
MP Upload section should allow only one document upload. The CR upload and supporting Doc Upload in the MP section can have more than one document. 

There is no file removal implemented yet so cannot replace, the previous management plan upload when a new one is uploaded