### PR TITLE
SUBMIT-580 Filters rejected documents for active records

### DIFF
--- a/submit-api/src/submit_api/models/queries/submitted_document.py
+++ b/submit-api/src/submit_api/models/queries/submitted_document.py
@@ -87,7 +87,9 @@ class DocumentQueries:
         query = session.query(Submission).filter_by(
             item_id=item_id,
             type=SubmissionType.DOCUMENT,
-            status=SubmissionStatus.REJECTED
+            status=SubmissionStatus.REJECTED,
+            active=True,
+            deleted=False
         )
 
         return query.all()

--- a/submit-web/src/components/SubmissionStatusChip/index.tsx
+++ b/submit-web/src/components/SubmissionStatusChip/index.tsx
@@ -208,16 +208,6 @@ const statusStyles: Record<string, StyleProps> = {
       width: "85px",
     },
   },
-  REVIEWED: {
-    label: "Reviewed",
-    sx: {
-      borderRadius: 1,
-      border: `1px solid ${BCDesignTokens.supportBorderColorSuccess}`,
-      background: BCDesignTokens.supportSurfaceColorSuccess,
-      height: "24px",
-      width: "85px",
-    },
-  },
   NO_REVISION_REQUIRED: {
     label: "No Revision Required",
     sx: {


### PR DESCRIPTION
Ensures that the query for rejected documents only returns active, non-deleted records. This prevents displaying stale or irrelevant data.
- Refines the query to include active and deleted status.
- Removes unused 'Reviewed' status style.