### PR TITLE
Staff should always get all udpate_requests, active or inactive in the package

### DIFF
--- a/submit-api/src/submit_api/models/package.py
+++ b/submit-api/src/submit_api/models/package.py
@@ -60,6 +60,11 @@ class Package(BaseModel):
         """Get the active update requests for the package."""
         return [ur for ur in self._update_requests if ur.active]
 
+    @property
+    def all_update_requests(self):
+        """Get all update requests for the package."""
+        return self._update_requests
+
     @classmethod
     def get_package_by_id_with_items(cls, package_id: int):
         """Return model by package id."""

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -165,7 +165,7 @@ class StaffPackageSchema(PackageSchema):
     items = fields.Nested(StaffItemSchema, data_key="items", many=True)
     review_status = fields.Method('get_review_status')
     update_requests = fields.Nested(
-        PackageUpdateRequestSchema, data_key="all_update_requests", many=True)
+        PackageUpdateRequestSchema, data_key="update_requests", many=True, attribute="all_update_requests")
 
     def get_review_status(self, package):
         """Add review status."""

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -164,6 +164,8 @@ class StaffPackageSchema(PackageSchema):
 
     items = fields.Nested(StaffItemSchema, data_key="items", many=True)
     review_status = fields.Method('get_review_status')
+    update_requests = fields.Nested(
+        PackageUpdateRequestSchema, data_key="all_update_requests", many=True)
 
     def get_review_status(self, package):
         """Add review status."""

--- a/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
+++ b/submit-web/src/components/PackageStatusChip/PackageStatusChipStack.tsx
@@ -34,7 +34,8 @@ export const PackageStatusChipStack = ({
     return (
       submissionPackage.update_requests.filter(
         (updateRequest) =>
-          updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value
+          updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value &&
+          updateRequest.active,
       ).length > 0
     );
   }, [submissionPackage.update_requests]);
@@ -44,7 +45,8 @@ export const PackageStatusChipStack = ({
       submissionPackage.update_requests.filter(
         (updateRequest) =>
           updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value &&
-          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value
+          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
+          updateRequest.active,
       ).length > 0
     );
   }, [submissionPackage.update_requests]);

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow.tsx
@@ -54,7 +54,8 @@ export default function StaffSubmissionItemTableRow({
       .filter(
         (updateRequest) =>
           updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value &&
-          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
+          updateRequest.active,
       )
       .sort((a, b) => dayjs(b.created_date).diff(dayjs(a.created_date)))[0];
 
@@ -80,7 +81,8 @@ export default function StaffSubmissionItemTableRow({
     return submissionPackage.update_requests
       .filter(
         (updateRequest) =>
-          updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value,
+          updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value &&
+          updateRequest.active,
       )
       .some((updateRequest) => updateRequest.submission_item_ids.includes(id));
   }, [submissionPackage, id]);

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -11,7 +11,7 @@ import {
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
 import { BCDesignTokens } from "epic.theme";
 import { When } from "react-if";
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { SubmissionPackage } from "@/models/Package";
 import RequestSection from "./RequestSection";
 import { useCreatePackageUpdateRequest } from "@/hooks/api/usePackages";
@@ -32,7 +32,10 @@ export default function UpdateRequestWidget({
   const [isCreateRequestOpen, setIsCreateRequestOpen] = useState(false);
   const [expanded, setExpanded] = useState(false);
 
-  const updateRequests = submissionPackage?.update_requests || [];
+  const updateRequests = useMemo(() => {
+    if (!submissionPackage?.update_requests) return [];
+    return submissionPackage.update_requests;
+  }, [submissionPackage?.update_requests]);
 
   const { mutate: createUpdateRequest, isPending: isCreatingUpdateRequest } =
     useCreatePackageUpdateRequest({
@@ -48,7 +51,7 @@ export default function UpdateRequestWidget({
           notify.error(
             isAxiosError(error)
               ? (error.response?.data.message ?? defaultMessage)
-              : defaultMessage
+              : defaultMessage,
           );
         },
       },
@@ -76,6 +79,11 @@ export default function UpdateRequestWidget({
   const handleCancelReason = () => {
     setIsCreateRequestOpen(false);
   };
+
+  const activeRequests = useMemo(() => {
+    if (!updateRequests) return [];
+    return updateRequests.filter((request) => request.active);
+  }, [updateRequests]);
 
   if (!updateRequests) return null;
 
@@ -139,7 +147,7 @@ export default function UpdateRequestWidget({
             >
               Update Requests
             </Typography>
-            <When condition={updateRequests && updateRequests.length > 0}>
+            <When condition={activeRequests.length > 0}>
               <Chip
                 sx={{
                   backgroundColor: "#F18A15",
@@ -156,7 +164,7 @@ export default function UpdateRequestWidget({
                     justifyContent: "center",
                   },
                 }}
-                label={`${updateRequests.length}`}
+                label={`${activeRequests.length}`}
               />
             </When>
             <KeyboardArrowRightIcon

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -31,7 +31,7 @@ import { UPDATE_REQUEST_STATUS } from "@/models/UpdateRequest";
 import BarTitle from "@/components/Shared/Text/BarTitle";
 
 export const Route = createFileRoute(
-  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/"
+  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
 )({
   component: SubmissionPage,
 });
@@ -80,7 +80,7 @@ export default function SubmissionPage() {
           !isSubmissionItemReadyToSubmit({
             submissionItem: item,
             submissionPackage: submissionPackage,
-          })
+          }),
       )
     ) {
       setIsValidating(true);
@@ -104,7 +104,8 @@ export default function SubmissionPage() {
     isPackageSubmitted &&
     submissionPackage.update_requests.filter(
       (updateRequest) =>
-        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value
+        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
+        updateRequest.active,
     ).length === 0;
 
   return (

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId.tsx
@@ -51,7 +51,8 @@ export function Submission() {
   const hasPackageUpdateRequest =
     submissionPackage?.update_requests.filter(
       (updateRequest) =>
-        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value,
+        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
+        updateRequest.active,
     ).length > 0;
   const isPackageSubmitted = submissionPackage?.submitted_on;
 

--- a/submit-web/src/utils/index.ts
+++ b/submit-web/src/utils/index.ts
@@ -35,6 +35,7 @@ export const filterOpenUpdateRequests = (updateRequests: UpdateRequest[]) => {
   return updateRequests.filter(
     (updateRequest) =>
       updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
-      updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value,
+      updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value &&
+      updateRequest.active,
   );
 };


### PR DESCRIPTION
- Added a property to get all update_requests
- Updated Staff Package schema to use the all_update_requests attribute
- Update the update request widget to display the number of active requests
- Updated frontend to filter for active requests when calculating status