### PR TITLE
SUBMIT-507 & SUBMI-481 Minor ux assurance

### DIFF
--- a/submit-web/src/components/Submission/VersionGroup.tsx
+++ b/submit-web/src/components/Submission/VersionGroup.tsx
@@ -84,7 +84,9 @@ export default function VersionGroup({
     setOpenModal(
       <ConfirmationModal
         title="New Submission Package"
-        description="This option will create another package so the Holder can resubmit documents. If a review is in progress, it will be cancelled, and the review will have to start over again when the holder submits a new package. Do you want to cancel the current review and create a new package?"
+        description={
+          "This option will create another package so the holder can resubmit documents. If a review is in progress, it will be cancelled, and the review will have to start over again when the holder submits a new package.\nDo you want to cancel the current review and create a new package?"
+        }
         confirmText="Create New Package"
         onConfirm={() => {
           createNewPackageVersion({

--- a/submit-web/src/components/SubmissionItem/InternalDocumentSection.tsx
+++ b/submit-web/src/components/SubmissionItem/InternalDocumentSection.tsx
@@ -55,7 +55,7 @@ export default function InternalDocumentSection() {
           }}
         >
           These documents will be accessible during your review and will be
-          saved with the submission Package.
+          saved with the submission package.
         </Typography>
       </Grid>
       <Grid item xs={12} mt={BCDesignTokens.layoutMarginXlarge}>


### PR DESCRIPTION
    Capitalize the H in ‘Holder’

    Have a line break after the first paragraph so that “Do you want to cancel the current review and create a new package?” appears on its own line

Small edit: Un-capitalize the word ‘Package’ below the “EAO Internal Documents” header
