### PR TITLE
Make review confirmation reusable

### DIFF
--- a/submit-web/src/components/Projects/ProjectTable/StaffTableRow.tsx
+++ b/submit-web/src/components/Projects/ProjectTable/StaffTableRow.tsx
@@ -14,9 +14,9 @@ import dayjs from "dayjs";
 import { SubmitLink } from "@/components/Shared/SubmitLink";
 import { useMemo } from "react";
 
-interface ProjectRowProps {
+type ProjectRowProps = Readonly<{
   submissionPackage: SubmissionPackage;
-}
+}>;
 
 export default function StaffTableRow({ submissionPackage }: ProjectRowProps) {
   const navigate = useNavigate();

--- a/submit-web/src/components/Submission/DocumentRow/index.tsx
+++ b/submit-web/src/components/Submission/DocumentRow/index.tsx
@@ -1,21 +1,12 @@
-import { useEffect, useState } from "react";
+import { useState } from "react";
 import { Link as MuiLink, TableRow, Typography } from "@mui/material";
 import { Submission } from "@/models/Submission";
-import {
-  SUBMISSION_ITEM_METHOD,
-  SUBMISSION_ITEM_MODAL_CONTENT,
-  SUBMISSION_ITEM_TYPE,
-  SubmissionItem,
-} from "@/models/SubmissionItem";
-import { useUpdateStateSubmissionPackage } from "@/hooks/api/usePackages";
-import { useParams } from "@tanstack/react-router";
-import { PACKAGE_STATUS } from "@/models/Package";
-import { useModal } from "@/components/Shared/Modals/modalStore";
+import { SubmissionItem } from "@/models/SubmissionItem";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
-import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
 import { getObjectFromS3 } from "@/components/Shared/Table/utils";
 import { SubmitTableCell } from "@/components/Shared/Table/common";
 import { StatusCell } from "./StatusCell";
+import SubmissionItemReviewConfirmation from "../SubmissionItemReviewConfirmation";
 
 type DocumentRowProps = Readonly<{
   documentSubmission: Submission;
@@ -26,71 +17,13 @@ export default function DocumentRow({
   documentSubmission,
   submissionItem,
 }: DocumentRowProps) {
-  const { submissionPackageId } = useParams({ strict: false });
   const [pendingGetObject, setPendingGetObject] = useState(false);
-  const {
-    setOpen: setOpenModal,
-    setClose: setCloseModal,
-    setIsLoading,
-  } = useModal();
 
   const {
     submitted_document: { name, url },
     version,
     submitted_by,
   } = documentSubmission;
-  const isConsultationRecord =
-    name === SUBMISSION_ITEM_TYPE.CONSULTATION_RECORD;
-
-  const subItemName = submissionItem.type.name;
-
-  const {
-    mutate: updateStateSubmissionPackage,
-    isPending: updatingSubmission,
-  } = useUpdateStateSubmissionPackage({
-    onError: () => {
-      setCloseModal();
-      notify.error("Failed to start review");
-    },
-    onSuccess: () => {
-      setCloseModal();
-      downloadDocument();
-      notify.success("Successfully started review");
-    },
-  });
-
-  useEffect(() => {
-    setIsLoading(updatingSubmission);
-  }, [updatingSubmission, setIsLoading]);
-
-  const openConfirmationModal = () => {
-    const { title, description, confirmText } = SUBMISSION_ITEM_MODAL_CONTENT[
-      submissionItem.type.name
-    ] || {
-      title: `Start ${subItemName} Review`,
-      description: `Would you like to start the ${subItemName} review now? This will begin the review counter.`,
-      confirmText: `Start ${subItemName} Review`,
-    };
-
-    setOpenModal(
-      <ConfirmationModal
-        onConfirm={() => {
-          updateStateSubmissionPackage({
-            packageId: Number(submissionPackageId),
-            data: {
-              status: isConsultationRecord
-                ? PACKAGE_STATUS.UNDER_CONSULTATION_CHECK.value
-                : PACKAGE_STATUS.UNDER_REVIEW.value,
-            },
-          });
-        }}
-        title={title}
-        description={description}
-        confirmText={confirmText}
-        cancelText="Start Later"
-      />
-    );
-  };
 
   const downloadDocument = async () => {
     try {
@@ -105,14 +38,6 @@ export default function DocumentRow({
   };
 
   const openDocument = () => {
-    if (
-      !submissionItem.review_start_date &&
-      submissionItem.type.submission_method ===
-        SUBMISSION_ITEM_METHOD.DOCUMENT_UPLOAD
-    ) {
-      openConfirmationModal();
-      return;
-    }
     downloadDocument();
   };
 
@@ -129,7 +54,14 @@ export default function DocumentRow({
             mx: 0.5,
           }}
         >
-          <MuiLink onClick={openDocument}>{name}</MuiLink>
+          <SubmissionItemReviewConfirmation
+            packageId={submissionItem.package_id}
+            itemType={submissionItem.type.name}
+            onClick={openDocument}
+            bypass={Boolean(submissionItem.review_start_date)}
+          >
+            <MuiLink onClick={openDocument}>{name}</MuiLink>
+          </SubmissionItemReviewConfirmation>
         </Typography>
       </SubmitTableCell>
       <SubmitTableCell align="right">{submitted_by || ""}</SubmitTableCell>

--- a/submit-web/src/components/Submission/DocumentRow/index.tsx
+++ b/submit-web/src/components/Submission/DocumentRow/index.tsx
@@ -60,7 +60,7 @@ export default function DocumentRow({
             onClick={openDocument}
             bypass={Boolean(submissionItem.review_start_date)}
           >
-            <MuiLink onClick={openDocument}>{name}</MuiLink>
+            <MuiLink>{name}</MuiLink>
           </SubmissionItemReviewConfirmation>
         </Typography>
       </SubmitTableCell>

--- a/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
@@ -1,0 +1,116 @@
+import React, { useEffect } from "react";
+import {
+  SUBMISSION_ITEM_MODAL_CONTENT,
+  SUBMISSION_ITEM_TYPE,
+  SubmissionItemTypeName,
+} from "@/models/SubmissionItem";
+import { useUpdateStateSubmissionPackage } from "@/hooks/api/usePackages";
+import { useModal } from "@/components/Shared/Modals/modalStore";
+import { notify } from "@/components/Shared/Snackbar/snackbarStore";
+import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
+import { PACKAGE_STATUS } from "@/models/Package";
+
+const acceptedSubmissionItemTypes = [
+  SUBMISSION_ITEM_TYPE.CONSULTATION_RECORD,
+  SUBMISSION_ITEM_TYPE.MANAGEMENT_PLAN,
+];
+
+const ItemTypePackageStatusMap = {
+  [SUBMISSION_ITEM_TYPE.CONSULTATION_RECORD]:
+    PACKAGE_STATUS.UNDER_CONSULTATION_CHECK.value,
+  [SUBMISSION_ITEM_TYPE.MANAGEMENT_PLAN]: PACKAGE_STATUS.UNDER_REVIEW.value,
+};
+
+type SubmissionItemReviewConfirmationProps = Readonly<{
+  packageId: number;
+  itemType: SubmissionItemTypeName;
+  onClick: () => void;
+  children: React.ReactElement;
+  bypass?: boolean;
+}>;
+
+export default function SubmissionItemReviewConfirmation({
+  children,
+  onClick,
+  itemType,
+  packageId,
+  bypass = false,
+}: SubmissionItemReviewConfirmationProps) {
+  const {
+    setOpen: setOpenModal,
+    setClose: setCloseModal,
+    setIsLoading,
+  } = useModal();
+
+  const {
+    mutate: updateStateSubmissionPackage,
+    isPending: updatingSubmission,
+  } = useUpdateStateSubmissionPackage({
+    onError: () => {
+      setCloseModal();
+      notify.error("Failed to start review");
+    },
+    onSuccess: () => {
+      setCloseModal();
+      onClick();
+      notify.success("Successfully started review");
+    },
+  });
+
+  useEffect(() => {
+    setIsLoading(updatingSubmission);
+  }, [updatingSubmission, setIsLoading]);
+
+  const openConfirmationModal = () => {
+    const { title, description, confirmText } = SUBMISSION_ITEM_MODAL_CONTENT[
+      itemType
+    ] || {
+      title: `Start ${itemType} Review`,
+      description: `Would you like to start the ${itemType} review now? This will begin the review counter.`,
+      confirmText: `Start ${itemType} Review`,
+    };
+
+    setOpenModal(
+      <ConfirmationModal
+        onConfirm={() => {
+          updateStateSubmissionPackage({
+            packageId: packageId,
+            data: {
+              status: ItemTypePackageStatusMap[itemType],
+            },
+          });
+        }}
+        title={title}
+        description={description}
+        confirmText={confirmText}
+        cancelText="Start Later"
+      />,
+    );
+  };
+
+  const handleBypassClick = () => {
+    onClick();
+  };
+
+  const handleConfirmationClick = () => {
+    if (
+      !acceptedSubmissionItemTypes.includes(itemType) ||
+      !ItemTypePackageStatusMap[itemType]
+    ) {
+      notify.error(`Cannot start review on this item type: ${itemType}`);
+      return;
+    }
+    openConfirmationModal();
+  };
+
+  const childrenWithProps = React.Children.map(children, (child) => {
+    if (React.isValidElement(child)) {
+      return React.cloneElement(child as React.ReactElement<any>, {
+        onClick: bypass ? handleBypassClick : handleConfirmationClick,
+      });
+    }
+    return child;
+  });
+
+  return <>{childrenWithProps}</>;
+}

--- a/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
@@ -105,7 +105,7 @@ export default function SubmissionItemReviewConfirmation({
 
   const childrenWithProps = React.Children.map(children, (child) => {
     if (React.isValidElement(child)) {
-      return React.cloneElement(child as React.ReactElement<any>, {
+      return React.cloneElement(child as React.ReactElement, {
         onClick: bypass ? handleBypassClick : handleConfirmationClick,
       });
     }

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow.tsx
@@ -10,19 +10,10 @@ import { When } from "react-if";
 import { SubmissionItemTableRowProps } from ".";
 import { useNavigate, useParams } from "@tanstack/react-router";
 import { SubmissionStatusChipStack } from "../../SubmissionStatusChip";
-import { useModal } from "@/components/Shared/Modals/modalStore";
-import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
-import {
-  getStaffSubmissionPackageQueryOptions,
-  useUpdateStateSubmissionPackage,
-} from "@/hooks/api/usePackages";
-import { notify } from "@/components/Shared/Snackbar/snackbarStore";
-import { PACKAGE_STATUS } from "@/models/Package";
-import {
-  SUBMISSION_ITEM_METHOD,
-  SUBMISSION_ITEM_TYPE,
-} from "@/models/SubmissionItem";
-import { useEffect, useMemo } from "react";
+import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
+
+import { SUBMISSION_ITEM_METHOD } from "@/models/SubmissionItem";
+import { useMemo } from "react";
 import {
   SubmitPrimaryRowTableCell,
   SubmitTablePrimaryRow,
@@ -35,24 +26,21 @@ import {
 } from "@/models/UpdateRequest";
 import dayjs from "dayjs";
 import { SUBMISSION_TYPE } from "@/models/Submission";
+import SubmissionItemReviewConfirmation from "../SubmissionItemReviewConfirmation";
 
 export default function StaffSubmissionItemTableRow({
   item,
   error = false,
 }: SubmissionItemTableRowProps) {
   const { projectId, submissionPackageId } = useParams({ strict: false });
-  const {
-    setOpen: setOpenModal,
-    setClose: setCloseModal,
-    setIsLoading,
-  } = useModal();
+
   const navigate = useNavigate();
 
   const { data: submissionPackage, isPending: isPackagePending } =
     useSuspenseQuery(
       getStaffSubmissionPackageQueryOptions({
         packageId: Number(submissionPackageId),
-      })
+      }),
     );
 
   const { submissions, id, status, review, review_start_date } = item;
@@ -66,15 +54,17 @@ export default function StaffSubmissionItemTableRow({
       .filter(
         (updateRequest) =>
           updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value &&
-          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value
+          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
       )
       .sort((a, b) => dayjs(b.created_date).diff(dayjs(a.created_date)))[0];
 
     if (!last_update_request) return false;
     return Boolean(
       item.submissions.find((submission) =>
-        dayjs(submission.created_date).isAfter(last_update_request.created_date)
-      )
+        dayjs(submission.created_date).isAfter(
+          last_update_request.created_date,
+        ),
+      ),
     );
   }, [item, submissionPackage.update_requests]);
 
@@ -90,65 +80,17 @@ export default function StaffSubmissionItemTableRow({
     return submissionPackage.update_requests
       .filter(
         (updateRequest) =>
-          updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value
+          updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value,
       )
       .some((updateRequest) => updateRequest.submission_item_ids.includes(id));
   }, [submissionPackage, id]);
 
   const actionLabel = hasDocument ? "Review" : "View";
-  const isConsultationRecord =
-    name === SUBMISSION_ITEM_TYPE.CONSULTATION_RECORD;
 
-  const {
-    mutate: updateStateSubmissionPackage,
-    isPending: updatingSubmission,
-  } = useUpdateStateSubmissionPackage({
-    onError: () => {
-      setCloseModal();
-      notify.error("Failed to start review");
-    },
-    onSuccess: () => {
-      setCloseModal();
-      navigate({
-        to: `/staff/projects/${projectId}/submission-packages/${submissionPackageId}/submissions/${id}`,
-      });
-      notify.success("Successfully started review");
-    },
-  });
-
-  const onActionClick = () => {
-    if (!review_start_date && hasDocument) {
-      openConfirmationModal();
-      return;
-    }
+  const handleClick = () => {
     navigate({
       to: `/staff/projects/${projectId}/submission-packages/${submissionPackageId}/submissions/${id}`,
     });
-  };
-
-  useEffect(() => {
-    setIsLoading(updatingSubmission);
-  }, [updatingSubmission, setIsLoading]);
-
-  const openConfirmationModal = () => {
-    setOpenModal(
-      <ConfirmationModal
-        onConfirm={() => {
-          updateStateSubmissionPackage({
-            packageId: Number(submissionPackageId),
-            data: {
-              status: isConsultationRecord
-                ? PACKAGE_STATUS.UNDER_CONSULTATION_CHECK.value
-                : PACKAGE_STATUS.UNDER_REVIEW.value,
-            },
-          });
-        }}
-        title={`Start ${name} Review`}
-        description={`Would you like to start the ${name} review now? This will start the counter for the Review.`}
-        confirmText={`Start ${name} Review`}
-        cancelText="Start Later"
-      />
-    );
   };
 
   if (isPackagePending) {
@@ -157,11 +99,7 @@ export default function StaffSubmissionItemTableRow({
 
   return (
     <>
-      <SubmitTablePrimaryRow
-        key={`row-${name}`}
-        error={error}
-        onClick={onActionClick}
-      >
+      <SubmitTablePrimaryRow key={`row-${name}`} error={error}>
         <SubmitPrimaryRowTableCell>
           <MuiLink
             color="inherit"
@@ -193,19 +131,25 @@ export default function StaffSubmissionItemTableRow({
         </SubmitPrimaryRowTableCell>
 
         <SubmitPrimaryRowTableCell align="center">
-          <Typography
-            variant="body2"
-            sx={{
-              color: BCDesignTokens.typographyColorLink,
-              "&:hover": {
-                cursor: "pointer",
-                textDecoration: "underline",
-              },
-            }}
-            onClick={onActionClick}
+          <SubmissionItemReviewConfirmation
+            onClick={handleClick}
+            itemType={name}
+            packageId={Number(submissionPackageId)}
+            bypass={Boolean(review_start_date)}
           >
-            {actionLabel}
-          </Typography>
+            <Typography
+              variant="body2"
+              sx={{
+                color: BCDesignTokens.typographyColorLink,
+                "&:hover": {
+                  cursor: "pointer",
+                  textDecoration: "underline",
+                },
+              }}
+            >
+              {actionLabel}
+            </Typography>
+          </SubmissionItemReviewConfirmation>
         </SubmitPrimaryRowTableCell>
       </SubmitTablePrimaryRow>
       {submissions

--- a/submit-web/src/models/SubmissionItem.ts
+++ b/submit-web/src/models/SubmissionItem.ts
@@ -2,7 +2,7 @@ import { Note } from "@/components/SubmissionItem/Note";
 import { Submission, SubmissionItemStatus } from "./Submission";
 import { SubmissionReview } from "./SubmissionReview";
 
-type SubmissionItemTypeName =
+export type SubmissionItemTypeName =
   | "Contact Information Form"
   | "Management Plan"
   | "Consultation Record(s)";


### PR DESCRIPTION
- Fix clicking download Consultation Records triggers under (MP) review status
- Refactor usage of review confirmation modal to turn it into a reusable component