### PR TITLE
Display Previously Failed status for CR with failed submissions in history

### DIFF
--- a/submit-api/src/submit_api/models/queries/submitted_document.py
+++ b/submit-api/src/submit_api/models/queries/submitted_document.py
@@ -20,7 +20,7 @@ from submit_api.models.db import db
 from submit_api.models.item import Item
 from submit_api.models.package import Package
 from submit_api.models.project import Project
-from submit_api.models.submission import Submission, SubmissionType
+from submit_api.models.submission import Submission, SubmissionType, SubmissionStatus
 from submit_api.models.submitted_document import SubmittedDocument
 
 
@@ -78,3 +78,16 @@ class DocumentQueries:
                 Project.name.ilike(f"%{search_text}%")
             )
         )
+
+    @classmethod
+    def get_failed_documents_by_item_id(cls, item_id):
+        """Get all failed documents by item id."""
+        session = db.session
+
+        query = session.query(Submission).filter_by(
+            item_id=item_id,
+            type=SubmissionType.DOCUMENT,
+            status=SubmissionStatus.REJECTED
+        )
+
+        return query.all()

--- a/submit-api/src/submit_api/resources/staff/submitted_document.py
+++ b/submit-api/src/submit_api/resources/staff/submitted_document.py
@@ -82,6 +82,5 @@ class ItemFailedDocuments(Resource):
     @cors.crossdomain(origin="*")
     def get(item_id):
         """Get all failed documents by item id."""
-
         documents = DocumentService.get_failed_documents_by_item_id(item_id)
         return SubmissionSchema(many=True).dump(documents), HTTPStatus.OK

--- a/submit-api/src/submit_api/resources/staff/submitted_document.py
+++ b/submit-api/src/submit_api/resources/staff/submitted_document.py
@@ -21,7 +21,7 @@ from flask_restx import Namespace, Resource, cors
 from submit_api.auth import auth
 from submit_api.models.account_project_search_options import DocumentSearchOptions
 from submit_api.resources.apihelper import Api as ApiHelper
-from submit_api.schemas.submission import SubmittedDocumentByProjectSchema
+from submit_api.schemas.submission import SubmittedDocumentByProjectSchema, SubmissionSchema
 from submit_api.services.submitted_document_service import DocumentService
 from submit_api.utils.roles import EpicSubmitRole
 from submit_api.utils.util import cors_preflight
@@ -62,3 +62,26 @@ class AccountDocuments(Resource):
 
         documents = DocumentService.get_all_documents(search_options)
         return SubmittedDocumentByProjectSchema(many=True).dump(documents), HTTPStatus.OK
