### PR TITLE
SUBMIT-359 Update Delete submission warning modal text

### DIFF
--- a/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
+++ b/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
@@ -15,7 +15,7 @@ import CloseIcon from "@mui/icons-material/Close";
 
 type ConfirmationModalProps = {
   title: string;
-  description: string;
+  description: string | React.ReactNode;
   onConfirm: () => void;
   confirmText?: string;
   // Either show cancel or secondary action, but not both
@@ -65,9 +65,13 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
       </Box>
       <Divider />
       <DialogContent>
-        <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
-          {description}
-        </Typography>
+        {typeof description === "string" ? (
+          <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+            {description}
+          </Typography>
+        ) : (
+          description
+        )}
       </DialogContent>
       <Divider />
       <DialogActions sx={{ padding: "1rem" }}>

--- a/submit-web/src/components/Submission/DocumentRow/ActionButton.tsx
+++ b/submit-web/src/components/Submission/DocumentRow/ActionButton.tsx
@@ -1,4 +1,4 @@
-import { IconButton, Menu, MenuItem } from "@mui/material";
+import { Box, IconButton, Menu, MenuItem, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import MoreVertIcon from "@mui/icons-material/MoreVert";
 import { Submission } from "@/models/Submission";
@@ -84,7 +84,26 @@ export const ActionButton = ({ submission }: ActionButtonProps) => {
           setClose();
         }}
         title={"Document Deletion Warning"}
-        description={"Warning: This action cannot be undone."}
+        description={
+          <Box
+            sx={{
+              display: "flex",
+              flexDirection: "column",
+              gap: 2,
+            }}
+          >
+            <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+              Warning: This action cannot be undone.
+            </Typography>
+            <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+              You are about to delete this document permanently. Once deleted,
+              it cannot be recovered.
+            </Typography>
+            <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+              Are you sure you want to proceed?
+            </Typography>
+          </Box>
+        }
         confirmText={"Delete Document"}
         secondaryActionText="Cancel"
       />,


### PR DESCRIPTION
Header: Document Deletion Warning 

Content:  Warning: This action cannot be undone.

You are about to delete this document permanently. Once deleted, it cannot be recovered. 

Are you sure you want to proceed? 

Buttons:  Cancel (tertiary)  Delete Document (primary)