### PR TITLE
Setup Loaders For Plan Details

### DIFF
--- a/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
+++ b/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
@@ -29,34 +29,29 @@ export const PlanDetails = ({ onSubmit }: PlanDetailsProps) => {
         formData?.main_condition?.condition_number
     );
 
+  if (isLoading) {
+    return (
+      <TabBox title="Create New Submission">
+        <Grid container spacing={3}>
+          <Grid item xs={12}>
+            <CircularProgress size={40} />
+          </Grid>
+        </Grid>
+      </TabBox>
+    );
+  }
+
   return (
     <TabBox title="Create New Submission">
-      <If condition={isLoading}>
-        <Then>
-          <Grid
-            container
-            sx={{
-              padding: "16px 0px",
-            }}
-            spacing={3}
-          >
-            <Grid item xs={12}>
-              <CircularProgress size={40} />
-            </Grid>
-          </Grid>
-        </Then>
-        <Else>
-          <When condition={Boolean(existingPlan) && !newlyCreatedPlan}>
-            <ExistingPlanDetails existingPlan={existingPlan} />
-          </When>
-          <When condition={!existingPlan}>
-            <NewPlanDetails
-              onSubmit={onSubmit}
-              setNewlyCreatedPlan={setNewlyCreatedPlan}
-            />
-          </When>
-        </Else>
-      </If>
+      <When condition={Boolean(existingPlan) && !newlyCreatedPlan}>
+        <ExistingPlanDetails existingPlan={existingPlan} />
+      </When>
+      <When condition={!existingPlan}>
+        <NewPlanDetails
+          onSubmit={onSubmit}
+          setNewlyCreatedPlan={setNewlyCreatedPlan}
+        />
+      </When>
     </TabBox>
   );
 };

--- a/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
+++ b/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
@@ -5,7 +5,7 @@ import { useManagementPlanForm } from "./formStore";
 import { useAccount } from "@/store/accountStore";
 import { useGetAccountProjectsByAccount } from "@/hooks/api/useProjects";
 import { ExistingPlanDetails } from "./ExistingPlanDetails";
-import { Else, If, Then, When } from "react-if";
+import { When } from "react-if";
 import { useState } from "react";
 import { CircularProgress, Grid } from "@mui/material";
 

--- a/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
+++ b/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
@@ -5,8 +5,9 @@ import { useManagementPlanForm } from "./formStore";
 import { useAccount } from "@/store/accountStore";
 import { useGetAccountProjectsByAccount } from "@/hooks/api/useProjects";
 import { ExistingPlanDetails } from "./ExistingPlanDetails";
-import { When } from "react-if";
+import { Else, If, Then, When } from "react-if";
 import { useState } from "react";
+import { CircularProgress, Grid } from "@mui/material";
 
 type PlanDetailsProps = {
   onSubmit: (formData: NewManagementPlanForm) => void;
@@ -15,7 +16,7 @@ type PlanDetailsProps = {
 export const PlanDetails = ({ onSubmit }: PlanDetailsProps) => {
   const { formData } = useManagementPlanForm();
   const { accountId } = useAccount();
-  const { data: accountProjects } = useGetAccountProjectsByAccount({
+  const { data: accountProjects, isLoading } = useGetAccountProjectsByAccount({
     accountId,
   });
   const [newlyCreatedPlan, setNewlyCreatedPlan] = useState(false);
@@ -30,15 +31,32 @@ export const PlanDetails = ({ onSubmit }: PlanDetailsProps) => {
 
   return (
     <TabBox title="Create New Submission">
-      <When condition={Boolean(existingPlan) && !newlyCreatedPlan}>
-        <ExistingPlanDetails existingPlan={existingPlan} />
-      </When>
-      <When condition={!existingPlan}>
-        <NewPlanDetails
-          onSubmit={onSubmit}
-          setNewlyCreatedPlan={setNewlyCreatedPlan}
-        />
-      </When>
+      <If condition={!isLoading}>
+        <Then>
+          <Grid
+            container
+            sx={{
+              padding: "16px 0px",
+            }}
+            spacing={3}
+          >
+            <Grid item xs={12}>
+              <CircularProgress size={40} />
+            </Grid>
+          </Grid>
+        </Then>
+        <Else>
+          <When condition={Boolean(existingPlan) && !newlyCreatedPlan}>
+            <ExistingPlanDetails existingPlan={existingPlan} />
+          </When>
+          <When condition={!existingPlan}>
+            <NewPlanDetails
+              onSubmit={onSubmit}
+              setNewlyCreatedPlan={setNewlyCreatedPlan}
+            />
+          </When>
+        </Else>
+      </If>
     </TabBox>
   );
 };

--- a/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
+++ b/submit-web/src/components/NewManagementPlan/PlanDetails.tsx
@@ -31,7 +31,7 @@ export const PlanDetails = ({ onSubmit }: PlanDetailsProps) => {
 
   return (
     <TabBox title="Create New Submission">
-      <If condition={!isLoading}>
+      <If condition={isLoading}>
         <Then>
           <Grid
             container


### PR DESCRIPTION
-When loading the account projects we should display a loader to prevent having the user create a new plan by accident