### PR TITLE
Header touch ups

### DIFF
--- a/submit-web/src/components/Shared/ContentBox/index.tsx
+++ b/submit-web/src/components/Shared/ContentBox/index.tsx
@@ -37,7 +37,7 @@ export const ContentBox = ({
             alignItems: "center",
             justifyContent: "space-between",
             width: "auto",
-            padding: "12px 24px",
+            padding: "0px 24px",
             height: "56px",
           },
           contentBoxVariant === "primary" && {
@@ -62,20 +62,20 @@ export const ContentBox = ({
           {mainLabel || ""}
         </Typography>
         {topLabel && bottomLabel && (
-          <Stack>
+          <Stack textAlign={"center"}>
             <Typography
-              variant="h5"
+              variant="body1"
               sx={{
                 mr: 2,
+                fontWeight: "bold",
               }}
             >
               {topLabel}
             </Typography>
             <Typography
-              variant="h5"
+              variant="body1"
               sx={{
                 mr: 2,
-                fontWeight: 400,
               }}
             >
               {bottomLabel}


### PR DESCRIPTION
remove the 12px margin top and bottom to make the height of the header 56px total. CH name should be 16px bold, and the EAC# 16px regular. All text centre aligned.