### PR TITLE
SUBMIT-540 Remove unused filters

### DIFF
--- a/submit-web/src/models/Submission.ts
+++ b/submit-web/src/models/Submission.ts
@@ -131,14 +131,6 @@ export const EAO_SUBMISSION_ITEM_FILTERS: Partial<
     value: "UPDATED",
     label: "Updated",
   },
-  PARTIALLY_COMPLETED: {
-    value: "PARTIALLY_COMPLETED",
-    label: "Partially Completed",
-  },
-  SUBMITTED: {
-    value: "SUBMITTED",
-    label: "Submitted",
-  },
   UPDATE_REQUESTED: {
     value: "UPDATE_REQUESTED",
     label: "Update Requested",
@@ -158,10 +150,6 @@ export const EAO_SUBMISSION_ITEM_FILTERS: Partial<
   PASSED_CONSULTATION_CHECK: {
     value: "PASSED_CONSULTATION_CHECK",
     label: "Passed Consultation Check",
-  },
-  COMPLETED: {
-    value: "COMPLETED",
-    label: "Completed",
   },
   REVIEWED: {
     value: "REVIEWED",
@@ -227,10 +215,6 @@ export const PROPONENT_SUBMISSION_ITEM_FILTERS: Partial<
   APPROVED: {
     value: "APPROVED",
     label: "Approved",
-  },
-  NO_REVISION_REQUIRED: {
-    value: "NO_REVISION_REQUIRED",
-    label: "No Revision Required",
   },
   SATISFIED: {
     value: "SATISFIED",


### PR DESCRIPTION
    1. The “Completed”, Partially completed” and “Submitted” shouldn’t be there, they are not EAO status (entity only)

    2. Remove “No Revision Required” (It is the same as Satisfied & is displayed on the Entity side)