### PR TITLE
fix restrict upload to only one management plan

### DIFF
--- a/submit-web/src/components/FileUpload/Uploader.tsx
+++ b/submit-web/src/components/FileUpload/Uploader.tsx
@@ -10,6 +10,9 @@ interface UploaderProps {
   onDrop?: (acceptedFiles: File[]) => void;
   error?: boolean;
   maxSize?: number;
+  maxFiles?: number;
+  maxFilesErrorMessage?: string;
+  currentFileCount?: number;
 }
 const MAX_FILE_SIZE = 500 * 1024 * 1024;
 
@@ -22,8 +25,12 @@ const Uploader = ({
   error = false,
   children,
   maxSize = MAX_FILE_SIZE,
+  maxFiles,
+  maxFilesErrorMessage,
+  currentFileCount = 0
 }: UploaderProps) => {
   const [sizeError, setSizeError] = useState<string | null>(null);
+  const [fileCountError, setFileCountError] = useState<string | null>(null);
 
   return (
     <Dropzone
@@ -38,10 +45,23 @@ const Uploader = ({
           setSizeError(
             `This file exceeds the ${maxSize / (1024 * 1024)} MB limit.`
           );
-        } else {
-          setSizeError(null);
-          onDrop(acceptedFiles);
+          setFileCountError(null);
+          return;
         }
+
+        if (maxFiles && currentFileCount + acceptedFiles.length > maxFiles) {
+          setFileCountError(
+            maxFilesErrorMessage ||
+              `You can only upload up to ${maxFiles} file${maxFiles > 1 ? "s" : ""}.`
+          );
+          setSizeError(null);
+          return;
+        }
+  
+        // Clear errors and proceed
+        setSizeError(null);
+        setFileCountError(null);
+        onDrop(acceptedFiles);
       }}
       accept={accept}
     >
@@ -77,6 +97,14 @@ const Uploader = ({
               {sizeError}
             </FormHelperText>
           )}{" "}
+          {fileCountError && (
+            <FormHelperText
+              error
+              style={{ textAlign: "left", marginTop: "8px" }}
+            >
+              {fileCountError}
+            </FormHelperText>
+          )}
         </section>
       )}
     </Dropzone>

