### PR TITLE
fix ensure replaced document is stored in original S3 bucket folder

### DIFF
--- a/submit-web/src/components/SubmissionItem/DocumentsTable/AddDocumentActionButton.tsx
+++ b/submit-web/src/components/SubmissionItem/DocumentsTable/AddDocumentActionButton.tsx
@@ -11,10 +11,12 @@ import { useParams } from "@tanstack/react-router";
 type AddDocumentActionButtonProps = {
   handleAddDocument: (submission: Submission) => void;
   folder: string;
+  folderPath: string;
 };
 export const AddDocumentActionButton = ({
   handleAddDocument,
   folder,
+  folderPath,
 }: AddDocumentActionButtonProps) => {
   const { submissionPackageId, submissionId: submissionItemId } = useParams({
     from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId",
@@ -33,6 +35,7 @@ export const AddDocumentActionButton = ({
         file: fileToUpload,
         fileDetails: {
           filename: fileToUpload.name,
+          folder: folderPath,
         },
       });
 

--- a/submit-web/src/components/SubmissionItem/DocumentsTable/Row.tsx
+++ b/submit-web/src/components/SubmissionItem/DocumentsTable/Row.tsx
@@ -11,9 +11,10 @@ import { FileUploadButton } from "@/components/Shared/FileUploadButton";
 
 type DocumentRowProps = Readonly<{
   documentSubmission: Submission;
+  folderPath: string;
 }>;
 
-export default function Row({ documentSubmission }: DocumentRowProps) {
+export default function Row({ documentSubmission, folderPath }: DocumentRowProps) {
   const { submissionPackageId } = useParams({
     from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId",
   });
@@ -66,6 +67,7 @@ export default function Row({ documentSubmission }: DocumentRowProps) {
         file: fileToUpload,
         fileDetails: {
           filename: fileToUpload.name,
+          folder: folderPath,
         },
       });
 

--- a/submit-web/src/components/SubmissionItem/DocumentsTable/index.tsx
+++ b/submit-web/src/components/SubmissionItem/DocumentsTable/index.tsx
@@ -32,6 +32,12 @@ export default function DocumentsTable({ folder }: DocumentsTableProps) {
     from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId",
   });
 
+  const queryClient = useQueryClient();
+  const accountProject = queryClient.getQueryData<AccountProject>(
+    getAccountProjectQueryOptions(Number(projectId)).queryKey
+  );
+  const projectName = camelCase(accountProject?.project.name ?? "");
+
   const [addedSubmissions, setAddedSubmissions] = useState<Submission[]>([]);
 
   const { data: submissionItem, isPending: isItemLoading } =
@@ -60,12 +66,6 @@ export default function DocumentsTable({ folder }: DocumentsTableProps) {
   if (!submissionItem) {
     return null;
   }
-
-  const queryClient = useQueryClient();
-  const accountProject = queryClient.getQueryData<AccountProject>(
-    getAccountProjectQueryOptions(Number(projectId)).queryKey
-  );
-  const projectName = camelCase(accountProject?.project.name ?? "");
 
   return (
     <SubmitTableContainer>

--- a/submit-web/src/components/SubmissionItem/DocumentsTable/index.tsx
+++ b/submit-web/src/components/SubmissionItem/DocumentsTable/index.tsx
@@ -18,12 +18,17 @@ import { Submission, SUBMISSION_TYPE } from "@/models/Submission";
 import { useGetSubmissionItem } from "@/hooks/api/useItems";
 import { useMemo, useState } from "react";
 import { AddDocumentActionButton } from "./AddDocumentActionButton";
+import { useQueryClient } from "@tanstack/react-query";
+import { getAccountProjectQueryOptions } from "@/hooks/api/useProjects";
+import { AccountProject } from "@/models/Project";
+import { S3_FOLDER } from "@/hooks/api/useObjectStorage";
+import { camelCase } from "lodash";
 
 type DocumentsTableProps = Readonly<{
   folder: string;
 }>;
 export default function DocumentsTable({ folder }: DocumentsTableProps) {
-  const { submissionId: submissionItemId } = useParams({
+  const { submissionId: submissionItemId, projectId } = useParams({
     from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId",
   });
 
@@ -55,6 +60,13 @@ export default function DocumentsTable({ folder }: DocumentsTableProps) {
   if (!submissionItem) {
     return null;
   }
+
+  const queryClient = useQueryClient();
+  const accountProject = queryClient.getQueryData<AccountProject>(
+    getAccountProjectQueryOptions(Number(projectId)).queryKey
+  );
+  const projectName = camelCase(accountProject?.project.name ?? "");
+
   return (
     <SubmitTableContainer>
       <MuiTable>
@@ -79,6 +91,7 @@ export default function DocumentsTable({ folder }: DocumentsTableProps) {
             <SubmitPrimaryRowTableCell align="right">
               <AddDocumentActionButton
                 folder={folder}
+                folderPath={`${S3_FOLDER.SUBMISSIONS}/${projectName}/${folder}/`}
                 handleAddDocument={handleAddSubmission}
               />
             </SubmitPrimaryRowTableCell>
@@ -87,6 +100,7 @@ export default function DocumentsTable({ folder }: DocumentsTableProps) {
             <Row
               key={documentSubmission.id}
               documentSubmission={documentSubmission}
+              folderPath={`${S3_FOLDER.SUBMISSIONS}/${projectName}/${folder}/`}
             />
           ))}
         </TableBody>

--- a/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanUpdateForm/index.tsx
+++ b/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanUpdateForm/index.tsx
@@ -13,7 +13,7 @@ export const ManagementPlanUpdateForm = () => {
   return (
     <SubmissionFormContainer>
       <Box width={"100%"}>
-        <DocumentsTable folder={S3_FOLDER.CONSULTATION_RECORDS} />
+        <DocumentsTable folder={S3_FOLDER.MANAGEMENT_PLANS} />
       </Box>
       <Button
         sx={{


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/SUBMIT-305

- Added folder path to both 'replace' and 'add' operations in update requests to ensure the document is saved in its original S3 folder.