### PR TITLE
SUBMIT-489 - Show the entire submission of history of all package versions in the history table

### DIFF
--- a/submit-api/migrations/versions/5ca405e40d35_migrate_activity_logs_to_original_package_id.py
+++ b/submit-api/migrations/versions/5ca405e40d35_migrate_activity_logs_to_original_package_id.py
@@ -1,0 +1,45 @@
+""" join submission history of different versions of packages
+
+Revision ID: 5ca405e40d35
+Revises: 826fa830606a
+Create Date: 2025-05-13 10:37:03.793361
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision = '5ca405e40d35'
+down_revision = '826fa830606a'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    # Get the database connection
+    bind = op.get_bind()
+    metadata = sa.MetaData()
+    metadata.reflect(bind=bind)
+
+    # Retrieve the tables
+    activity_logs = sa.Table('activity_logs', metadata, autoload_with=bind)
+    packages = sa.Table('packages', metadata, autoload_with=bind)
+    package_versions = sa.Table('package_versions', metadata, autoload_with=bind)
+
+    # Perform the update using correct SQLAlchemy expressions
+    stmt = (
+        activity_logs.update()
+        .where(sa.and_(
+            activity_logs.c.entity_id == packages.c.id,
+            activity_logs.c.entity_type == sa.literal('PACKAGE'),
+            packages.c.version_id == package_versions.c.id
+        ))
+        .values(entity_id=package_versions.c.original_package_id)
+    )
+
+    bind.execute(stmt)
+
+
+def downgrade():
+    pass
+

--- a/submit-api/src/submit_api/services/consultation_record_service.py
+++ b/submit-api/src/submit_api/services/consultation_record_service.py
@@ -42,7 +42,7 @@ class ConsultationRecordService:
         session.add(package_metadata)
         package = Package.find_by_id(item.package_id)
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=ActivityActionType.PASSED_CONSULTATION_CHECK.value,
             entity_version=package.version.version,
             actor_id=TokenInfo.get_id(),
@@ -66,7 +66,7 @@ class ConsultationRecordService:
         cls._create_update_request(update_request_data, session)
         package = Package.find_by_id(item.package_id)
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=ActivityActionType.FAILED_CONSULTATION_CHECK.value,
             entity_version=package.version.version,
             actor_id=TokenInfo.get_id(),

--- a/submit-api/src/submit_api/services/iem_service.py
+++ b/submit-api/src/submit_api/services/iem_service.py
@@ -40,7 +40,7 @@ class IEMTermsOfEngagementService:
             f"Logging activity for iem rejection for package {item.package_id}.")
         package = PackageModel.find_by_id(item.package_id)
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=ActivityActionType.IEM_REVIEW_FAILED.value,
             entity_version=package.version.version,
             session=session
@@ -77,7 +77,7 @@ class IEMTermsOfEngagementService:
             raise ResourceNotFoundError(
                 f"Unsupported purpose {submitted_to_eao_for} for package {package.id}.")
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=action_type,
             entity_version=package.version.version,
             session=session

--- a/submit-api/src/submit_api/services/management_plan_service.py
+++ b/submit-api/src/submit_api/services/management_plan_service.py
@@ -68,7 +68,7 @@ class ManagementPlanService:
             f"Logging activity for management plan rejection for package {item.package_id}.")
         package = PackageModel.find_by_id(item.package_id)
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=ActivityActionType.MP_REVIEW_FAILED.value,
             entity_version=package.version.version,
             session=session
@@ -279,7 +279,7 @@ class ManagementPlanService:
             raise ResourceNotFoundError(
                 f"Unsupported purpose {submitted_to_eao_for} for package {package.id}.")
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=action_type,
             entity_version=package.version.version,
             session=session

--- a/submit-api/src/submit_api/services/package.py
+++ b/submit-api/src/submit_api/services/package.py
@@ -384,7 +384,7 @@ class PackageService:
     def _log_activity_submission(package, action, session):
         """Log activity for package submission."""
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=action,
             actor_type=ActorTypeEnum.ENTITY.value,
             entity_version=package.version.version,
@@ -457,7 +457,7 @@ class PackageService:
         if not action:
             raise BadRequestError("Unsupported package type for review")
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=action,
             entity_version=package.version.version,
             session=session
@@ -488,7 +488,7 @@ class PackageService:
     def _log_activity_start_consultation_check(package, session):
         """Log activity for starting consultation check."""
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=ActivityActionType.START_CONSULTATION_CHECK.value,
             entity_version=package.version.version,
             session=session
@@ -576,7 +576,7 @@ class PackageService:
     def _log_activity_update_request(package):
         """Log activity for update request creation."""
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=ActivityActionType.UPDATE_REQUESTED.value,
             entity_version=package.version.version,
         )

--- a/submit-api/src/submit_api/services/submission_review.py
+++ b/submit-api/src/submit_api/services/submission_review.py
@@ -228,7 +228,7 @@ class SubmissionReviewService:
         """Log activity for approving or rejecting the Management Plan review."""
         package = PackageModel.find_by_id(item.package_id)
         ActivityLogService.log_activity(
-            entity_id=package.id,
+            entity_id=package.version.original_package_id,
             action=action,
             entity_version=package.version.version,
             session=session

--- a/submit-web/src/components/NewManagementPlan/ExistingPlanDetails.tsx
+++ b/submit-web/src/components/NewManagementPlan/ExistingPlanDetails.tsx
@@ -80,7 +80,7 @@ export const ExistingPlanDetails = ({
           fontWeight={theme.typography.fontWeightBold}
         >
           Condition{" "}
-          {`${mainCondition.condition_number} - ${mainCondition.condition_name}`}
+          {`${mainCondition?.condition_number} - ${mainCondition?.condition_name}`}
         </Typography>
       </Grid>
       <When

--- a/submit-web/src/components/NewManagementPlan/NewPlanDetails.tsx
+++ b/submit-web/src/components/NewManagementPlan/NewPlanDetails.tsx
@@ -57,7 +57,7 @@ export const NewPlanDetails = ({
     setStep(Math.min(step - 1, 0));
   };
   const managementPlanName =
-    get(formData, "main_condition.condition_attributes.deliverable_name[0]") ??
+    formData?.main_condition?.condition_attributes?.deliverable_name?.[0] ??
     get(formData, "main_condition.condition_name");
 
   const submissionPackageType = useMemo(() => {

--- a/submit-web/src/components/Submission/InfoBox/AdminInfoBox.tsx
+++ b/submit-web/src/components/Submission/InfoBox/AdminInfoBox.tsx
@@ -69,7 +69,9 @@ export const AdminInfoBox = ({ submissionPackage }: InfoBoxProps) => {
       </Grid>
 
       <Grid item xs={12} container mt={"16px"}>
-        <SubmissionHistory submissionPackageId={String(submissionPackage.id)} />
+        <SubmissionHistory
+          submissionPackageId={String(version.original_package_id)}
+        />
       </Grid>
     </Grid>
   );

--- a/submit-web/src/components/Submission/InfoBox/EntityInfoBox.tsx
+++ b/submit-web/src/components/Submission/InfoBox/EntityInfoBox.tsx
@@ -67,7 +67,9 @@ export const EntityInfoBox = ({ submissionPackage }: InfoBoxProps) => {
         <VersionGroup currentPackageVersion={version} />
       </Grid>
       <Grid item xs={12} container mt={"16px"}>
-        <SubmissionHistory submissionPackageId={String(submissionPackage.id)} />
+        <SubmissionHistory
+          submissionPackageId={String(version.original_package_id)}
+        />
       </Grid>
     </Grid>
   );

--- a/submit-web/src/hooks/api/useActivtyLog.ts
+++ b/submit-web/src/hooks/api/useActivtyLog.ts
@@ -89,7 +89,7 @@ export const useGetActivityLog = ({
   id,
   entityType,
   isAdmin = false,
-  enabled = true,
+  enabled = undefined,
 }: UseGetActivityLogForAdminByIdParams & { isAdmin?: boolean }) => {
   // Always call both hooks
   const adminResult = useGetActivityLogForAdmin({

--- a/submit-web/src/routes/proponent/_proponentLayout.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout.tsx
@@ -7,6 +7,7 @@ import { useAccount } from "@/store/accountStore";
 import { LOGIN_REDIRECT } from "@/utils/constants";
 import { Box } from "@mui/material";
 import { createFileRoute, Outlet, redirect } from "@tanstack/react-router";
+
 export const Route = createFileRoute("/proponent/_proponentLayout")({
   component: ProponentLayout,
   beforeLoad: ({ context: { authentication, account } }) => {


### PR DESCRIPTION
- Save activity logs with the original_package_id instead of current_package.id
- create a migration to update all entity_ids of package logs to be the original_package_id