### PR TITLE
Update package submission and edit items lock and add validation

### DIFF
--- a/submit-api/src/submit_api/resources/staff/package.py
+++ b/submit-api/src/submit_api/resources/staff/package.py
@@ -111,7 +111,7 @@ class PackageUpdateRequestNote(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
-    # @auth.has_one_of_roles([EpicSubmitRole.PROPONENT_CREATE.value])
+    @auth.require
     @cors.crossdomain(origin="*")
     def post(package_id, update_request_id):
         """Create an update request note."""

--- a/submit-api/src/submit_api/services/package.py
+++ b/submit-api/src/submit_api/services/package.py
@@ -2,9 +2,11 @@
 from collections import defaultdict
 from datetime import datetime
 
+from flask import current_app
+
 from submit_api.enums.item_status import ItemStatus
 from submit_api.exceptions import BadRequestError, ResourceNotFoundError
-from submit_api.models import Item as ItemModel
+from submit_api.models import Item as ItemModel, User
 from submit_api.models import Package as PackageModel
 from submit_api.models import PackageType as PackageTypeModel
 from submit_api.models import PackageVersion as PackageVersionModel
@@ -20,6 +22,7 @@ from submit_api.models.queries.package import PackageQueries
 from submit_api.models.submission import SubmissionTypeStatus
 from submit_api.models.item_type import SubmissionItemType
 from submit_api.models.update_request import UpdateRequestType
+from submit_api.models.user import UserType
 from submit_api.utils.constants import (
     MANAGEMENT_PLAN_SUBMISSION_CONFIRMATION_EMAIL_TEMPLATE, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE)
 from submit_api.utils.token_info import TokenInfo
@@ -157,13 +160,33 @@ class PackageService:
 
         session.flush()
 
-    @staticmethod
-    def _get_and_validate_complete_package(package_id) -> PackageModel:
+    @classmethod
+    def _get_and_validate_complete_package(cls, package_id) -> PackageModel:
         """Retrieve and validate that all items in the package are completed."""
         package = PackageModel.find_by_id(package_id)
+        if package.submitted_on:
+            return cls._validate_package_for_resubmit(package)
+
         if any(item.status.value != ItemStatus.COMPLETED.value for item in package.items):
-            raise BadRequestError(
-                "All items must be completed before completing the package")
+            current_app.logger.info(f"Package {package_id} has incomplete items")
+            raise BadRequestError("All items must be completed before completing the package")
+
+        current_app.logger.info(f"Package {package_id} is ready to submit")
+        return package
+
+    @classmethod
+    def _validate_package_for_resubmit(cls, package) -> PackageModel:
+        """Validate that the package is in a state that allows resubmission."""
+        current_app.logger.info(f"Validating package {package.id} for resubmission")
+        if not package.submitted_on:
+            raise BadRequestError("Cannot resubmit a package that has not been submitted")
+        if package.status == PackageStatus.APPROVED:
+            raise BadRequestError("Cannot resubmit a package that has been approved")
+        if package.status == PackageStatus.REJECTED:
+            raise BadRequestError("Cannot resubmit a package that has been rejected")
+        if not package.update_requests:
+            raise BadRequestError("Cannot resubmit a package that has no update requests")
+        current_app.logger.info(f"Package {package.id} is ready to resubmit")
         return package
 
     @staticmethod
@@ -226,9 +249,10 @@ class PackageService:
     @classmethod
     def submit_package(cls, package_id):
         """Submit the package by updating its status and items."""
-        package = cls._get_and_validate_complete_package(package_id)
+        cls._validate_account_user()
 
         with session_scope() as session:
+            package = cls._get_and_validate_complete_package(package_id)
             cls._update_items_status(
                 package.items, ItemStatus.SUBMITTED.value, session)
             cls._update_package_status(package_id, session, package)
@@ -387,6 +411,14 @@ class PackageService:
         return package
 
     @classmethod
+    def _validate_account_user(cls):
+        """Validate the account user."""
+        auth_guid = TokenInfo.get_id()
+        user = User.get_by_guid(auth_guid)
+        if not user or not user.type == UserType.PROPONENT:
+            raise BadRequestError("User is not an account user")
+
+    @classmethod
     def _validate_create_update_request_note(cls, package_id, update_request):
         """Validate the creation of an update request note."""
         if not update_request:
@@ -399,3 +431,4 @@ class PackageService:
                 "Note already exists for the update request")
         if not update_request.active:
             raise BadRequestError("Update request is not active")
+        cls._validate_account_user()

