### PR TITLE
SUBMIT-580 Excludes PENDING submissions from queries

### DIFF
--- a/submit-api/src/submit_api/models/queries/submitted_document.py
+++ b/submit-api/src/submit_api/models/queries/submitted_document.py
@@ -104,6 +104,6 @@ class DocumentQueries:
                          Submission.type == SubmissionType.DOCUMENT,
                          Submission.active.is_(True),
                          Submission.deleted.is_(False),
-                         Submission.status == SubmissionStatus.SUBMITTED))
+                         Submission.status != SubmissionStatus.PENDING))
 
         return query.all()


### PR DESCRIPTION
Ensures that queries for submitted documents do not include submissions that are in the PENDING state.
This prevents incomplete or unconfirmed submissions from being included in document lists.