### PR TITLE
Revert updating item status to failed CR and keep status in resubmit

### DIFF
--- a/submit-api/src/submit_api/services/consultation_record_service.py
+++ b/submit-api/src/submit_api/services/consultation_record_service.py
@@ -55,7 +55,6 @@ class ConsultationRecordService:
     @classmethod
     def reject_consultation_record(cls, item, session):
         """Reject consultation record."""
-        item.status = ItemStatus.FAILED_CONSULTATION_CHECK.value
         cls._update_submissions_status(item, SubmissionStatus.REJECTED, session)
         update_request_data = cls._prepare_update_request_data(item)
         cls._create_update_request(update_request_data, session)

--- a/submit-api/src/submit_api/services/package.py
+++ b/submit-api/src/submit_api/services/package.py
@@ -228,8 +228,6 @@ class PackageService:
     def _update_items_status(items, status, session):
         """Update status of all items in the package."""
         for item in items:
-            if item.status in [ItemStatus.PASSED_CONSULTATION_CHECK]:
-                continue
             item.status = status
             session.add(item)
         session.flush()
@@ -342,9 +340,6 @@ class PackageService:
             raise BadRequestError("Cannot resubmit a package that has no open update requests")
         if package.completed_on:
             raise BadRequestError("Cannot resubmit a package that has been completed")
-        cls._update_items_status(
-            package.items, ItemStatus.SUBMITTED.value, session)
-        cls._update_package_status(package.id, session, package)
         cls._update_package_submission_details(package, session)
         cls.update_submission_status(package, SubmissionStatus.SUBMITTED.value, session)
         cls._create_email_queue_record(package, session)


### PR DESCRIPTION
- Remove logic to update item status to Failed CC
- Remove logic to do package or item status updates when we resubmit