--- a/submit-web/src/components/Submission/ItemsTable.tsx
+++ b/submit-web/src/components/Submission/ItemsTable.tsx
@@ -11,7 +11,7 @@ import { BCDesignTokens } from "epic.theme";
 import SubmissionItemTableRow from "./SubmissionItemTableRow";
 import { SUBMISSION_ITEM_METHOD } from "@/models/SubmissionItem";
 import { StyledTableHeadCell } from "../Shared/Table/common";
-import { SUBMISSION_STATUS, SUBMISSION_TYPE } from "@/models/Submission";
+import { SUBMISSION_TYPE } from "@/models/Submission";
 import { usePackageTableStore } from "./packageTableStore";
 import { useAccount } from "@/store/accountStore";
 import { USER_TYPE } from "@/models/User";
@@ -118,7 +118,7 @@ export default function ItemsTable({ submissionPackage }: ItemsTableProps) {
                 isValidating &&
                 !isSubmissionItemReadyToSubmit({
                   submissionItem: subItem,
-                  updateRequests: update_requests,
+                  submissionPackage: submissionPackage,
                 })
               }
             />

--- a/submit-web/src/components/Submission/ItemsTable.tsx
+++ b/submit-web/src/components/Submission/ItemsTable.tsx
@@ -20,6 +20,7 @@ import InternalDocumentsRows from "../SubmissionItem/InternalDocuments/Rows";
 import { SubmissionPackage } from "@/models/Package";
 import { useMemo } from "react";
 import { UPDATE_REQUEST_TYPE } from "@/models/UpdateRequest";
+import { isSubmissionItemReadyToSubmit } from "./utils";
 
 type ItemsTableProps = Readonly<{
   submissionPackage: SubmissionPackage;
@@ -115,7 +116,10 @@ export default function ItemsTable({ submissionPackage }: ItemsTableProps) {
               item={subItem}
               error={
                 isValidating &&
-                subItem.status !== SUBMISSION_STATUS.COMPLETED.value
+                !isSubmissionItemReadyToSubmit({
+                  submissionItem: subItem,
+                  updateRequests: update_requests,
+                })
               }
             />
           ))}

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
@@ -10,9 +10,15 @@ import { SUBMISSION_STATUS } from "@/models/Submission";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import DocumentRow from "../DocumentRow";
 import { Unless, When } from "react-if";
-import { SubmissionItemTableCell, SubmissionItemTableRowProps } from ".";
-import { PackageTableRow } from ".";
 import EmptyRow from "@/components/Projects/ProjectTable/EmptyRow";
