### PR TITLE
SUBMIT-565 fix invalidate activity logs when submitting a package

### DIFF
--- a/submit-web/src/hooks/api/useItems.ts
+++ b/submit-web/src/hooks/api/useItems.ts
@@ -8,7 +8,6 @@ import {
 } from "@tanstack/react-query";
 import { QUERY_KEY } from "./constants";
 import { SubmissionReview } from "@/models/SubmissionReview";
-import { ACTIVITY_LOG_ENTITY_TYPE } from "@/models/ActivityLog";
 
 type GetSubmissionItemByIdParams = {
   itemId: number;

--- a/submit-web/src/hooks/api/useItems.ts
+++ b/submit-web/src/hooks/api/useItems.ts
@@ -82,7 +82,7 @@ type SaveReviewRequestBody = {
 };
 export const saveSubmissionReview = (
   itemId: number,
-  data: SaveReviewRequestBody
+  data: SaveReviewRequestBody,
 ) => {
   return submitRequest<SubmissionReview>({
     url: `/staff/items/${itemId}/review`,
@@ -122,11 +122,7 @@ export const useSaveSubmissionReview = ({
         queryKey: [QUERY_KEY.ACCOUNT_PROJECTS],
       });
       queryClient.invalidateQueries({
-        queryKey: [
-          QUERY_KEY.ACTIVITY_LOGS,
-          ACTIVITY_LOG_ENTITY_TYPE.PACKAGE,
-          packageId,
-        ],
+        queryKey: [QUERY_KEY.ACTIVITY_LOGS],
       });
     },
   });

--- a/submit-web/src/hooks/api/usePackages.ts
+++ b/submit-web/src/hooks/api/usePackages.ts
@@ -8,7 +8,6 @@ import {
 import { Options } from "./types";
 import { PackageVersion, SubmissionPackage } from "@/models/Package";
 import { defaultUseQueryOptions, QUERY_KEY } from "./constants";
-import { ACTIVITY_LOG_ENTITY_TYPE } from "@/models/ActivityLog";
 
 const createSubmissionPackage = ({
   accountProjectId,

--- a/submit-web/src/hooks/api/usePackages.ts
+++ b/submit-web/src/hooks/api/usePackages.ts
@@ -49,7 +49,7 @@ export const useCreateSubmissionPackage = (options?: Options) => {
       }
       queryClient.setQueryData(
         [QUERY_KEY.SUBMISSION_PACKAGE, submissionPackage.id],
-        submissionPackage
+        submissionPackage,
       );
       queryClient.invalidateQueries({
         queryKey: [
@@ -76,7 +76,7 @@ export const useCreateNewPackageVersion = (options?: Options) => {
       }
       queryClient.setQueryData(
         [QUERY_KEY.SUBMISSION_PACKAGE, submissionPackage.id],
-        submissionPackage
+        submissionPackage,
       );
       queryClient.invalidateQueries({
         queryKey: [
@@ -228,12 +228,8 @@ export const useUpdateStateSubmissionPackage = (options?: Options) => {
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.ACCOUNT_PROJECTS],
       });
-      queryClient.invalidateQueries({
-        queryKey: [
-          QUERY_KEY.ACTIVITY_LOGS,
-          ACTIVITY_LOG_ENTITY_TYPE.PACKAGE,
-          submissionPackage.id,
-        ],
+      queryClient.refetchQueries({
+        queryKey: [QUERY_KEY.ACTIVITY_LOGS],
       });
       if (options?.onSuccess) {
         options.onSuccess();
@@ -290,7 +286,7 @@ export const useCreatePackageUpdateRequest = ({
 
       queryClient.setQueryData(
         [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
-        submissionPackage
+        submissionPackage,
       );
       queryClient.invalidateQueries({
         queryKey: [QUERY_KEY.ACCOUNT_PROJECT, accountProjectId],
@@ -337,7 +333,7 @@ export const useAcceptUpdateRequest = ({
 
       queryClient.setQueryData(
         [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
-        submissionPackage
+        submissionPackage,
       );
     },
   });
@@ -362,7 +358,7 @@ export const useCreatePackageUpdateRequesNote = ({
 
       queryClient.setQueryData(
         [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
-        submissionPackage
+        submissionPackage,
       );
     },
   });

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -42,7 +42,7 @@ import { AppConfig } from "@/utils/config";
 import WarningBox from "@/components/Shared/WarningBox";
 
 export const Route = createFileRoute(
-  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/"
+  "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
 )({
   component: SubmissionPage,
 });
@@ -71,19 +71,19 @@ export default function SubmissionPage() {
   const isLatestApprovedPackageVersion = packageVersions?.find(
     (packageVersion) =>
       packageVersion.is_approved &&
-      packageVersion.package_id === submissionPackageId
+      packageVersion.package_id === submissionPackageId,
   );
 
   const latestApprovedVersion = Math.max(
     ...(packageVersions
       ?.filter((pv) => pv.is_approved)
-      .map((pv) => pv.version) || [0])
+      .map((pv) => pv.version) || [0]),
   );
 
   const isNewerThanLastApprovedButNotApproved = Boolean(
     latestApprovedVersion > 0 &&
       !submissionPackage?.version?.is_approved &&
-      submissionPackage?.version?.version > latestApprovedVersion
+      (submissionPackage?.version?.version ?? 0) > latestApprovedVersion,
   );
 
   const {
@@ -114,13 +114,14 @@ export default function SubmissionPage() {
           !isSubmissionItemReadyToSubmit({
             submissionItem: item,
             submissionPackage: submissionPackage,
-          })
+          }),
       )
     ) {
       setIsValidating(true);
       return;
     }
 
+    setIsValidating(false);
     updateStateSubmissionPackage({
       packageId: submissionPackage.id,
       data: {
@@ -137,26 +138,26 @@ export default function SubmissionPage() {
   const isPackageSubmitted = Boolean(submissionPackage.submitted_on);
 
   const isFirstSubmission = submissionPackage.status.includes(
-    PACKAGE_STATUS.SUBMITTED.value
+    PACKAGE_STATUS.SUBMITTED.value,
   );
 
   const isRevisionRequired = submissionPackage.update_requests.some(
     (updateRequest) =>
       updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
       updateRequest.active &&
-      updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value
+      updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value,
   );
 
   const pendingRequests = submissionPackage.update_requests.filter(
     (updateRequest) =>
       updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
-      updateRequest.active
+      updateRequest.active,
   );
 
   const openRequests = submissionPackage.update_requests.filter(
     (updateRequest) =>
       updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
-      updateRequest.active
+      updateRequest.active,
   );
 
   const isSubmitDisabled =


### PR DESCRIPTION
The invalidating query was using the current package id while it should have been using the original_package_id

- invalidate activity log all together