### PR TITLE
EAO- Update/Revision Requested Tweaks

### DIFF
--- a/submit-web/src/components/Shared/WarningBox/index.tsx
+++ b/submit-web/src/components/Shared/WarningBox/index.tsx
@@ -1,10 +1,10 @@
-import { Box } from "@mui/material";
+import { Box, BoxProps } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import React from "react";
 
 type WarningBoxProps = {
   children: React.ReactNode;
-};
+} & BoxProps;
 
 export default function WarningBox({ children }: WarningBoxProps) {
   return (

--- a/submit-web/src/components/Submission/UpdateRequestWidget/AddRequestSection.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/AddRequestSection.tsx
@@ -106,7 +106,7 @@ export default function AddRequestSection({
                 mb: BCDesignTokens.layoutMarginSmall,
               }}
             >
-              EAO Note
+              EAO Comment
             </Typography>
             <ControlledTextField
               name="reason"

--- a/submit-web/src/components/Submission/UpdateRequestWidget/AddRequestSection.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/AddRequestSection.tsx
@@ -106,7 +106,7 @@ export default function AddRequestSection({
                 mb: BCDesignTokens.layoutMarginSmall,
               }}
             >
-              Request Note
+              EAO Note
             </Typography>
             <ControlledTextField
               name="reason"

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -6,7 +6,6 @@ import {
   Chip,
   Collapse,
   Divider,
-  Stack,
   Typography,
 } from "@mui/material";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
@@ -21,8 +20,6 @@ import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { isAxiosError } from "axios";
 import PermissionsGate from "@/components/Shared/PermissionGate";
 import { EPIC_SUBMIT_ROLE } from "@/models/Role";
-import WarningBox from "@/components/Shared/WarningBox";
-import PriorityHighIcon from "@mui/icons-material/PriorityHigh";
 
 type UpdateRequestWidgetProps = Readonly<{
   submissionPackage: SubmissionPackage;
@@ -216,16 +213,16 @@ export default function UpdateRequestWidget({
           },
         ]}
       >
-        {/* <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}> */}
-        <Collapse in={isCreateRequestOpen} unmountOnExit>
-          <AddRequestSection
-            submissionPackage={submissionPackage}
-            handleCreateUpdateRequest={handleCreateUpdateRequest}
-            isCreatingUpdateRequest={isCreatingUpdateRequest}
-            handleCancelReason={handleCancelReason}
-          />
-        </Collapse>
-        {/* </PermissionsGate> */}
+        <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}>
+          <Collapse in={isCreateRequestOpen} unmountOnExit>
+            <AddRequestSection
+              submissionPackage={submissionPackage}
+              handleCreateUpdateRequest={handleCreateUpdateRequest}
+              isCreatingUpdateRequest={isCreatingUpdateRequest}
+              handleCancelReason={handleCancelReason}
+            />
+          </Collapse>
+        </PermissionsGate>
         {updateRequests.length > 0 ? (
           updateRequests.map((updateRequest, index) => (
             <>
@@ -242,17 +239,6 @@ export default function UpdateRequestWidget({
             No requests have been made yet.
           </Typography>
         )}
-        {/* <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}> */}
-        <WarningBox mb={BCDesignTokens.layoutMarginXsmall}>
-          <Stack direction="row" alignItems="center" spacing={2}>
-            <PriorityHighIcon />
-            <Typography variant="body1" color="inherit">
-              This request, including the EAO Comment, will be sent to the
-              holder after a Manager confirms the decision.
-            </Typography>
-          </Stack>
-        </WarningBox>
-        {/* </PermissionsGate> */}
       </AccordionDetails>
     </Accordion>
   );

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   Collapse,
   Divider,
+  Stack,
   Typography,
 } from "@mui/material";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
@@ -20,6 +21,8 @@ import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { isAxiosError } from "axios";
 import PermissionsGate from "@/components/Shared/PermissionGate";
 import { EPIC_SUBMIT_ROLE } from "@/models/Role";
+import WarningBox from "@/components/Shared/WarningBox";
+import PriorityHighIcon from "@mui/icons-material/PriorityHigh";
 
 type UpdateRequestWidgetProps = Readonly<{
   submissionPackage: SubmissionPackage;
@@ -62,7 +65,7 @@ export default function UpdateRequestWidget({
           notify.error(
             isAxiosError(error)
               ? (error.response?.data.message ?? defaultMessage)
-              : defaultMessage,
+              : defaultMessage
           );
         },
       },
@@ -151,7 +154,7 @@ export default function UpdateRequestWidget({
                 fontWeight: BCDesignTokens.typographyBoldBody,
               }}
             >
-              Update Requests
+              Update & Revision Requests
             </Typography>
             <When condition={activeRequests.length > 0}>
               <Chip
@@ -213,16 +216,16 @@ export default function UpdateRequestWidget({
           },
         ]}
       >
-        <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}>
-          <Collapse in={isCreateRequestOpen} unmountOnExit>
-            <AddRequestSection
-              submissionPackage={submissionPackage}
-              handleCreateUpdateRequest={handleCreateUpdateRequest}
-              isCreatingUpdateRequest={isCreatingUpdateRequest}
-              handleCancelReason={handleCancelReason}
-            />
-          </Collapse>
-        </PermissionsGate>
+        {/* <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}> */}
+        <Collapse in={isCreateRequestOpen} unmountOnExit>
+          <AddRequestSection
+            submissionPackage={submissionPackage}
+            handleCreateUpdateRequest={handleCreateUpdateRequest}
+            isCreatingUpdateRequest={isCreatingUpdateRequest}
+            handleCancelReason={handleCancelReason}
+          />
+        </Collapse>
+        {/* </PermissionsGate> */}
         {updateRequests.length > 0 ? (
           updateRequests.map((updateRequest, index) => (
             <>
@@ -239,6 +242,17 @@ export default function UpdateRequestWidget({
             No requests have been made yet.
           </Typography>
         )}
+        {/* <PermissionsGate scopes={[EPIC_SUBMIT_ROLE.eao_create]}> */}
+        <WarningBox mb={BCDesignTokens.layoutMarginXsmall}>
+          <Stack direction="row" alignItems="center" spacing={2}>
+            <PriorityHighIcon />
+            <Typography variant="body1" color="inherit">
+              This request, including the EAO Comment, will be sent to the
+              holder after a Manager confirms the decision.
+            </Typography>
+          </Stack>
+        </WarningBox>
+        {/* </PermissionsGate> */}
       </AccordionDetails>
     </Accordion>
   );

--- a/submit-web/src/components/SubmissionItem/AddRequestSection.tsx
+++ b/submit-web/src/components/SubmissionItem/AddRequestSection.tsx
@@ -44,7 +44,6 @@ export default function AddRequestSection({
 
   return (
     <Box
-      mt="20px"
       sx={{
         border: `1px solid ${BCDesignTokens.supportBorderColorWarning}`,
         backgroundColor: "#FFF",

--- a/submit-web/src/components/SubmissionItem/AddRequestSection.tsx
+++ b/submit-web/src/components/SubmissionItem/AddRequestSection.tsx
@@ -14,6 +14,9 @@ import ControlledTextField from "@/components/Shared/controlled/ControlledTextFi
 import { useQueryClient } from "@tanstack/react-query";
 import { useParams } from "@tanstack/react-router";
 import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
+import WarningBox from "@/components/Shared/WarningBox";
+import PriorityHighIcon from "@mui/icons-material/PriorityHigh";
+import Stack from "@mui/material/Stack";
 
 type AddRequestSectionProps = {
   readonly disabled?: boolean;
@@ -29,13 +32,13 @@ export default function AddRequestSection({
   const submissionPackage = queryClient.getQueryData<SubmissionPackage>(
     getStaffSubmissionPackageQueryOptions({
       packageId: Number(submissionPackageId),
-    }).queryKey,
+    }).queryKey
   );
   const filteredItems = useMemo(() => {
     if (!submissionPackage?.items) return [];
     return submissionPackage.items.filter(
       (item) =>
-        item.type.submission_method === SUBMISSION_ITEM_METHOD.DOCUMENT_UPLOAD,
+        item.type.submission_method === SUBMISSION_ITEM_METHOD.DOCUMENT_UPLOAD
     );
   }, [submissionPackage?.items]);
 
@@ -87,6 +90,15 @@ export default function AddRequestSection({
           decision.
         </FormHelperText>
       </Box>
+      <WarningBox mb={BCDesignTokens.layoutMarginXsmall}>
+        <Stack direction="row" alignItems="center" spacing={2}>
+          <PriorityHighIcon fontSize="large" />
+          <Typography variant="body1" color="inherit">
+            This request, including the EAO Comment, will be sent to the holder
+            after a Manager confirms the decision.
+          </Typography>
+        </Stack>
+      </WarningBox>
     </Box>
   );
 }

--- a/submit-web/src/components/SubmissionItem/ConsultationRecord/ConsultationRecordProponentView/index.tsx
+++ b/submit-web/src/components/SubmissionItem/ConsultationRecord/ConsultationRecordProponentView/index.tsx
@@ -215,7 +215,10 @@ export const ConsultationRecordProponentView = () => {
             <Grid item xs={12}>
               <DocumentUploadSection />
             </Grid>
-            <UpdateRequestWidget submissionPackage={submissionPackage} />
+            {submissionPackage &&
+              submissionPackage?.update_requests?.length > 0 && (
+                <UpdateRequestWidget submissionPackage={submissionPackage} />
+              )}
             <ActionButtons saveAndClose={saveAndClose} />
           </Grid>
         </Form>

--- a/submit-web/src/components/SubmissionItem/ConsultationRecord/ConsultationRecordProponentView/index.tsx
+++ b/submit-web/src/components/SubmissionItem/ConsultationRecord/ConsultationRecordProponentView/index.tsx
@@ -24,6 +24,7 @@ import { consultationRecordSchema, ConsultationRecordForm } from "../constants";
 import { SubmissionFormContainer } from "../../SubmissionFormContainer";
 import { getSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
 import { SubmissionPackage } from "@/models/Package";
+import UpdateRequestWidget from "@/components/Submission/UpdateRequestWidget";
 
 export const ConsultationRecordProponentView = () => {
   const {
@@ -50,7 +51,7 @@ export const ConsultationRecordProponentView = () => {
   const submissionPackage = queryClient.getQueryData<SubmissionPackage>(
     getSubmissionPackageQueryOptions({
       packageId: Number(submissionPackageId),
-    }).queryKey,
+    }).queryKey
   );
 
   const partiesList = useMemo(() => {
@@ -70,7 +71,7 @@ export const ConsultationRecordProponentView = () => {
   }, [submissionPackage]);
 
   const formSubmission = submissionItem?.submissions?.find(
-    (submission) => submission.type === SUBMISSION_TYPE.FORM,
+    (submission) => submission.type === SUBMISSION_TYPE.FORM
   );
   const defaultFormValues = useMemo(() => {
     if (!formSubmission?.submitted_form?.submission_json) return {};
@@ -78,32 +79,32 @@ export const ConsultationRecordProponentView = () => {
     return {
       ...formSubmission.submitted_form.submission_json,
       allPartiesConsulted: booleanToString(
-        formSubmission.submitted_form.submission_json.allPartiesConsulted,
+        formSubmission.submitted_form.submission_json.allPartiesConsulted
       ),
       planWasReviewed: booleanToString(
-        formSubmission.submitted_form.submission_json.planWasReviewed,
+        formSubmission.submitted_form.submission_json.planWasReviewed
       ),
       writtenExplanationsProvidedToParties: booleanToString(
         formSubmission.submitted_form.submission_json
-          .writtenExplanationsProvidedToParties,
+          .writtenExplanationsProvidedToParties
       ),
       writtenExplanationsProvidedToCommenters: booleanToString(
         formSubmission.submitted_form.submission_json
-          .writtenExplanationsProvidedToCommenters,
+          .writtenExplanationsProvidedToCommenters
       ),
       notes: formSubmission.submitted_form.submission_json.notes,
     };
   }, [formSubmission]);
 
   const documentSubmissions = submissionItem?.submissions?.filter(
-    (submission) => submission.type === SUBMISSION_TYPE.DOCUMENT,
+    (submission) => submission.type === SUBMISSION_TYPE.DOCUMENT
   );
   const defaultDocumentValues = useMemo(() => {
     if (!documentSubmissions) return {};
 
     return {
       consultationRecords: documentSubmissions.map(
-        (submission) => submission.submitted_document.url,
+        (submission) => submission.submitted_document.url
       ),
     };
   }, [documentSubmissions]);
@@ -149,7 +150,7 @@ export const ConsultationRecordProponentView = () => {
 
   const saveSubmission = async (
     formData: ConsultationRecordForm,
-    status: SubmissionItemStatus,
+    status: SubmissionItemStatus
   ) => {
     const {
       consultedParties,
@@ -169,10 +170,10 @@ export const ConsultationRecordProponentView = () => {
           allPartiesConsulted: stringToBoolean(allPartiesConsulted),
           planWasReviewed: stringToBoolean(planWasReviewed),
           writtenExplanationsProvidedToParties: stringToBoolean(
-            writtenExplanationsProvidedToParties,
+            writtenExplanationsProvidedToParties
           ),
           writtenExplanationsProvidedToCommenters: stringToBoolean(
-            writtenExplanationsProvidedToCommenters,
+            writtenExplanationsProvidedToCommenters
           ),
           notes,
         },
@@ -214,6 +215,7 @@ export const ConsultationRecordProponentView = () => {
             <Grid item xs={12}>
               <DocumentUploadSection />
             </Grid>
+            <UpdateRequestWidget submissionPackage={submissionPackage} />
             <ActionButtons saveAndClose={saveAndClose} />
           </Grid>
         </Form>

--- a/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanStaffView/ReviewSection.tsx
+++ b/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanStaffView/ReviewSection.tsx
@@ -1,4 +1,10 @@
-import { Grid, Divider, Typography } from "@mui/material";
+import {
+  Grid,
+  Divider,
+  Typography,
+  Box,
+  AccordionSummary,
+} from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { useForm, FormProvider } from "react-hook-form";
 import { yupResolver } from "@hookform/resolvers/yup";
@@ -200,6 +206,50 @@ export default function ReviewSection() {
             </PermissionsGate>
             <NotesSection />
             <When condition={failedManagementPlan}>
+              <AccordionSummary
+                expandIcon={null}
+                aria-controls="panel1-content"
+                id="panel1-header"
+                sx={[
+                  {
+                    py: 0,
+                    borderRadius: "4px",
+                    border: `1px solid ${BCDesignTokens.supportBorderColorWarning}`,
+                    background: BCDesignTokens.themeGold10,
+                    borderBottomLeftRadius: 0,
+                    borderBottomRightRadius: 0,
+                  },
+                ]}
+              >
+                <Box
+                  sx={{
+                    display: "flex",
+                    alignItems: "space-between",
+                    justifyContent: "space-between",
+                    width: "100%",
+                  }}
+                >
+                  <Box
+                    sx={{
+                      display: "flex",
+                      alignItems: "center",
+                      justifyContent: "flex-start",
+                    }}
+                    width={"80%"}
+                  >
+                    <Typography
+                      variant="h6"
+                      sx={{
+                        color: "#38598A",
+                        mr: BCDesignTokens.layoutMarginSmall,
+                        fontWeight: BCDesignTokens.typographyBoldBody,
+                      }}
+                    >
+                      Update & Revision Requests
+                    </Typography>
+                  </Box>
+                </Box>
+              </AccordionSummary>
               <AddRequestSection disabled={isFormDisabled} />
             </When>
             <NotificationBox />

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -33,7 +33,7 @@ import PermissionsGate from "@/components/Shared/PermissionGate";
 import { ACCOUNT_USER_PERMISSIONS } from "@/models/Role";
 
 export const Route = createFileRoute(
-  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
+  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/"
 )({
   component: SubmissionPage,
 });
@@ -82,7 +82,7 @@ export default function SubmissionPage() {
           !isSubmissionItemReadyToSubmit({
             submissionItem: item,
             submissionPackage: submissionPackage,
-          }),
+          })
       )
     ) {
       setIsValidating(true);
@@ -106,14 +106,14 @@ export default function SubmissionPage() {
   const openRequests = submissionPackage.update_requests.filter(
     (updateRequest) =>
       updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
-      updateRequest.active,
+      updateRequest.active
   );
 
   const openOrPendingRequests = submissionPackage.update_requests.filter(
     (updateRequest) =>
       (updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value ||
         updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value) &&
-      updateRequest.active,
+      updateRequest.active
   );
   const isSubmitDisabled =
     isPackageSubmitted && openOrPendingRequests.length === 0;

--- a/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -124,13 +124,22 @@ export default function SubmissionPage() {
               <InfoBox submissionPackage={submissionPackage} />
               <Box
                 sx={{
+                  pt: BCDesignTokens.layoutMarginXlarge,
+                  mb: BCDesignTokens.layoutMarginLarge,
+                  width: "100%",
+                }}
+              >
+                <UpdateRequestWidget submissionPackage={submissionPackage} />
+              </Box>
+              <Box
+                sx={{
                   mb: BCDesignTokens.layoutMarginXlarge,
-                  pt: BCDesignTokens.layoutPaddingSmall,
+                  pt: BCDesignTokens.layoutPaddingXsmall,
                 }}
               >
                 <ItemsTable submissionPackage={submissionPackage} />
               </Box>
-              <UpdateRequestWidget submissionPackage={submissionPackage} />
+
               <Box
                 sx={{
                   pt: BCDesignTokens.layoutPaddingXlarge,


### PR DESCRIPTION
    Change the name of the widget to “Update & Revision Requests”

    Move the section from the bottom to the top of the document section.

    Add the header (yellow box) to the widget that shows up on the CR/MP (when decision is a “No”)

    Change “Request /Note for  “EAO Comment”

    Add a “Warning” orange box below the “EAO Comment”. the box is similar to the submission confirmation, the same orange as the status badge, black text, with a Warning icon first  (triangle with ! inside) and the following text: 

“This request, including the EAO Comment, will be sent to the holder after a Manager confirms the decision.”