### PR TITLE
SUBMIT-505 Enable multiple file uploads in the internal staff document uploader

### DIFF
--- a/submit-web/src/components/Submission/DocumentRow/FileOrganizeModal/index.tsx
+++ b/submit-web/src/components/Submission/DocumentRow/FileOrganizeModal/index.tsx
@@ -71,7 +71,7 @@ const FileOrganizeModal = ({
   const isLoading = isSubmissionsLoading;
 
   return (
-    <Box sx={modalStyle}>
+    <Box sx={{ ...modalStyle, width: "450px" }}>
       <Box sx={{ display: "flex", justifyContent: "space-between" }}>
         <DialogTitle>Move "{submission.submitted_document.name}"</DialogTitle>
         <IconButton onClick={setClose}>

--- a/submit-web/src/components/SubmissionItem/InternalDocumentSection.tsx
+++ b/submit-web/src/components/SubmissionItem/InternalDocumentSection.tsx
@@ -15,8 +15,7 @@ export default function InternalDocumentSection() {
     from: "/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/submissions/$submissionId",
   });
 
-  const { reset, addPendingFile, pendingFiles, initializeFiles } =
-    useFileStore();
+  const { reset, addPendingFile, initializeFiles } = useFileStore();
 
   const queryClient = useQueryClient();
   const submissionItem = queryClient.getQueryData(
@@ -38,10 +37,9 @@ export default function InternalDocumentSection() {
   }, [internalStaffDocuments, initializeFiles]);
 
   const handleFileDrop = (acceptedFiles: File[]) => {
-    if (pendingFiles.length > 0) {
-      return;
-    }
-    addPendingFile(acceptedFiles[0]);
+    acceptedFiles.forEach((file) => {
+      addPendingFile(file);
+    });
   };
 
   return (
@@ -63,7 +61,7 @@ export default function InternalDocumentSection() {
         <Typography variant="body1">Upload Documents</Typography>
       </Grid>
       <Grid item xs={12}>
-        <FileUpload height="13.125rem" onDrop={handleFileDrop} />
+        <FileUpload height="13.125rem" onDrop={handleFileDrop} maxFiles={10} />
         <Typography
           variant="body2"
           sx={{

--- a/submit-web/src/components/SubmissionItem/InternalDocuments/Rows.tsx
+++ b/submit-web/src/components/SubmissionItem/InternalDocuments/Rows.tsx
@@ -54,6 +54,7 @@ export default function Rows({
         <PendingRow
           key={`pending-doc-row-${pendingDocument.id}`}
           pendingDocument={pendingDocument}
+          numColumns={5}
         />
       ))}
       <EmptyRow colSpan={5} />


### PR DESCRIPTION
- allow multiple file drop
- unrelated, but set a specific width for the file move modal