+import {
+  PackageTableRow,
+  SubmissionItemTableCell,
+  SubmissionItemTableRowProps,
+} from ".";
+import { useQueryClient } from "@tanstack/react-query";
+import { getSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
+import { SubmissionPackage } from "@/models/Package";
 
 export default function ProponentSubmissionItemTableRow({
   item,
@@ -24,6 +30,13 @@ export default function ProponentSubmissionItemTableRow({
   });
 
   const { name, id, submissions, has_document, status, isUpdateRequest } = item;
+  const queryClient = useQueryClient();
+
+  const submissionPackage = queryClient.getQueryData<SubmissionPackage>(
+    getSubmissionPackageQueryOptions({
+      packageId: Number(submissionPackageId),
+    }).queryKey,
+  );
 
   const actionLabel = has_document ? "Add/Edit Files" : "Fill/Edit Form";
 
@@ -63,7 +76,12 @@ export default function ProponentSubmissionItemTableRow({
           />
         </SubmissionItemTableCell>
         <SubmissionItemTableCell align="right">
-          <Unless condition={status === SUBMISSION_STATUS.SUBMITTED.value}>
+          <Unless
+            condition={
+              submissionPackage?.submitted_on &&
+              submissionPackage.update_requests.length === 0
+            }
+          >
             <Typography
               variant="body2"
               sx={{

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
@@ -6,7 +6,6 @@ import {
 } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { SubmissionStatusChipStack } from "../../SubmissionStatusChip";
-import { SUBMISSION_STATUS } from "@/models/Submission";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import DocumentRow from "../DocumentRow";
 import { Unless, When } from "react-if";

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/index.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/index.tsx
@@ -64,10 +64,10 @@ export const PackageTableRow = ({
   );
 };
 
-export type SubmissionItemTableRowProps = {
+export type SubmissionItemTableRowProps = Readonly<{
   item: SubmissionItemTableRowType;
   error?: boolean;
-};
+}>;
 
 export default function SubmissionItemTableRow({
   item,

--- a/submit-web/src/components/Submission/utils.ts
+++ b/submit-web/src/components/Submission/utils.ts
@@ -1,0 +1,20 @@
+import { SUBMISSION_STATUS, SubmissionStatus } from "@/models/Submission";
+import { UpdateRequest } from "@/models/UpdateRequest";
+
+export const isSubmissionItemReadyToSubmit = ({
+  submissionItem,
+  updateRequests,
+}: {
+  updateRequests: UpdateRequest[];
+  submissionItem: {
+    id: number;
+    status: SubmissionStatus;
+  };
+}) => {
+  if (updateRequests.length > 0) {
+    return true;
+  }
+  const isSubmissionItemCompleted =
+    submissionItem.status === SUBMISSION_STATUS.COMPLETED.value;
+  return isSubmissionItemCompleted;
+};

--- a/submit-web/src/components/Submission/utils.ts
+++ b/submit-web/src/components/Submission/utils.ts
@@ -1,17 +1,20 @@
+import { SubmissionPackage } from "@/models/Package";
 import { SUBMISSION_STATUS, SubmissionStatus } from "@/models/Submission";
-import { UpdateRequest } from "@/models/UpdateRequest";
 
 export const isSubmissionItemReadyToSubmit = ({
   submissionItem,
-  updateRequests,
+  submissionPackage,
 }: {
-  updateRequests: UpdateRequest[];
+  submissionPackage: SubmissionPackage;
   submissionItem: {
     id: number;
     status: SubmissionStatus;
   };
 }) => {
-  if (updateRequests.length > 0) {
+  if (
+    submissionPackage.submitted_on &&
+    submissionPackage.update_requests.length > 0
+  ) {
     return true;
   }
   const isSubmissionItemCompleted =

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -12,14 +12,12 @@ import {
 } from "@tanstack/react-router";
 import { BCDesignTokens } from "epic.theme";
 import { PageGrid } from "@/components/Shared/PageGrid";
-import { SUBMISSION_STATUS } from "@/models/Submission";
 import { InfoBox } from "@/components/Submission/InfoBox";
 import {
   useGetSubmissionPackage,
   useUpdateStateSubmissionPackage,
 } from "@/hooks/api/usePackages";
 import { useGetAccountProject } from "@/hooks/api/useProjects";
-import { useEffect } from "react";
 import { PACKAGE_STATUS } from "@/models/Package";
 import { LoadingButton as Button } from "@/components/Shared/LoadingButton";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
@@ -80,7 +78,7 @@ export default function SubmissionPage() {
         (item) =>
           !isSubmissionItemReadyToSubmit({
             submissionItem: item,
-            updateRequests: submissionPackage.update_requests,
+            submissionPackage: submissionPackage,
           }),
       )
     ) {

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -28,6 +28,8 @@ import { When } from "react-if";
 import { PackageStatusChipStack } from "@/components/PackageStatusChip/PackageStatusChipStack";
 import { usePackageTableStore } from "@/components/Submission/packageTableStore";
 import UpdateRequestWidget from "@/components/Submission/UpdateRequestWidget";
+import { useMounted } from "@/hooks/common";
+import { isSubmissionItemReadyToSubmit } from "@/components/Submission/utils";
 
 export const Route = createFileRoute(
   "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
@@ -62,12 +64,11 @@ export default function SubmissionPage() {
 
   const navigate = useNavigate();
 
-  useEffect(() => {
+  useMounted(() => {
     return () => {
       reset();
     };
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, []);
+  });
 
   const submitPackage = () => {
     if (!submissionPackage) {
@@ -76,7 +77,11 @@ export default function SubmissionPage() {
 
     if (
       submissionPackage.items.some(
-        (item) => item.status !== SUBMISSION_STATUS.COMPLETED.value,
+        (item) =>
+          !isSubmissionItemReadyToSubmit({
+            submissionItem: item,
+            updateRequests: submissionPackage.update_requests,
+          }),
       )
     ) {
       setIsValidating(true);
@@ -95,9 +100,9 @@ export default function SubmissionPage() {
     return <Navigate to={"/error"} />;
   }
 
-  const isPackageSubmitted = submissionPackage.status.includes(
-    PACKAGE_STATUS.SUBMITTED.value,
-  );
+  const isPackageSubmitted = Boolean(submissionPackage.submitted_on);
+  const isSubmitDisabled =
+    isPackageSubmitted && submissionPackage.update_requests.length === 0;
 
   return (
     <PageGrid>
@@ -200,7 +205,7 @@ export default function SubmissionPage() {
                 <Button
                   onClick={submitPackage}
                   loading={isSubmittingPackage}
-                  disabled={isPackageSubmitted}
+                  disabled={isSubmitDisabled}
                 >
                   Submit to EAO
                 </Button>


### PR DESCRIPTION
- unlock submission if there are update requests
- bypass validation when there's an update request and package is submitted
- Add validation in the backend for package resubmission