+
+
+@cors_preflight("GET, OPTIONS")
+@API.route(
+    "/failed/items/<int:item_id>",
+    methods=["GET", "OPTIONS"],
+)
+class ItemFailedDocuments(Resource):
+    """Resource for managing submitted documents."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description="Get submitted documents")
+    @API.response(
+        code=HTTPStatus.OK, model=document_list_model, description="Get documents"
+    )
+    @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
+    @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
+    @cors.crossdomain(origin="*")
+    def get(item_id):
+        """Get all failed documents by item id."""
+
+        documents = DocumentService.get_failed_documents_by_item_id(item_id)
+        return SubmissionSchema(many=True).dump(documents), HTTPStatus.OK

--- a/submit-api/src/submit_api/services/submitted_document_service.py
+++ b/submit-api/src/submit_api/services/submitted_document_service.py
@@ -11,3 +11,8 @@ class DocumentService:
     def get_all_documents(cls, search_options: DocumentSearchOptions = None):
         """Get all documents."""
         return DocumentQueries.get_filtered_documents(search_options)
+
+    @classmethod
+    def get_failed_documents_by_item_id(cls, item_id):
+        """Get all failed documents by item id."""
+        return DocumentQueries.get_failed_documents_by_item_id(item_id)

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
@@ -48,7 +48,7 @@ export default function ProponentSubmissionItemTableRow({
   const submissionPackage = queryClient.getQueryData<SubmissionPackage>(
     getSubmissionPackageQueryOptions({
       packageId: Number(submissionPackageId),
-    }).queryKey
+    }).queryKey,
   );
 
   const isUpdated = useMemo(() => {
@@ -56,7 +56,7 @@ export default function ProponentSubmissionItemTableRow({
     const last_update_request = submissionPackage.update_requests
       .filter(
         (updateRequest) =>
-          updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value
+          updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value,
       )
       .sort((a, b) => dayjs(b.created_date).diff(dayjs(a.created_date)))[0];
 
@@ -64,9 +64,9 @@ export default function ProponentSubmissionItemTableRow({
     return Boolean(
       item.submissions.find((submission) =>
         dayjs(submission.created_date).isAfter(
-          last_update_request?.created_date
-        )
-      )
+          last_update_request?.created_date,
+        ),
+      ),
     );
   }, [item, submissionPackage]);
 
@@ -125,7 +125,7 @@ export default function ProponentSubmissionItemTableRow({
               submissionPackage?.submitted_on &&
               submissionPackage.update_requests.filter(
                 (updateRequest) =>
-                  updateRequest.status !== UPDATE_REQUEST_STATUS.ACCEPTED.value
+                  updateRequest.status !== UPDATE_REQUEST_STATUS.ACCEPTED.value,
               ).length === 0
             }
           >

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
@@ -1,0 +1,27 @@
+import { SubmissionStatusChipStack } from "@/components/SubmissionStatusChip";
+import { PackageStatus } from "@/models/Package";
+import { SubmissionItemStatus } from "@/models/Submission";
+
+type CRStaffCellProps = Readonly<{
+  status?: SubmissionItemStatus;
+  isUpdateRequested: boolean;
+  isUpdated: boolean;
+  packageStatus: PackageStatus[];
+  submissionItemId: number;
+}>;
+export const CRStaffCell = ({
+  status,
+  isUpdateRequested,
+  isUpdated,
+  packageStatus,
+  submissionItemId,
+}: CRStaffCellProps) => {
+  return (
+    <SubmissionStatusChipStack
+      status={status}
+      isUpdateRequested={isUpdateRequested}
+      isUpdated={isUpdated}
+      packageStatus={packageStatus}
+    />
+  );
+};

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
@@ -1,6 +1,13 @@
-import { SubmissionStatusChipStack } from "@/components/SubmissionStatusChip";
+import {
+  SubmissionStatusChip,
+  SubmissionStatusChipStack,
+} from "@/components/SubmissionStatusChip";
+import { useGetFailedSubmissionsByItemId } from "@/hooks/api/useSubmissions";
 import { PackageStatus } from "@/models/Package";
-import { SubmissionItemStatus } from "@/models/Submission";
+import {
+  NON_CANONICAL_SUBMISSION_STATUS,
+  SubmissionItemStatus,
+} from "@/models/Submission";
 
 type CRStaffCellProps = Readonly<{
   status?: SubmissionItemStatus;
@@ -16,12 +23,22 @@ export const CRStaffCell = ({
   packageStatus,
   submissionItemId,
 }: CRStaffCellProps) => {
+  const { data: failedSubmissions } =
+    useGetFailedSubmissionsByItemId(submissionItemId);
+  console.log("failedSubmissions", failedSubmissions);
   return (
-    <SubmissionStatusChipStack
-      status={status}
-      isUpdateRequested={isUpdateRequested}
-      isUpdated={isUpdated}
-      packageStatus={packageStatus}
-    />
+    <>
+      <SubmissionStatusChipStack
+        status={status}
+        isUpdateRequested={isUpdateRequested}
+        isUpdated={isUpdated}
+        packageStatus={packageStatus}
+      />
+      {failedSubmissions && failedSubmissions.length > 0 && (
+        <SubmissionStatusChip
+          status={NON_CANONICAL_SUBMISSION_STATUS.PREVIOUSLY_FAILED}
+        />
+      )}
+    </>
   );
 };

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
@@ -25,7 +25,6 @@ export const CRStaffCell = ({
 }: CRStaffCellProps) => {
   const { data: failedSubmissions } =
     useGetFailedSubmissionsByItemId(submissionItemId);
-  console.log("failedSubmissions", failedSubmissions);
   return (
     <>
       <SubmissionStatusChipStack

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
@@ -1,0 +1,92 @@
+import { Box } from "@mui/material";
+import { useParams } from "@tanstack/react-router";
+import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
+import { SUBMISSION_ITEM_TYPE, SubmissionItem } from "@/models/SubmissionItem";
+import { useMemo } from "react";
+import { useSuspenseQuery } from "@tanstack/react-query";
+import { filterOpenUpdateRequests } from "@/utils";
+import {
+  UPDATE_REQUEST_STATUS,
+  UPDATE_REQUEST_TYPE,
+} from "@/models/UpdateRequest";
+import dayjs from "dayjs";
+import { SubmissionStatusChipStack } from "@/components/SubmissionStatusChip";
+import { Case, Default, Switch } from "react-if";
+import { CRStaffCell } from "./CRStaffCell";
+
+type StaffStatusCellProps = Readonly<{
+  submissionItem: SubmissionItem;
+}>;
+export default function StaffStatusCell({
+  submissionItem,
+}: StaffStatusCellProps) {
+  const { submissionPackageId } = useParams({
+    from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId",
+  });
+
+  const { data: submissionPackage, isPending: isPackagePending } =
+    useSuspenseQuery(
+      getStaffSubmissionPackageQueryOptions({
+        packageId: Number(submissionPackageId),
+      }),
+    );
+
+  const { status, type_id, type } = submissionItem;
+
+  const isUpdated = useMemo(() => {
+    const last_update_request = submissionPackage.update_requests
+      .filter(
+        (updateRequest) =>
+          updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value &&
+          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
+          updateRequest.active,
+      )
+      .sort((a, b) => dayjs(b.created_date).diff(dayjs(a.created_date)))[0];
+
+    if (!last_update_request) return false;
+    return Boolean(
+      submissionItem.submissions.find((submission) =>
+        dayjs(submission.created_date).isAfter(
+          last_update_request.created_date,
+        ),
+      ),
+    );
+  }, [submissionItem, submissionPackage.update_requests]);
+
+  const isUpdateRequest = useMemo(() => {
+    if (!submissionPackage) return false;
+    return filterOpenUpdateRequests(submissionPackage.update_requests)
+      .flatMap((updateRequest) => updateRequest.submission_item_types)
+      .includes(type_id);
+  }, [submissionPackage, type_id]);
+
+  if (isPackagePending) {
+    return null;
+  }
+
+  return (
+    <Box mr={2}>
+      <Switch>
+        <Case
+          condition={type.name === SUBMISSION_ITEM_TYPE.CONSULTATION_RECORD}
+        >
+          <CRStaffCell
+            status={status}
+            isUpdateRequested={isUpdateRequest}
+            isUpdated={isUpdated}
+            packageStatus={submissionPackage.status}
+            submissionItemId={submissionItem.id}
+          />
+        </Case>
+        <Default>
+          <SubmissionStatusChipStack
+            status={status}
+            isUpdateRequested={isUpdateRequest}
+            isUpdated={isUpdated}
+            packageStatus={submissionPackage.status}
+          />
+        </Default>
+      </Switch>
+    </Box>
+  );
+}

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Stack } from "@mui/material";
+import { Stack } from "@mui/material";
 import { useParams } from "@tanstack/react-router";
 import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
 import { SUBMISSION_ITEM_TYPE, SubmissionItem } from "@/models/SubmissionItem";

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
@@ -1,4 +1,4 @@
-import { Box } from "@mui/material";
+import { Box, Stack } from "@mui/material";
 import { useParams } from "@tanstack/react-router";
 import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
 import { SUBMISSION_ITEM_TYPE, SubmissionItem } from "@/models/SubmissionItem";
@@ -21,7 +21,7 @@ export default function StaffStatusCell({
   submissionItem,
 }: StaffStatusCellProps) {
   const { submissionPackageId } = useParams({
-    from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId",
+    from: "/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId",
   });
 
   const { data: submissionPackage, isPending: isPackagePending } =
@@ -65,7 +65,7 @@ export default function StaffStatusCell({
   }
 
   return (
-    <Box mr={2}>
+    <Stack mr={2} direction={"column"} alignItems={"flex-end"} spacing={1}>
       <Switch>
         <Case
           condition={type.name === SUBMISSION_ITEM_TYPE.CONSULTATION_RECORD}
@@ -87,6 +87,6 @@ export default function StaffStatusCell({
           />
         </Default>
       </Switch>
-    </Box>
+    </Stack>
   );
 }

--- a/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/index.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/index.tsx
@@ -1,34 +1,25 @@
 import {
-  Box,
   Link as MuiLink,
   TableCell,
   TableRow,
   Typography,
 } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
-import DocumentRow from "../DocumentRow";
 import { When } from "react-if";
-import { SubmissionItemTableRowProps } from ".";
 import { useNavigate, useParams } from "@tanstack/react-router";
-import { SubmissionStatusChipStack } from "../../SubmissionStatusChip";
 import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
-
 import { SUBMISSION_ITEM_METHOD } from "@/models/SubmissionItem";
-import { useMemo } from "react";
 import {
   SubmitPrimaryRowTableCell,
   SubmitTablePrimaryRow,
 } from "@/components/Shared/Table/common";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { filterOpenUpdateRequests } from "@/utils";
-import {
-  UPDATE_REQUEST_STATUS,
-  UPDATE_REQUEST_TYPE,
-} from "@/models/UpdateRequest";
-import dayjs from "dayjs";
 import { SUBMISSION_TYPE } from "@/models/Submission";
-import SubmissionItemReviewConfirmation from "../SubmissionItemReviewConfirmation";
 import EmptyRow from "@/components/Projects/ProjectTable/EmptyRow";
+import { SubmissionItemTableRowProps } from "..";
+import SubmissionItemReviewConfirmation from "../../SubmissionItemReviewConfirmation";
+import DocumentRow from "../../DocumentRow";
+import StaffStatusCell from "./StaffStatusCell";
 
 export default function StaffSubmissionItemTableRow({
   item,
@@ -45,40 +36,13 @@ export default function StaffSubmissionItemTableRow({
       }),
     );
 
-  const { submissions, id, status, type_id } = item;
+  const { submissions, id } = item;
 
   const { submitted_on } = submissionPackage;
 
   const name = item.type.name;
   const hasDocument =
     item.type.submission_method === SUBMISSION_ITEM_METHOD.DOCUMENT_UPLOAD;
-
-  const isUpdated = useMemo(() => {
-    const last_update_request = submissionPackage.update_requests
-      .filter(
-        (updateRequest) =>
-          updateRequest.type === UPDATE_REQUEST_TYPE.UPDATE.value &&
-          updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
-          updateRequest.active,
-      )
-      .sort((a, b) => dayjs(b.created_date).diff(dayjs(a.created_date)))[0];
-
-    if (!last_update_request) return false;
-    return Boolean(
-      item.submissions.find((submission) =>
-        dayjs(submission.created_date).isAfter(
-          last_update_request.created_date,
-        ),
-      ),
-    );
-  }, [item, submissionPackage.update_requests]);
-
-  const isUpdateRequest = useMemo(() => {
-    if (!submissionPackage) return false;
-    return filterOpenUpdateRequests(submissionPackage.update_requests)
-      .flatMap((updateRequest) => updateRequest.submission_item_types)
-      .includes(type_id);
-  }, [submissionPackage, type_id]);
 
   const actionLabel = hasDocument ? "Review" : "View";
 
@@ -117,16 +81,8 @@ export default function StaffSubmissionItemTableRow({
         <SubmitPrimaryRowTableCell align="left" width={"10%"} />
         <SubmitPrimaryRowTableCell align="right" width={"10%"} />
         <SubmitPrimaryRowTableCell align="right" width={"20%"}>
-          <Box mr={2}>
-            <SubmissionStatusChipStack
-              status={status}
-              isUpdateRequested={isUpdateRequest}
-              isUpdated={isUpdated}
-              packageStatus={submissionPackage.status}
-            />
-          </Box>
+          <StaffStatusCell submissionItem={item} />
         </SubmitPrimaryRowTableCell>
-
         <SubmitPrimaryRowTableCell align="left" width={"10%"}>
           <When condition={submitted_on}>
             <SubmissionItemReviewConfirmation

--- a/submit-web/src/components/SubmissionStatusChip/index.tsx
+++ b/submit-web/src/components/SubmissionStatusChip/index.tsx
@@ -1,4 +1,4 @@
-import { PackageStatus } from "@/models/Package";
+import { PACKAGE_STATUS, PackageStatus } from "@/models/Package";
 import {
   NON_CANONICAL_SUBMISSION_STATUS,
   SUBMISSION_ITEM_STATUS,
@@ -189,6 +189,15 @@ const statusStyles: Record<string, StyleProps> = {
       width: "157px",
     },
   },
+  PREVIOUSLY_FAILED: {
+    label: "Previously Failed",
+    sx: {
+      borderRadius: 1,
+      border: `1px solid ${BCDesignTokens.supportBorderColorDanger}`,
+      background: BCDesignTokens.supportSurfaceColorDanger,
+      height: "24px",
+    },
+  },
 };
 
 type SubmissionStatusChipProps = Readonly<{
@@ -232,7 +241,7 @@ export const SubmissionStatusChipStack = ({
     } else if (userType === USER_TYPE.PROPONENT) {
       return (
         status === SUBMISSION_ITEM_STATUS.SUBMITTED.value &&
-        !packageStatus?.includes(SUBMISSION_ITEM_STATUS.SUBMITTED.value)
+        !packageStatus?.includes(PACKAGE_STATUS.SUBMITTED.value)
       );
     }
     return false;

--- a/submit-web/src/components/SubmissionStatusChip/index.tsx
+++ b/submit-web/src/components/SubmissionStatusChip/index.tsx
@@ -196,6 +196,7 @@ const statusStyles: Record<string, StyleProps> = {
       border: `1px solid ${BCDesignTokens.supportBorderColorDanger}`,
       background: BCDesignTokens.supportSurfaceColorDanger,
       height: "24px",
+      width: "128px",
     },
   },
 };

--- a/submit-web/src/hooks/api/constants.ts
+++ b/submit-web/src/hooks/api/constants.ts
@@ -24,4 +24,5 @@ export const QUERY_KEY = Object.freeze({
   PROPONENTS: "proponents",
   PROPONENT: "proponent",
   USER_ACCOUNT_DATA: "user-account-data",
+  FAILED_SUBMISSIONS: "failed-submissions",
 });

--- a/submit-web/src/hooks/api/useSubmissions.ts
+++ b/submit-web/src/hooks/api/useSubmissions.ts
@@ -202,19 +202,19 @@ export const getSubmissionVersions = (submissionId: number) => {
   });
 };
 
-export const getFailedSubmissions = (submissionItemId: number) => {
+export const getFailedSubmissionsByItemId = (submissionItemId: number) => {
   return submitRequest<Submission[]>({
-    url: `/submissions/failed/items/${submissionItemId}`,
+    url: `/staff/documents/failed/items/${submissionItemId}`,
   });
 };
 
-export const useGetFailedSubmissions = (
+export const useGetFailedSubmissionsByItemId = (
   submissionItemId: number,
   options?: Options,
 ) => {
   return useQuery({
     queryKey: [QUERY_KEY.FAILED_SUBMISSIONS, submissionItemId],
-    queryFn: () => getFailedSubmissions(submissionItemId),
+    queryFn: () => getFailedSubmissionsByItemId(submissionItemId),
     enabled: Boolean(submissionItemId),
     ...defaultUseQueryOptions,
     ...options,

--- a/submit-web/src/hooks/api/useSubmissions.ts
+++ b/submit-web/src/hooks/api/useSubmissions.ts
@@ -201,3 +201,22 @@ export const getSubmissionVersions = (submissionId: number) => {
     url: `/submissions/${submissionId}/versions`,
   });
 };
+
+export const getFailedSubmissions = (submissionItemId: number) => {
+  return submitRequest<Submission[]>({
+    url: `/submissions/failed/items/${submissionItemId}`,
+  });
+};
+
+export const useGetFailedSubmissions = (
+  submissionItemId: number,
+  options?: Options,
+) => {
+  return useQuery({
+    queryKey: [QUERY_KEY.FAILED_SUBMISSIONS, submissionItemId],
+    queryFn: () => getFailedSubmissions(submissionItemId),
+    enabled: Boolean(submissionItemId),
+    ...defaultUseQueryOptions,
+    ...options,
+  });
+};

--- a/submit-web/src/models/Submission.ts
+++ b/submit-web/src/models/Submission.ts
@@ -5,6 +5,7 @@ export type NonCanonicalSubmissionStatus =
   | "UPDATED"
   | "UPDATE_REQUESTED"
   | "NO_REVISION_REQUIRED"
+  | "PREVIOUSLY_FAILED"
   | "FAILED";
 
 export const NON_CANONICAL_SUBMISSION_STATUS = Object.freeze<
@@ -16,6 +17,7 @@ export const NON_CANONICAL_SUBMISSION_STATUS = Object.freeze<
   UPDATED: "UPDATED",
   FAILED: "FAILED",
   NO_REVISION_REQUIRED: "NO_REVISION_REQUIRED",
+  PREVIOUSLY_FAILED: "PREVIOUSLY_FAILED",
 });
 
 export type SubmissionItemStatus =
@@ -26,6 +28,7 @@ export type SubmissionItemStatus =
   | "REVIEW_REJECTED"
   | "FAILED_CONSULTATION_CHECK"
   | "PASSED_CONSULTATION_CHECK"
+  | "REVISION_REQUIRED"
   | "APPROVED";
 
 export const SUBMISSION_ITEM_STATUS: Record<
@@ -63,6 +66,10 @@ export const SUBMISSION_ITEM_STATUS: Record<
   APPROVED: {
     value: "APPROVED",
     label: "Approved",
+  },
+  REVISION_REQUIRED: {
+    value: "REVISION_REQUIRED",
+    label: "Revision Required",
   },
 };
 

--- a/submit-web/src/models/SubmissionItem.ts
+++ b/submit-web/src/models/SubmissionItem.ts
@@ -21,12 +21,11 @@ export type SubmissionItemType = {
   submission_method: SubmissionItemMethod;
 };
 
-export const SUBMISSION_ITEM_TYPE: Record<string, SubmissionItemTypeName> =
-  Object.freeze({
-    CONTACT_INFORMATION: "Contact Information Form",
-    MANAGEMENT_PLAN: "Management Plan",
-    CONSULTATION_RECORD: "Consultation Record(s)",
-  });
+export enum SUBMISSION_ITEM_TYPE {
+  CONTACT_INFORMATION = "Contact Information Form",
+  MANAGEMENT_PLAN = "Management Plan",
+  CONSULTATION_RECORD = "Consultation Record(s)",
+}
 
 export const SUBMISSION_ITEM_MODAL_CONTENT: Record<
   string,


### PR DESCRIPTION
- Add GET failed submissions by item id
- Add Previously Failed status
- Add custom status cell for CR items
- Call endpoint and display status accordingly