### PR TITLE
Fix clicking on package in project table causing failure

### DIFF
--- a/submit-api/src/submit_api/schemas/project.py
+++ b/submit-api/src/submit_api/schemas/project.py
@@ -50,6 +50,7 @@ class AccountProjectPackageSchema(Schema):
     submitted_on = fields.DateTime(data_key="submitted_on")
     submitted_by = fields.Str(data_key="submitted_by")
     items = fields.Function(lambda obj: [])
+    account_project_id = fields.Int(data_key="account_project_id")
 
     @pre_dump
     def get_submitted_by(self, obj, **kwargs):


### PR DESCRIPTION
the projects.packages are being returned without the account_project_id, the nav link on click on package name needs it

Add account_project_id in the schema