### PR TITLE
Fix duplicate submission name displayed while ading new user

### DIFF
--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -17,6 +17,7 @@ from submit_api.enums.item_status import ItemStatus
 from submit_api.models import AccountProject, db
 from submit_api.models.package import Package as PackageModel
 from submit_api.models.package import PackageStatus
+from submit_api.models.package_version import PackageVersion
 
 
 # pylint: disable=too-few-public-methods
@@ -132,7 +133,21 @@ class PackageQueries:
 
     @classmethod
     def get_account_project_packages(cls, account_id: int):
-        """Fetch project_id and related packages (id, name) for a given account_id."""
+        """Fetch project_id and related packages (id, name) for a given account_id.
+        
+        Only includes packages with the latest version_id matching the highest version 
+        of the original_package_id from package_versions.
+        """
+        # Subquery to get the latest version_id for each original_package_id
+        latest_versions_subquery = (
+            db.session.query(
+                PackageVersion.original_package_id,
+                func.max(PackageVersion.id).label("latest_version_id")  # Get the latest version_id
+            )
+            .group_by(PackageVersion.original_package_id)  # Group by original_package_id
+            .subquery()
+        )
+
         query = (
             db.session.query(
                 AccountProject.project_id,
@@ -144,6 +159,10 @@ class PackageQueries:
                 ).label('packages')  # Aggregate packages as a JSON array
             )
             .join(PackageModel, PackageModel.account_project_id == AccountProject.id)
+            .join(
+                latest_versions_subquery,
+                PackageModel.version_id == latest_versions_subquery.c.latest_version_id
+            )  # Only fetch packages with the latest version_id
             .filter(AccountProject.account_id == account_id)
             .group_by(AccountProject.project_id)  # Group by project_id
             .all()

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -132,7 +132,7 @@ class PackageQueries:
             session.add(package)
 
     @classmethod
-    def get_account_project_packages(cls, account_id: int):
+    def get_latest_account_project_packages(cls, account_id: int):
         """Fetch project_id and related packages (id, name) for a given account_id.
 
         Only includes packages with the latest version_id matching the highest version

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -134,8 +134,8 @@ class PackageQueries:
     @classmethod
     def get_account_project_packages(cls, account_id: int):
         """Fetch project_id and related packages (id, name) for a given account_id.
-        
-        Only includes packages with the latest version_id matching the highest version 
+
+        Only includes packages with the latest version_id matching the highest version
         of the original_package_id from package_versions.
         """
         # Subquery to get the latest version_id for each original_package_id

--- a/submit-api/src/submit_api/services/account_service.py
+++ b/submit-api/src/submit_api/services/account_service.py
@@ -100,4 +100,4 @@ class AccountService:
     @classmethod
     def get_all_account_packages(cls, account_id):
         """Get packages by account id."""
-        return PackageQueries.get_account_project_packages(account_id)
+        return PackageQueries.get_latest_account_project_packages(account_id)


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/SUBMIT-440

- Updated the logic to ensure that package names and IDs are retrieved based on the latest version of the original package.
- This change prevents duplicate package names from appearing when adding a new user for a specific submission.