### PR TITLE
Stay on package table page after package submission

### DIFF
--- a/submit-web/src/routes/_authenticated/_dashboard/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/_authenticated/_dashboard/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -54,9 +54,6 @@ export default function SubmissionPage() {
     mutate: updateStateSubmissionPackage,
     isPending: isSubmittingPackage,
   } = useUpdateStateSubmissionPackage({
-    onSuccess: () => {
-      navigate({ to: `/projects/${accountProject?.id}` });
-    },
     onError: () => {
       notify.error("Failed to submit management plan");
     },


### PR DESCRIPTION
- Remove the onSuccess that navigates to projec page