### PR TITLE
Update request ui updates

### DIFF
--- a/submit-web/src/components/Submission/UpdateRequestWidget/AddRequestSection.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/AddRequestSection.tsx
@@ -70,7 +70,7 @@ export default function AddRequestSection({
   const filteredItems = useMemo(() => {
     return submissionPackage.items.filter(
       (item) =>
-        item.type.submission_method === SUBMISSION_ITEM_METHOD.DOCUMENT_UPLOAD,
+        item.type.submission_method === SUBMISSION_ITEM_METHOD.DOCUMENT_UPLOAD
     );
   }, [submissionPackage.items]);
 
@@ -78,18 +78,36 @@ export default function AddRequestSection({
     <FormProvider {...methods}>
       <Form onSubmit={handleSubmit(onCreateUpdateRequest)}>
         <Box>
-          <Typography variant="body1">Update requested for</Typography>
+          <Typography
+            variant="body1"
+            sx={{
+              pt: BCDesignTokens.layoutPaddingLarge,
+              fontWeight: BCDesignTokens.typographyBoldBody,
+              mb: BCDesignTokens.layoutMarginSmall,
+            }}
+          >
+            Update requested for
+          </Typography>
           <ControlledCheckboxGroup name="submissionItems">
             {filteredItems.map((item) => (
               <FormControlLabel
                 key={item.id}
-                control={<Checkbox value={item.id} />}
+                control={<Checkbox value={item.id} sx={{ py: 0 }} />}
                 label={item.type.name}
               />
             ))}
           </ControlledCheckboxGroup>
           <Box sx={{ mb: BCDesignTokens.layoutMarginMedium }}>
-            <Typography variant="body1">Request reason</Typography>
+            <Typography
+              variant="body1"
+              sx={{
+                fontWeight: BCDesignTokens.typographyBoldBody,
+                pt: BCDesignTokens.layoutPaddingLarge,
+                mb: BCDesignTokens.layoutMarginSmall,
+              }}
+            >
+              Request reason
+            </Typography>
             <ControlledTextField
               name="reason"
               variant="outlined"
@@ -100,6 +118,7 @@ export default function AddRequestSection({
                 "& .MuiInputBase-root": {
                   borderColor: BCDesignTokens.typographyColorDisabled,
                 },
+                mb: BCDesignTokens.layoutMarginSmall,
               }}
             />
             <LoadingButton

--- a/submit-web/src/components/Submission/UpdateRequestWidget/RequestSection.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/RequestSection.tsx
@@ -52,13 +52,18 @@ export default function RequestSection({
         <Typography variant="body1">{createdDate}</Typography>
       </Box>
 
-      <Typography variant="body1" sx={{ mb: 1, fontWeight: "bold" }}>
+      <Typography
+        variant="body1"
+        sx={{ mb: 1, fontWeight: BCDesignTokens.typographyFontWeightsBold }}
+      >
         <Switch>
           <Case condition={type === UPDATE_REQUEST_TYPE.REVIEW.value}>
-            Revision required for {submissionItems[0]?.type.name}
+            Revision required for{" "}
+            {submissionItems.map((item) => item.type.name).join(", ")}
           </Case>
           <Case condition={type === UPDATE_REQUEST_TYPE.UPDATE.value}>
-            Update requested for {submissionItems[0]?.type.name}
+            Update requested for{" "}
+            {submissionItems.map((item) => item.type.name).join(", ")}
           </Case>
         </Switch>
       </Typography>
@@ -68,7 +73,10 @@ export default function RequestSection({
       </Typography>
 
       <When condition={showNoteSection}>
-        <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: "bold" }}>
+        <Typography
+          variant="subtitle1"
+          sx={{ mb: 1, fontWeight: BCDesignTokens.typographyFontWeightsBold }}
+        >
           Note to EAO
         </Typography>
         <Typography variant="body1" sx={{ mb: 1 }}>

--- a/submit-web/src/components/Submission/UpdateRequestWidget/RequestSection.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/RequestSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Divider, Typography } from "@mui/material";
+import { Box, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import dayjs from "dayjs";
 import { UPDATE_REQUEST_TYPE, UpdateRequest } from "@/models/UpdateRequest";
@@ -38,7 +38,6 @@ export default function RequestSection({
 
   return (
     <Box sx={{ my: BCDesignTokens.layoutMarginLarge }}>
-      <Divider sx={{ mb: BCDesignTokens.layoutMarginMedium }} />
       <Box
         sx={{
           display: "flex",
@@ -47,32 +46,21 @@ export default function RequestSection({
           mb: BCDesignTokens.layoutMarginSmall,
         }}
       >
-        <Typography
-          variant="subtitle1"
-          sx={{ fontWeight: BCDesignTokens.typographyBoldBody }}
-        >
+        <Typography variant="body1" sx={{ fontWeight: "bold" }}>
           {created_by}
         </Typography>
-        <Typography variant="subtitle1">{createdDate}</Typography>
+        <Typography variant="body1">{createdDate}</Typography>
       </Box>
 
-      <Typography variant="subtitle1" sx={{ mb: 1, fontWeight: "bold" }}>
+      <Typography variant="body1" sx={{ mb: 1, fontWeight: "bold" }}>
         <Switch>
           <Case condition={type === UPDATE_REQUEST_TYPE.REVIEW.value}>
-            Revision required for
+            Revision required for {submissionItems[0]?.type.name}
           </Case>
           <Case condition={type === UPDATE_REQUEST_TYPE.UPDATE.value}>
-            Update requested for
+            Update requested for {submissionItems[0]?.type.name}
           </Case>
         </Switch>
-      </Typography>
-
-      <Typography variant="subtitle1">
-        <ul>
-          {submissionItems.map((item) => (
-            <li key={item.id}>{item.type.name}</li>
-          ))}
-        </ul>
       </Typography>
 
       <Typography variant="body1" sx={{ mb: 1 }}>

--- a/submit-web/src/components/Submission/UpdateRequestWidget/RequestSection.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/RequestSection.tsx
@@ -1,4 +1,4 @@
-import { Box, Typography } from "@mui/material";
+import { Box, Divider, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import dayjs from "dayjs";
 import { UPDATE_REQUEST_TYPE, UpdateRequest } from "@/models/UpdateRequest";
@@ -26,18 +26,19 @@ export default function RequestSection({
   const isEAO = checkIfEAO(roles || []);
 
   const submissionItems = submissionPackage.items.filter((item) =>
-    submission_item_ids.includes(item.id),
+    submission_item_ids.includes(item.id)
   );
 
   const showNoteSection =
     (isEAO &&
       submissionPackage.status.includes(
-        SUBMISSION_ITEM_STATUS.SUBMITTED.value,
+        SUBMISSION_ITEM_STATUS.SUBMITTED.value
       )) ||
     (!isEAO && Boolean(note));
 
   return (
-    <Box sx={{ mb: BCDesignTokens.layoutMarginMedium }}>
+    <Box sx={{ my: BCDesignTokens.layoutMarginLarge }}>
+      <Divider sx={{ mb: BCDesignTokens.layoutMarginMedium }} />
       <Box
         sx={{
           display: "flex",
@@ -46,7 +47,10 @@ export default function RequestSection({
           mb: BCDesignTokens.layoutMarginSmall,
         }}
       >
-        <Typography variant="subtitle1" sx={{ fontWeight: "bold" }}>
+        <Typography
+          variant="subtitle1"
+          sx={{ fontWeight: BCDesignTokens.typographyBoldBody }}
+        >
           {created_by}
         </Typography>
         <Typography variant="subtitle1">{createdDate}</Typography>

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -5,6 +5,7 @@ import {
   Box,
   Chip,
   Collapse,
+  Divider,
   Typography,
 } from "@mui/material";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
@@ -74,7 +75,6 @@ export default function UpdateRequestWidget({
 
   const handleCancelReason = () => {
     setIsCreateRequestOpen(false);
-    setExpanded(false);
   };
 
   if (!updateRequests) return null;
@@ -101,6 +101,7 @@ export default function UpdateRequestWidget({
             borderRadius: "4px",
             backgroundColor: summaryBackgroundColor,
             border: `1px solid ${BCDesignTokens.supportBorderColorWarning}`,
+            background: BCDesignTokens.themeGold10,
           },
           expanded && {
             borderBottomLeftRadius: 0,
@@ -161,7 +162,14 @@ export default function UpdateRequestWidget({
             />
           </Box>
           <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}>
-            <Box onClick={handleIsCreateRequestOpen}>
+            <Box
+              onClick={handleIsCreateRequestOpen}
+              sx={{
+                display: "flex",
+                alignItems: "center",
+                justifyContent: "center",
+              }}
+            >
               <Typography
                 variant="body2"
                 color={BCDesignTokens.typographyColorLink}
@@ -198,12 +206,15 @@ export default function UpdateRequestWidget({
         </PermissionsGate>
         <When condition={Boolean(updateRequests)}>
           {updateRequests.length > 0 ? (
-            updateRequests.map((updateRequest) => (
-              <RequestSection
-                key={updateRequest.id}
-                updateRequest={updateRequest}
-                submissionPackage={submissionPackage}
-              />
+            updateRequests.map((updateRequest, index) => (
+              <>
+                <RequestSection
+                  key={updateRequest.id}
+                  updateRequest={updateRequest}
+                  submissionPackage={submissionPackage}
+                />
+                {index !== updateRequests.length - 1 && <Divider />}
+              </>
             ))
           ) : (
             <Typography variant="body1" sx={{ mb: 1 }}>

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -88,6 +88,9 @@ export default function UpdateRequestWidget({
         mb: BCDesignTokens.layoutMarginLarge,
         p: 0,
         width: "100%",
+        "& MuiPaper-root": {
+          color: "white",
+        },
       }}
       expanded={expanded}
     >
@@ -185,14 +188,16 @@ export default function UpdateRequestWidget({
         </Box>
       </AccordionSummary>
       <AccordionDetails
-        sx={{
-          pb: 0,
-          border: `1px solid ${BCDesignTokens.supportBorderColorWarning}`,
-          borderTop: "none",
-          borderRadius: "4px",
-          borderTopLeftRadius: 0,
-          borderTopRightRadius: 0,
-        }}
+        sx={[
+          {
+            pb: 0,
+            border: `1px solid ${BCDesignTokens.supportBorderColorWarning}`,
+            borderTop: `${0}px solid ${BCDesignTokens.supportBorderColorWarning}`,
+            borderRadius: "4px",
+            borderTopLeftRadius: 0,
+            borderTopRightRadius: 0,
+          },
+        ]}
       >
         <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}>
           <Collapse in={isCreateRequestOpen} unmountOnExit>

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -47,7 +47,7 @@ export default function UpdateRequestWidget({
           notify.error(
             isAxiosError(error)
               ? (error.response?.data.message ?? defaultMessage)
-              : defaultMessage,
+              : defaultMessage
           );
         },
       },
@@ -129,9 +129,11 @@ export default function UpdateRequestWidget({
               variant="h6"
               sx={{
                 color: "#38598A",
+                mr: BCDesignTokens.layoutMarginSmall,
+                fontWeight: BCDesignTokens.typographyBoldBody,
               }}
             >
-              Submission/Update Request
+              Update Requests
             </Typography>
             <When condition={updateRequests && updateRequests.length > 0}>
               <Chip
@@ -161,9 +163,12 @@ export default function UpdateRequestWidget({
           <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}>
             <Box onClick={handleIsCreateRequestOpen}>
               <Typography
-                variant="body1"
+                variant="body2"
                 color={BCDesignTokens.typographyColorLink}
-                sx={{ cursor: "pointer", width: "100%" }}
+                sx={{
+                  cursor: "pointer",
+                  width: "100%",
+                }}
               >
                 + Request an Update
               </Typography>

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -31,7 +31,7 @@ import ItemsTable from "@/components/Submission/ItemsTable";
 import { UPDATE_REQUEST_STATUS } from "@/models/UpdateRequest";
 
 export const Route = createFileRoute(
-  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
+  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/"
 )({
   component: SubmissionPage,
 });
@@ -80,7 +80,7 @@ export default function SubmissionPage() {
           !isSubmissionItemReadyToSubmit({
             submissionItem: item,
             submissionPackage: submissionPackage,
-          }),
+          })
       )
     ) {
       setIsValidating(true);
@@ -104,7 +104,7 @@ export default function SubmissionPage() {
     isPackageSubmitted &&
     submissionPackage.update_requests.filter(
       (updateRequest) =>
-        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value,
+        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value
     ).length === 0;
 
   return (
@@ -171,13 +171,14 @@ export default function SubmissionPage() {
                 </Box>
               </Box>
               <InfoBox submissionPackage={submissionPackage} />
-
-              <Box mt="1em" width="100%">
-                <UpdateRequestWidget
-                  submissionPackage={submissionPackage}
-                  summaryBackgroundColor="#FEF8E8"
-                />
-              </Box>
+              {submissionPackage?.update_requests && (
+                <Box mt="1em" width="100%">
+                  <UpdateRequestWidget
+                    submissionPackage={submissionPackage}
+                    summaryBackgroundColor="#FEF8E8"
+                  />
+                </Box>
+              )}
               <Box
                 sx={{
                   mb: BCDesignTokens.layoutMarginXlarge,


### PR DESCRIPTION
Yellow border should be 1px

Remove “Submission/” from the section header so the header is only “Update Requests”

Add 8px padding between the header (Update Requests) and the badge with the number of active requests. (layout.margin.small)

“+ Request an Update” action should be 14px (typography.regular.smallBody).

The “Update Requested” and “Request Note” labels should be bold (typography.bold.body). Add 8px between the labels and checkboxes/text area (layout.margin.small)..

Checkboxes: remove the 9px padding top and bottom on the checkboxes.

Add 24px padding-top for the “Updated Requested for” and “Request Note” sections (layout.margin.large).

Change the 24px margin under the text area to 8px (layout.margin.small).

Name of the person who wrote the note should b 16px, bold, not H6 (typography.bold.body).

Make the padding 24px between the Request Update section and the previous notes (layout.margin.large). 

Same between each note section if more than one.

The widget is there when the submission is new. The widget should only appear when an update request is made.

Make the background-color #FEF8E8

“+ Request an Update” action should be 14px

Name should be 16px, bold (label)

Date should be 16px

“Update Requested for” should be 16px, bold (label)

Selection “Consultation Record(s)/Management Plan” should be included in the line ““Update Requested for” with a period at the end. (all on one line)

for example, “Update Requested for Consultation Record(s).” or “Update Requested for Consultation Record(s) and Management Plan.”

Add a separator line between comments