### PR TITLE
SUBMIT-583 Adds Cypress tests for package status and navigation

### DIFF
--- a/submit-web/cypress/components/_routes/SubmissionPackagePage.cy.tsx
+++ b/submit-web/cypress/components/_routes/SubmissionPackagePage.cy.tsx
@@ -329,6 +329,13 @@ describe("package table page", () => {
       ],
       mockActivityLogs,
     );
+    queryClient.setQueryData(
+      [
+        QUERY_KEY.PACKAGE_VERSIONS,
+        newerUnapprovedPackage.version.original_package_id,
+      ],
+      packageVersions,
+    );
 
     const router = createRouter({
       routeTree: routeTree,
@@ -357,7 +364,6 @@ describe("package table page", () => {
         </AuthProvider>
       </QueryClientProvider>,
     );
-    // cy.wait(["@getNewerUnapprovedPackage", "@getMixedPackageVersions"]);
 
     cy.contains(
       "Please Note: This submission is still pending EAO review.",
@@ -423,6 +429,13 @@ describe("package table page", () => {
       ],
       mockActivityLogs,
     );
+    queryClient.setQueryData(
+      [
+        QUERY_KEY.PACKAGE_VERSIONS,
+        oldUnapprovedPackage.version.original_package_id,
+      ],
+      packageVersions,
+    );
 
     const router = createRouter({
       routeTree: routeTree,
@@ -450,8 +463,6 @@ describe("package table page", () => {
         </AuthProvider>
       </QueryClientProvider>,
     );
-
-    // cy.wait(["@getOldPackage", "@getOldPackageVersions"]);
 
     cy.contains(
       "This submission is the version the EAO has finalized for implementation.",
@@ -485,7 +496,7 @@ describe("package table page", () => {
     });
 
     // Spy on navigate AFTER router creation but BEFORE initial navigation for the test
-    const navigateSpy = cy.spy(router, "navigate").as("navigateSpy");
+    cy.spy(router, "navigate").as("navigateSpy");
 
     router.navigate({
       // This is the initial navigation to the page under test

--- a/submit-web/cypress/components/_routes/SubmissionPackagePage.cy.tsx
+++ b/submit-web/cypress/components/_routes/SubmissionPackagePage.cy.tsx
@@ -174,4 +174,349 @@ describe("package table page", () => {
       cy.get("tbody tr").should("have.length", mockActivityLogs.length);
     });
   });
+
+  it("should display SuccessBox when the package is the latest approved version", () => {
+    const approvedPackage = {
+      ...mockSubmissionPackage,
+      version: {
+        ...mockSubmissionPackage.version,
+        is_approved: true,
+        version: 2,
+      },
+    };
+    const packageVersions = [
+      { package_id: 1, version: 1, is_approved: true, name: "v1" },
+      {
+        package_id: mockSubmissionPackage.id,
+        version: 2,
+        is_approved: true,
+        name: "v2",
+      },
+    ];
+
+    cy.intercept(
+      "GET",
+      `${AppConfig.apiUrl}/staff/packages/${mockSubmissionPackage.id}`,
+      {
+        body: approvedPackage,
+      },
+    ).as("getApprovedPackage");
+    cy.intercept(
+      "GET",
+      `${AppConfig.apiUrl}/staff/packages/${mockSubmissionPackage.version.original_package_id}/versions`,
+      {
+        body: packageVersions,
+      },
+    ).as("getApprovedPackageVersions");
+
+    // Custom mount for this specific scenario
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      // Seed the specific package
+      [QUERY_KEY.SUBMISSION_PACKAGE, approvedPackage.id],
+      approvedPackage,
+    );
+    queryClient.setQueryData(
+      // Seed account project
+      [QUERY_KEY.ACCOUNT_PROJECT, mockAccountProject.id],
+      mockAccountProject,
+    );
+    queryClient.setQueryData(
+      // Seed activity logs
+      [
+        QUERY_KEY.ACTIVITY_LOGS,
+        approvedPackage.version.original_package_id,
+        ACTIVITY_LOG_ENTITY_TYPE.PACKAGE,
+      ],
+      mockActivityLogs,
+    );
+
+    const router = createRouter({
+      routeTree: routeTree,
+      context: {
+        authentication: mockAuthentication,
+        queryClient: queryClient,
+        account: mockAccount,
+      },
+    });
+    router.navigate({
+      // Navigate to the correct package ID
+      to: `/staff/projects/${mockAccountProject.id}/submission-packages/${approvedPackage.id}`,
+    });
+
+    mount(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider {...OidcConfig}>
+          <RouterProvider
+            router={router}
+            context={{
+              authentication: mockAuthentication,
+              account: mockAccount,
+            }}
+          />
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    // cy.wait(["@getApprovedPackage", "@getApprovedPackageVersions"]);
+
+    cy.contains(
+      "This submission is the version the EAO has finalized for implementation.",
+    ).should("be.visible");
+    cy.contains(
+      "Please Note: This submission is still pending EAO review.",
+    ).should("not.exist");
+  });
+
+  it("should display WarningBox when the package is newer than last approved but not approved", () => {
+    const newerUnapprovedPackage = {
+      ...mockSubmissionPackage,
+      id: 27, // different id for this specific test case if needed
+      version: {
+        ...mockSubmissionPackage.version,
+        original_package_id: mockSubmissionPackage.version.original_package_id,
+        is_approved: false,
+        version: 3, // Newer version
+      },
+    };
+    const packageVersions = [
+      { package_id: 1, version: 1, is_approved: true, name: "v1" },
+      { package_id: 2, version: 2, is_approved: true, name: "v2" }, // Last approved is v2
+      {
+        package_id: 27,
+        version: 3,
+        is_approved: false,
+        name: "v3",
+      },
+    ];
+
+    // Update intercepts for this specific package ID and original_package_id if they differ
+    cy.intercept(
+      "GET",
+      `${AppConfig.apiUrl}/staff/packages/${newerUnapprovedPackage.id}`,
+      {
+        body: newerUnapprovedPackage,
+      },
+    ).as("getNewerUnapprovedPackage");
+
+    cy.intercept(
+      "GET",
+      `${AppConfig.apiUrl}/staff/packages/${newerUnapprovedPackage.version.original_package_id}/versions`,
+      {
+        body: packageVersions,
+      },
+    ).as("getMixedPackageVersions");
+
+    // Adjust mountDefaultPage or how queryClient is pre-filled if packageId changes for the route
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      [QUERY_KEY.SUBMISSION_PACKAGE, newerUnapprovedPackage.id],
+      newerUnapprovedPackage,
+    );
+    queryClient.setQueryData(
+      [QUERY_KEY.ACCOUNT_PROJECT, mockAccountProject.id],
+      mockAccountProject,
+    );
+    queryClient.setQueryData(
+      [
+        QUERY_KEY.ACTIVITY_LOGS,
+        newerUnapprovedPackage.version.original_package_id,
+        ACTIVITY_LOG_ENTITY_TYPE.PACKAGE,
+      ],
+      mockActivityLogs,
+    );
+
+    const router = createRouter({
+      routeTree: routeTree,
+      context: {
+        authentication: mockAuthentication,
+        queryClient: queryClient,
+        account: mockAccount,
+      },
+    });
+
+    // Navigate to the page with the ID of the newerUnapprovedPackage
+    router.navigate({
+      to: `/staff/projects/${mockAccountProject.id}/submission-packages/${newerUnapprovedPackage.id}`,
+    });
+
+    mount(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider {...OidcConfig}>
+          <RouterProvider
+            router={router}
+            context={{
+              authentication: mockAuthentication,
+              account: mockAccount,
+            }}
+          />
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+    // cy.wait(["@getNewerUnapprovedPackage", "@getMixedPackageVersions"]);
+
+    cy.contains(
+      "Please Note: This submission is still pending EAO review.",
+    ).should("be.visible");
+    cy.contains(
+      "This submission is the version the EAO has finalized for implementation.",
+    ).should("not.exist");
+  });
+
+  it("should not display SuccessBox or WarningBox for a package that is old or first unapproved", () => {
+    const oldUnapprovedPackage = {
+      ...mockSubmissionPackage, // Use the default mock ID
+      version: {
+        ...mockSubmissionPackage.version,
+        is_approved: false,
+        version: 1, // Assuming this is the first version or an old one
+      },
+    };
+    const packageVersions = [
+      // Only this version exists, or others are newer but this isn't special
+      {
+        package_id: mockSubmissionPackage.id,
+        version: 1,
+        is_approved: false,
+        name: "v1",
+      },
+    ];
+    cy.intercept(
+      "GET",
+      `${AppConfig.apiUrl}/staff/packages/${mockSubmissionPackage.id}`,
+      {
+        body: oldUnapprovedPackage,
+      },
+    ).as("getOldPackage");
+    cy.intercept(
+      "GET",
+      `${AppConfig.apiUrl}/staff/packages/${mockSubmissionPackage.version.original_package_id}/versions`,
+      {
+        body: packageVersions,
+      },
+    ).as("getOldPackageVersions");
+
+    // Custom mount for this specific scenario
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      // Seed the specific package
+      [QUERY_KEY.SUBMISSION_PACKAGE, oldUnapprovedPackage.id],
+      oldUnapprovedPackage,
+    );
+    queryClient.setQueryData(
+      // Seed account project
+      [QUERY_KEY.ACCOUNT_PROJECT, mockAccountProject.id],
+      mockAccountProject,
+    );
+    queryClient.setQueryData(
+      // Seed activity logs
+      [
+        QUERY_KEY.ACTIVITY_LOGS,
+        oldUnapprovedPackage.version.original_package_id,
+        ACTIVITY_LOG_ENTITY_TYPE.PACKAGE,
+      ],
+      mockActivityLogs,
+    );
+
+    const router = createRouter({
+      routeTree: routeTree,
+      context: {
+        authentication: mockAuthentication,
+        queryClient: queryClient,
+        account: mockAccount,
+      },
+    });
+    router.navigate({
+      // Navigate to the correct package ID
+      to: `/staff/projects/${mockAccountProject.id}/submission-packages/${oldUnapprovedPackage.id}`,
+    });
+
+    mount(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider {...OidcConfig}>
+          <RouterProvider
+            router={router}
+            context={{
+              authentication: mockAuthentication,
+              account: mockAccount,
+            }}
+          />
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    // cy.wait(["@getOldPackage", "@getOldPackageVersions"]);
+
+    cy.contains(
+      "This submission is the version the EAO has finalized for implementation.",
+    ).should("not.exist");
+    cy.contains(
+      "Please Note: This submission is still pending EAO review.",
+    ).should("not.exist");
+  });
+
+  it("test Close button functionality", () => {
+    const queryClient = new QueryClient({
+      defaultOptions: { queries: { retry: false } },
+    });
+    queryClient.setQueryData(
+      [QUERY_KEY.SUBMISSION_PACKAGE, mockSubmissionPackage.id],
+      mockSubmissionPackage,
+    );
+    queryClient.setQueryData(
+      [QUERY_KEY.ACCOUNT_PROJECT, mockAccountProject.id],
+      mockAccountProject,
+    );
+
+    const router = createRouter({
+      routeTree: routeTree,
+      context: {
+        authentication: mockAuthentication,
+        queryClient: queryClient,
+        account: mockAccount,
+      },
+      // history: Cypress.routerHistory, // Removed: Not needed, router will use memory history
+    });
+
+    // Spy on navigate AFTER router creation but BEFORE initial navigation for the test
+    const navigateSpy = cy.spy(router, "navigate").as("navigateSpy");
+
+    router.navigate({
+      // This is the initial navigation to the page under test
+      to: `/staff/projects/${mockAccountProject.id}/submission-packages/${mockSubmissionPackage.id}`,
+    });
+
+    mount(
+      <QueryClientProvider client={queryClient}>
+        <AuthProvider {...OidcConfig}>
+          <RouterProvider
+            router={router}
+            context={{
+              authentication: mockAuthentication,
+              account: mockAccount,
+            }}
+          />
+        </AuthProvider>
+      </QueryClientProvider>,
+    );
+
+    cy.contains("button", "Close").should("be.visible").click();
+    cy.get("@navigateSpy").should("have.been.calledWith", {
+      to: `/staff/projects/${mockAccountProject.id}`,
+    });
+  });
+
+  it("renders UpdateRequestWidget", () => {
+    mountDefaultPage();
+    // Assuming UpdateRequestWidget has a distinct element or data-testid
+    // For now, let's check for a known text/element if possible, or its container
+    // This might need adjustment based on UpdateRequestWidget's actual content
+    cy.get("[data-testid='update-request-accordion']").should("be.visible");
+  });
 });

--- a/submit-web/cypress/components/_routes/SubmissionPackagePage.cy.tsx
+++ b/submit-web/cypress/components/_routes/SubmissionPackagePage.cy.tsx
@@ -232,6 +232,10 @@ describe("package table page", () => {
       ],
       mockActivityLogs,
     );
+    queryClient.setQueryData(
+      [QUERY_KEY.PACKAGE_VERSIONS, approvedPackage.version.original_package_id],
+      packageVersions,
+    );
 
     const router = createRouter({
       routeTree: routeTree,
@@ -260,8 +264,6 @@ describe("package table page", () => {
       </QueryClientProvider>,
     );
 
-    // cy.wait(["@getApprovedPackage", "@getApprovedPackageVersions"]);
-
     cy.contains(
       "This submission is the version the EAO has finalized for implementation.",
     ).should("be.visible");
@@ -276,11 +278,11 @@ describe("package table page", () => {
       id: 27, // different id for this specific test case if needed
       version: {
         ...mockSubmissionPackage.version,
-        original_package_id: mockSubmissionPackage.version.original_package_id,
         is_approved: false,
         version: 3, // Newer version
       },
     };
+
     const packageVersions = [
       { package_id: 1, version: 1, is_approved: true, name: "v1" },
       { package_id: 2, version: 2, is_approved: true, name: "v2" }, // Last approved is v2

--- a/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
+++ b/submit-web/src/components/Submission/UpdateRequestWidget/index.tsx
@@ -62,7 +62,7 @@ export default function UpdateRequestWidget({
           notify.error(
             isAxiosError(error)
               ? (error.response?.data.message ?? defaultMessage)
-              : defaultMessage
+              : defaultMessage,
           );
         },
       },
@@ -107,6 +107,7 @@ export default function UpdateRequestWidget({
         },
       }}
       expanded={expanded}
+      data-testid="update-request-accordion"
     >
       <AccordionSummary
         expandIcon={null}


### PR DESCRIPTION
Adds Cypress tests to verify the display of success and warning boxes based on package approval status.

Also includes tests to ensure the "Close" button navigates correctly.

These tests enhance the reliability of the submission package page.