--- a/submit-web/src/components/FileUpload/Uploader.tsx
+++ b/submit-web/src/components/FileUpload/Uploader.tsx
@@ -32,6 +32,13 @@ const Uploader = ({
   const [sizeError, setSizeError] = useState<string | null>(null);
   const [fileCountError, setFileCountError] = useState<string | null>(null);
 
+  const clearErrors = () => {
+    if (sizeError || fileCountError) {
+      setSizeError(null);
+      setFileCountError(null);
+    }
+  };
+
   return (
     <Dropzone
       maxSize={maxSize}
@@ -59,8 +66,7 @@ const Uploader = ({
         }
   
         // Clear errors and proceed
-        setSizeError(null);
-        setFileCountError(null);
+        clearErrors();
         onDrop(acceptedFiles);
       }}
       accept={accept}

--- a/submit-web/src/components/FileUpload/index.tsx
+++ b/submit-web/src/components/FileUpload/index.tsx
@@ -9,6 +9,9 @@ export type FileUploadProps = {
   accept?: Accept;
   onDrop: (acceptedFiles: File[]) => void;
   error?: boolean;
+  maxFiles?: number;
+  maxFilesErrorMessage?: string;
+  currentFileCount?: number;
 };
 export const FileUpload = ({
   height = "10em",
@@ -22,9 +25,20 @@ export const FileUpload = ({
   },
   error = false,
   onDrop,
+  maxFiles,
+  maxFilesErrorMessage,
+  currentFileCount
 }: FileUploadProps) => {
   return (
-    <Uploader height={height} accept={accept} onDrop={onDrop} error={error}>
+    <Uploader
+      height={height}
+      accept={accept}
+      onDrop={onDrop}
+      error={error}
+      maxFiles={maxFiles}
+      maxFilesErrorMessage={maxFilesErrorMessage}
+      currentFileCount={currentFileCount}
+    >
       <Box sx={{ p: BCDesignTokens.layoutPaddingSmall }}>
         <UploaderIcon />
       </Box>

--- a/submit-web/src/components/Shared/controlled/ControlledFileUpload.tsx
+++ b/submit-web/src/components/Shared/controlled/ControlledFileUpload.tsx
@@ -5,9 +5,13 @@ import { Controller, useFormContext } from "react-hook-form";
 
 type ControlledFileUploadProps = FileUploadProps & {
   name: string;
+  maxFiles?: number;
+  maxFilesErrorMessage?: string;
 };
 export const ControlledFileUpload = ({
   name,
+  maxFiles,
+  maxFilesErrorMessage,
   onDrop,
   ...otherProps
 }: ControlledFileUploadProps) => {
@@ -20,6 +24,7 @@ export const ControlledFileUpload = ({
 
   const error = get(errors, name);
   const helperText = error?.message?.toString() ?? "";
+  const currentFiles = getValues(name) || [];
 
   return (
     <Controller
@@ -30,6 +35,10 @@ export const ControlledFileUpload = ({
           <FileUpload
             {...otherProps}
             onDrop={(acceptedFiles: File[]) => {
+              if (maxFiles && currentFiles.length + acceptedFiles.length > maxFiles) {
+                // Handle error: maxFiles limit exceeded
+                return;
+              }
               if (acceptedFiles.length === 0) return;
               // Get current values and add the new file
               const currentValues = getValues(name) || [];
@@ -39,6 +48,9 @@ export const ControlledFileUpload = ({
               onDrop(acceptedFiles);
             }}
             error={Boolean(error)}
+            maxFiles={maxFiles}
+            maxFilesErrorMessage={maxFilesErrorMessage}
+            currentFileCount={currentFiles.length}
           />
           {error && <FormHelperText error>{helperText}</FormHelperText>}
         </Stack>

--- a/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanProponentView/DocumentUploadSection.tsx
+++ b/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanProponentView/DocumentUploadSection.tsx
@@ -53,17 +53,6 @@ export const DocumentUploadSection = () => {
   }, [submissionItem, getDocumentSubmissions, initializeFiles]);
 
   const handleOnDrop = (acceptedFiles: File[], folder: string) => {
-    const isManagementPlanFolder =
-      folder === MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN;
-
-    if (
-      isManagementPlanFolder &&
-      (managementPlanDocuments.length > 0 || pendingManagementPlanDocuments.length > 0)
-    ) {
-      notify.error("You can only submit one Management Plan/IEM Terms of Engagement per submission. Please add supporting documents in the section below.");
-      return;
-    }
-
     addPendingFile(acceptedFiles[0], folder);
   };
 
@@ -138,6 +127,10 @@ export const DocumentUploadSection = () => {
               acceptedFiles,
               MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN,
             )
+          }
+          maxFiles={1}
+          maxFilesErrorMessage={
+            "You can only submit one Management Plan/IEM Terms of Engagement per submission. Please add supporting documents in the section below."
           }
         />
         <Typography

--- a/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanProponentView/DocumentUploadSection.tsx
+++ b/submit-web/src/components/SubmissionItem/ManagementPlanSubmission/ManagementPlanProponentView/DocumentUploadSection.tsx
@@ -53,6 +53,17 @@ export const DocumentUploadSection = () => {
   }, [submissionItem, getDocumentSubmissions, initializeFiles]);
 
   const handleOnDrop = (acceptedFiles: File[], folder: string) => {
+    const isManagementPlanFolder =
+      folder === MANAGEMENT_PLAN_DOCUMENT_FOLDERS.MANAGEMENT_PLAN;
+
+    if (
+      isManagementPlanFolder &&
+      (managementPlanDocuments.length > 0 || pendingManagementPlanDocuments.length > 0)
+    ) {
+      notify.error("You can only submit one Management Plan/IEM Terms of Engagement per submission. Please add supporting documents in the section below.");
+      return;
+    }
+
     addPendingFile(acceptedFiles[0], folder);
   };
 


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/SUBMIT-528

- Implemented a check to prevent uploading multiple management plans. If a management plan is already uploaded, further uploads are blocked, and an error notification is displayed.