### PR TITLE
Hide conditions without a required management plan

### DIFF
--- a/submit-web/src/hooks/useConditions.ts
+++ b/submit-web/src/hooks/useConditions.ts
@@ -33,8 +33,12 @@ export const getConditionsQueryOptions = ({
 }: UseGetConditionParams) =>
   queryOptions({
     queryKey: [QUERY_KEY.SUBMISSION_ITEM, projectId],
-    queryFn: () =>
-      getConditions({ projectId, includeAttributes: includeAttributes }),
+    queryFn: async () => {
+      const conditions = await getConditions({ projectId, includeAttributes: includeAttributes });
+      return conditions.filter(
+        (condition) => condition.condition_attributes?.requires_management_plan === "true"
+      );
+    },
     enabled: enabled && Boolean(projectId),
   });
 


### PR DESCRIPTION
- Added a new filter while pulling conditions from condition repo to include only the conditions that are having the required management plan as "true"