### PR TITLE
hide created and new status if revision required

### DIFF
--- a/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
+++ b/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
@@ -72,7 +72,12 @@ export const PackageStatusChipStack = ({
       hideStatus(status),
     ]);
     return Object.fromEntries(entries);
-  }, [isRevisionRequired, isUpdateRequested, submissionPackage.status]);
+  }, [
+    isRevisionRequired,
+    isUpdateRequested,
+    submissionPackage.status,
+    hideStatus,
+  ]);
 
   return (
     <Box sx={{ display: "inline-block", width: "fit-content" }}>

--- a/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
+++ b/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
@@ -1,10 +1,12 @@
 import {
   NON_CANONICAL_PACKAGE_STATUS,
+  PACKAGE_STATUS,
+  PackageStatus,
   SubmissionPackage,
 } from "@/models/Package";
 import { Box, Stack } from "@mui/material";
 import PackageStatusChip from ".";
-import { When } from "react-if";
+import { Unless, When } from "react-if";
 import {
   UPDATE_REQUEST_STATUS,
   UPDATE_REQUEST_TYPE,
@@ -47,11 +49,38 @@ export const PackageStatusChipStack = ({
     );
   }, [submissionPackage.update_requests]);
 
+  const hideStatus = (status: PackageStatus) => {
+    const isNewOrCreated = [
+      PACKAGE_STATUS.CREATED.value,
+      PACKAGE_STATUS.NEW_SUBMISSION.value,
+    ].includes(status);
+
+    if (isNewOrCreated && isRevisionRequired) {
+      return true;
+    }
+    const notFirstVersion = submissionPackage.version.version > 1;
+    const alreadySubmitted = Boolean(submissionPackage.submitted_on);
+    if (isNewOrCreated && (notFirstVersion || alreadySubmitted)) {
+      return true;
+    }
+    return false;
+  };
+
+  const hideStatusMap: Record<PackageStatus, boolean> = useMemo(() => {
+    const entries = submissionPackage.status.map((status) => [
+      status,
+      hideStatus(status),
+    ]);
+    return Object.fromEntries(entries);
+  }, [isRevisionRequired, isUpdateRequested]);
+
   return (
     <Box sx={{ display: "inline-block", width: "fit-content" }}>
       <Stack direction="column" spacing={1} alignItems={"flex-end"}>
         {status.map((value) => (
-          <PackageStatusChip key={value} status={value} />
+          <Unless condition={hideStatusMap[value]} key={value}>
+            <PackageStatusChip key={value} status={value} />
+          </Unless>
         ))}
         <When
           condition={

--- a/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
+++ b/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
@@ -11,7 +11,7 @@ import {
   UPDATE_REQUEST_STATUS,
   UPDATE_REQUEST_TYPE,
 } from "@/models/UpdateRequest";
-import { useMemo } from "react";
+import { useCallback, useMemo } from "react";
 import { filterOpenUpdateRequests } from "@/utils";
 
 type PackageStatusChipStackProps = {
@@ -49,22 +49,29 @@ export const PackageStatusChipStack = ({
     );
   }, [submissionPackage.update_requests]);
 
-  const hideStatus = (status: PackageStatus) => {
-    const isNewOrCreated = [
-      PACKAGE_STATUS.CREATED.value,
-      PACKAGE_STATUS.NEW_SUBMISSION.value,
-    ].includes(status);
+  const hideStatus = useCallback(
+    (status: PackageStatus) => {
+      const isNewOrCreated = [
+        PACKAGE_STATUS.CREATED.value,
+        PACKAGE_STATUS.NEW_SUBMISSION.value,
+      ].includes(status);
 
-    if (isNewOrCreated && isRevisionRequired) {
-      return true;
-    }
-    const notFirstVersion = submissionPackage.version.version > 1;
-    const alreadySubmitted = Boolean(submissionPackage.submitted_on);
-    if (isNewOrCreated && (notFirstVersion || alreadySubmitted)) {
-      return true;
-    }
-    return false;
-  };
+      if (isNewOrCreated && isRevisionRequired) {
+        return true;
+      }
+      const notFirstVersion = submissionPackage.version.version > 1;
+      const alreadySubmitted = Boolean(submissionPackage.submitted_on);
+      if (isNewOrCreated && (notFirstVersion || alreadySubmitted)) {
+        return true;
+      }
+      return false;
+    },
+    [
+      submissionPackage.submitted_on,
+      submissionPackage.version.version,
+      isRevisionRequired,
+    ],
+  );
 
   const hideStatusMap: Record<PackageStatus, boolean> = useMemo(() => {
     const entries = submissionPackage.status.map((status) => [

--- a/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
+++ b/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
@@ -72,7 +72,7 @@ export const PackageStatusChipStack = ({
       hideStatus(status),
     ]);
     return Object.fromEntries(entries);
-  }, [isRevisionRequired, isUpdateRequested]);
+  }, [isRevisionRequired, isUpdateRequested, submissionPackage.status]);
 
   return (
     <Box sx={{ display: "inline-block", width: "fit-content" }}>

--- a/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
+++ b/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
@@ -72,12 +72,7 @@ export const PackageStatusChipStack = ({
       hideStatus(status),
     ]);
     return Object.fromEntries(entries);
-  }, [
-    isRevisionRequired,
-    isUpdateRequested,
-    submissionPackage.status,
-    hideStatus,
-  ]);
+  }, [submissionPackage.status, hideStatus]);
 
   return (
     <Box sx={{ display: "inline-block", width: "fit-content" }}>

--- a/submit-web/src/models/Package.ts
+++ b/submit-web/src/models/Package.ts
@@ -89,7 +89,7 @@ export type SubmissionPackageMeta = Record<string, number | string>;
 export type PackageVersion = {
   id: number;
   package_id: number;
-  version: string;
+  version: number;
   original_package_id: number;
 };
 


### PR DESCRIPTION
- hide created and new status if it's not the first version of a package or if it has revision required