### PR TITLE
Fix to fetch project name using account id

### DIFF
--- a/submit-cron/src/submit_cron/services/invitation_email_service.py
+++ b/submit-cron/src/submit_cron/services/invitation_email_service.py
@@ -31,7 +31,6 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
         elif invitation.package_ids:
             project_name = cls.get_project_names_for_package_id(invitation.package_ids)
         elif invitation.account_id:
-            print('--invitation.account_id--',invitation.account_id)
             project_name = cls.get_project_name_for_account_id(invitation.account_id)
 
         if not project_name:

--- a/submit-cron/src/submit_cron/services/invitation_email_service.py
+++ b/submit-cron/src/submit_cron/services/invitation_email_service.py
@@ -30,6 +30,9 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
             project_name = cls.get_project_names(invitation.project_ids)
         elif invitation.package_ids:
             project_name = cls.get_project_names_for_package_id(invitation.package_ids)
+        elif invitation.account_id:
+            print('--invitation.account_id--',invitation.account_id)
+            project_name = cls.get_project_name_for_account_id(invitation.account_id)
 
         if not project_name:
             raise BadRequestError(f"Project name not found for invitation id: {invitation.id}")
@@ -76,6 +79,20 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
             .scalar()
         )
 
+        return project_name or ""
+
+    @staticmethod
+    def get_project_name_for_account_id(account_id: int) -> str:
+        """Fetch project name for a given account ID."""
+        if not account_id:
+            return ""
+
+        project_name = (
+            db.session.query(ProjectModel.name)
+            .join(AccountProjectModel, ProjectModel.id == AccountProjectModel.project_id)
+            .filter(AccountProjectModel.account_id == account_id)
+            .scalar()
+        )
         return project_name or ""
 
     @staticmethod


### PR DESCRIPTION
In the first case when there is no submissions and somebody is added a collaborator , the code was failing to fetch project name since there wasnt any submission or there was no project .. So used account id 