### PR TITLE
Continue to form preview & document preview on start later

### DIFF
--- a/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
+++ b/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
@@ -19,6 +19,7 @@ type ConfirmationModalProps = {
   onConfirm: () => void;
   confirmText?: string;
   cancelText?: string;
+  onCancel?: () => void;
 };
 
 const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
@@ -27,8 +28,14 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   onConfirm,
   confirmText,
   cancelText,
+  onCancel,
 }) => {
   const { setClose, isLoading } = useModal();
+
+  const handleCancel = () => {
+    onCancel?.();
+    setClose();
+  };
 
   return (
     <Box sx={modalStyle}>
@@ -44,7 +51,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
       </DialogContent>
       <Divider />
       <DialogActions sx={{ padding: "1rem" }}>
-        <Button onClick={setClose} color="secondary" sx={{ border: 0 }}>
+        <Button onClick={handleCancel} color="secondary" sx={{ border: 0 }}>
           {cancelText ?? "Cancel"}
         </Button>
         <LoadingButton

--- a/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
+++ b/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
@@ -18,8 +18,11 @@ type ConfirmationModalProps = {
   description: string;
   onConfirm: () => void;
   confirmText?: string;
+  // Either show cancel or secondary action, but not both
   cancelText?: string;
   onCancel?: () => void;
+  secondaryActionText?: string;
+  onSecondaryAction?: () => void;
 };
 
 const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
@@ -29,6 +32,8 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   confirmText,
   cancelText,
   onCancel,
+  secondaryActionText,
+  onSecondaryAction,
 }) => {
   const { setClose, isLoading } = useModal();
 
@@ -36,6 +41,14 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
     onCancel?.();
     setClose();
   };
+
+  const handleSecondaryAction = () => {
+    onSecondaryAction?.();
+    setClose();
+  };
+
+  // Only show cancel button if secondary action is not provided
+  const showCancel = !secondaryActionText;
 
   return (
     <Box sx={modalStyle}>
@@ -51,9 +64,19 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
       </DialogContent>
       <Divider />
       <DialogActions sx={{ padding: "1rem" }}>
-        <Button onClick={handleCancel} color="secondary" sx={{ border: 0 }}>
-          {cancelText ?? "Cancel"}
-        </Button>
+        {showCancel ? (
+          <Button onClick={handleCancel} color="secondary" sx={{ border: 0 }}>
+            {cancelText ?? "Cancel"}
+          </Button>
+        ) : (
+          <Button
+            onClick={handleSecondaryAction}
+            color="secondary"
+            sx={{ border: 0 }}
+          >
+            {secondaryActionText}
+          </Button>
+        )}
         <LoadingButton
           loading={isLoading}
           variant="contained"

--- a/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
@@ -85,13 +85,13 @@ export default function SubmissionItemReviewConfirmation({
             },
           });
         }}
-        onCancel={() => {
+        onSecondaryAction={() => {
           onClick();
         }}
         title={title}
         description={description}
         confirmText={confirmText}
-        cancelText="Start Later"
+        secondaryActionText="Start Later"
       />
     );
   };

--- a/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
+++ b/submit-web/src/components/Submission/SubmissionItemReviewConfirmation.tsx
@@ -85,11 +85,14 @@ export default function SubmissionItemReviewConfirmation({
             },
           });
         }}
+        onCancel={() => {
+          onClick();
+        }}
         title={title}
         description={description}
         confirmText={confirmText}
         cancelText="Start Later"
-      />,
+      />
     );
   };
 


### PR DESCRIPTION
-If Eao selects start later it will allow the user preview the document or view the form without starting an official review