### PR TITLE
SUBMIT-618 Refactors user roles to use original package IDs

### DIFF
--- a/submit-api/migrations/versions/7cadbb980cf7_.py
+++ b/submit-api/migrations/versions/7cadbb980cf7_.py
@@ -66,3 +66,4 @@ def upgrade():
 def downgrade():
     # Remove the new column — original package IDs
     op.drop_column('user_roles', 'original_package_ids')
+    op.drop_column('invitations', 'original_package_ids')

--- a/submit-api/migrations/versions/7cadbb980cf7_.py
+++ b/submit-api/migrations/versions/7cadbb980cf7_.py
@@ -10,7 +10,7 @@ import sqlalchemy as sa
 from sqlalchemy.orm import Session
 from sqlalchemy.ext.declarative import declarative_base
 
-from submit_api.models import Package, PackageVersion, UserRole
+from submit_api.models import Package, PackageVersion, UserRole, Invitations
 
 # revision identifiers, used by Alembic.
 revision = '7cadbb980cf7'
@@ -24,7 +24,7 @@ Base = declarative_base()
 def upgrade():
     # Add new column — keeping old one intact
     op.add_column('user_roles', sa.Column('original_package_ids', sa.ARRAY(sa.Integer), nullable=True))
-
+    op.add_column('invitations', sa.Column('original_package_ids', sa.ARRAY(sa.Integer), nullable=True))
     bind = op.get_bind()
     session = Session(bind=bind)
 
@@ -50,6 +50,15 @@ def upgrade():
             if package_to_original.get(pid) is not None
         ]
         role.original_package_ids = mapped_ids
+
+    invitations = session.query(Invitations).filter(Invitations.package_ids.isnot(None)).all()
+    for invitation in invitations:
+        mapped_ids = [
+            package_to_original.get(pid)
+            for pid in invitation.package_ids or []
+            if package_to_original.get(pid) is not None
+        ]
+        invitation.original_package_ids = mapped_ids
 
     session.commit()
 

--- a/submit-api/migrations/versions/7cadbb980cf7_.py
+++ b/submit-api/migrations/versions/7cadbb980cf7_.py
@@ -1,0 +1,59 @@
+""" Update user_roles package_ids to original_package_ids
+
+Revision ID: 7cadbb980cf7
+Revises: c5f4cd047da4
+Create Date: 2025-07-14 09:03:38.061983
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.orm import Session
+from sqlalchemy.ext.declarative import declarative_base
+
+from submit_api.models import Package, PackageVersion, UserRole
+
+# revision identifiers, used by Alembic.
+revision = '7cadbb980cf7'
+down_revision = 'c5f4cd047da4'
+branch_labels = None
+depends_on = None
+
+Base = declarative_base()
+
+
+def upgrade():
+    # Add new column — keeping old one intact
+    op.add_column('user_roles', sa.Column('original_package_ids', sa.ARRAY(sa.Integer), nullable=True))
+
+    bind = op.get_bind()
+    session = Session(bind=bind)
+
+    # Build mapping: package.id → version_id → original_package_id
+    packages = session.query(Package.id, Package.version_id).all()
+    versions = session.query(PackageVersion.id, PackageVersion.original_package_id).all()
+
+    package_to_version = {p.id: p.version_id for p in packages}
+    version_to_original = {v.id: v.original_package_id for v in versions}
+
+    package_to_original = {
+        pid: version_to_original.get(vid)
+        for pid, vid in package_to_version.items()
+        if version_to_original.get(vid) is not None
+    }
+
+    # Assign new original_package_ids for each user role
+    roles = session.query(UserRole).filter(UserRole.package_ids.isnot(None)).all()
+    for role in roles:
+        mapped_ids = [
+            package_to_original.get(pid)
+            for pid in role.package_ids or []
+            if package_to_original.get(pid) is not None
+        ]
+        role.original_package_ids = mapped_ids
+
+    session.commit()
+
+
+def downgrade():
+    # Remove the new column — original package IDs
+    op.drop_column('user_roles', 'original_package_ids')

--- a/submit-api/src/submit_api/models/invitations.py
+++ b/submit-api/src/submit_api/models/invitations.py
@@ -23,6 +23,7 @@ class Invitations(BaseModel):
     account_id = Column(Integer, ForeignKey('accounts.id'), nullable=False)
     project_ids = Column(ARRAY(Integer), nullable=False)
     package_ids = Column(ARRAY(Integer), nullable=True)
+    original_package_ids = Column(ARRAY(Integer), nullable=True)  # For original package IDs
     token = Column(String(255), unique=True, nullable=False)
     email = Column(String(255), nullable=True)  # Optional email for client
     status = Column(String(50), default=InvitationStatus.PENDING.value, nullable=False)
@@ -40,6 +41,7 @@ class Invitations(BaseModel):
             "account_id": self.account_id,
             "project_ids": self.project_ids,
             "package_ids": self.package_ids,
+            "original_package_ids": self.original_package_ids,
             "token": self.token,
             "email": self.email,
             "status": self.status,

--- a/submit-api/src/submit_api/models/package.py
+++ b/submit-api/src/submit_api/models/package.py
@@ -128,10 +128,18 @@ class Package(BaseModel):
         return cls.query.filter(Package.id.in_(package_ids)).all()
 
     @classmethod
-    def get_all_active_packages_by_original_package_ids(cls, original_package_ids: list[int]):
-        """Return all active packages by original package ids."""
-        return cls.query.join(PackageVersion).filter(PackageVersion.original_package_id.in_(original_package_ids),
-                                                     Package.active.is_(True)).all()
+    def get_all_latest_packages_by_original_package_ids(cls, original_package_ids: list[int]):
+        """Return all packages with the greatest PackageVersion.version by original package ids."""
+        subquery = db.session.query(
+            PackageVersion.original_package_id,
+            db.func.max(PackageVersion.version).label('max_version')
+        ).filter(PackageVersion.original_package_id.in_(original_package_ids)).group_by(PackageVersion.original_package_id).subquery()
+
+        return cls.query.join(PackageVersion).join(
+            subquery,
+            (PackageVersion.original_package_id == subquery.c.original_package_id) &
+            (PackageVersion.version == subquery.c.max_version)
+        ).all()
 
     @classmethod
     def get_account_project_id_by_package_id(cls, package_id: int) -> int | None:

--- a/submit-api/src/submit_api/models/package.py
+++ b/submit-api/src/submit_api/models/package.py
@@ -9,6 +9,7 @@ import enum
 from sqlalchemy import Column, Enum, ForeignKey
 from sqlalchemy.orm import joinedload
 
+from . import PackageVersion
 from .base_model import BaseModel
 from .db import db
 
@@ -76,7 +77,7 @@ class Package(BaseModel):
         'account_projects.id'), nullable=False)
     name = Column(db.String(255), nullable=False)
     type_id = Column(db.Integer, ForeignKey(
-        'package_types.id'), nullable=False)
+        'package_types.id'), nullablQe=False)
     type = db.relationship('PackageType', foreign_keys=[
                            type_id], lazy='joined')
     submitted_on = Column(db.DateTime, nullable=True)
@@ -125,6 +126,12 @@ class Package(BaseModel):
     def get_all_package_by_ids(cls, package_ids: list[int]):
         """Return model by package ids."""
         return cls.query.filter(Package.id.in_(package_ids)).all()
+
+    @classmethod
+    def get_all_active_packages_by_original_package_ids(cls, original_package_ids: list[int]):
+        """Return all active packages by original package ids."""
+        return cls.query.join(PackageVersion).filter(PackageVersion.original_package_id.in_(original_package_ids),
+                                                     Package.active.is_(True)).all()
 
     @classmethod
     def get_account_project_id_by_package_id(cls, package_id: int) -> int | None:

--- a/submit-api/src/submit_api/models/package.py
+++ b/submit-api/src/submit_api/models/package.py
@@ -9,7 +9,7 @@ import enum
 from sqlalchemy import Column, Enum, ForeignKey
 from sqlalchemy.orm import joinedload
 
-from . import PackageVersion
+from .package_version import PackageVersion
 from .base_model import BaseModel
 from .db import db
 
@@ -77,7 +77,7 @@ class Package(BaseModel):
         'account_projects.id'), nullable=False)
     name = Column(db.String(255), nullable=False)
     type_id = Column(db.Integer, ForeignKey(
-        'package_types.id'), nullablQe=False)
+        'package_types.id'), nullable=False)
     type = db.relationship('PackageType', foreign_keys=[
                            type_id], lazy='joined')
     submitted_on = Column(db.DateTime, nullable=True)

--- a/submit-api/src/submit_api/models/package.py
+++ b/submit-api/src/submit_api/models/package.py
@@ -130,10 +130,11 @@ class Package(BaseModel):
     @classmethod
     def get_all_latest_packages_by_original_package_ids(cls, original_package_ids: list[int]):
         """Return all packages with the greatest PackageVersion.version by original package ids."""
-        subquery = db.session.query(
+        subquery = (db.session.query(
             PackageVersion.original_package_id,
             db.func.max(PackageVersion.version).label('max_version')
-        ).filter(PackageVersion.original_package_id.in_(original_package_ids)).group_by(PackageVersion.original_package_id).subquery()
+        ).filter(PackageVersion.original_package_id.in_(original_package_ids))
+                    .group_by(PackageVersion.original_package_id).subquery())
 
         return cls.query.join(PackageVersion).join(
             subquery,

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -17,7 +17,7 @@ from sqlalchemy import or_
 from sqlalchemy.orm import joinedload, contains_eager, aliased
 from submit_api.enums.role import RoleEnum
 from submit_api.models.package import PackageStatus, NonCanonicalPackageStatus
-from submit_api.models import AccountProject, Project, db, User
+from submit_api.models import AccountProject, Project, db, User, PackageVersion
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions
 from submit_api.models.package import Package
 from submit_api.models.user import UserType
@@ -172,9 +172,11 @@ class ProjectQueries:
         if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value]:
             return package_query
 
-        if user_role.package_ids:
-            package_query = package_query.filter(Package.id.in_(user_role.package_ids)) if package_query\
-                else db.session.query(Package).filter(Package.id.in_(user_role.package_ids))
+        if user_role.original_package_ids:
+            package_query = package_query.join(PackageVersion)
+            package_query = package_query.filter(
+                PackageVersion.original_package_id.in_(user_role.original_package_ids))\
+                if package_query else db.session.query(Package).filter(Package.id.in_(user_role.original_package_ids))
         else:
             package_query = package_query.filter(False)
 

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -168,15 +168,15 @@ class ProjectQueries:
         user_role = user.account_user.role
         if not user_role:
             raise ValueError("User role not found.")
-
         if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value]:
             return package_query
 
+        if package_query is None:
+            package_query = db.session.query(Package)
+
         if user_role.original_package_ids:
-            package_query = package_query.join(PackageVersion)
-            package_query = package_query.filter(
-                PackageVersion.original_package_id.in_(user_role.original_package_ids))\
-                if package_query else db.session.query(Package).filter(Package.id.in_(user_role.original_package_ids))
+            package_query = package_query.join(PackageVersion).filter(
+                PackageVersion.original_package_id.in_(user_role.original_package_ids))
         else:
             package_query = package_query.filter(False)
 

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -170,11 +170,16 @@ class PackageQueries:
                 func.array_agg(
                     func.json_build_object(
                         "id", PackageModel.id,
-                        "name", PackageModel.name
+                        "name", PackageModel.name,
+                        "original_package_id", PackageVersion.original_package_id,
                     )
                 ).label('packages')  # Aggregate packages as a JSON array
             )
             .join(PackageModel, PackageModel.account_project_id == AccountProject.id)
+            .join(
+                PackageVersion,
+                PackageModel.version_id == PackageVersion.id
+            )  # Join with PackageVersion to filter by version_id
             .join(
                 latest_versions_subquery,
                 PackageModel.version_id == latest_versions_subquery.c.latest_version_id

--- a/submit-api/src/submit_api/models/user_role.py
+++ b/submit-api/src/submit_api/models/user_role.py
@@ -18,6 +18,7 @@ class UserRole(BaseModel):
     account_project_id = Column(Integer, ForeignKey("account_projects.id"),
                                 nullable=True)  # NULL for account-wide roles
     package_ids = Column(ARRAY(Integer), nullable=True)  # NULL for project-wide roles
+    original_package_ids = Column(ARRAY(Integer), nullable=True)  # For original package IDs
     active = Column(db.Boolean, nullable=False, default=True)
     role_id = Column(Integer, ForeignKey("roles.id"), nullable=False)
     role = db.relationship("Role", lazy="joined")
@@ -51,6 +52,7 @@ class UserRole(BaseModel):
             "account_user_id": self.account_user_id,
             "account_project_id": self.account_project_id,
             "package_ids": self.package_ids,
+            "original_package_ids": self.original_package_ids,
             "role_id": self.role_id,
             "role": self.role.to_dict(),
             "permissions": self.permissions,
@@ -64,6 +66,7 @@ class UserRole(BaseModel):
             account_user_id=data.get("account_user_id"),
             account_project_id=data.get("account_project_id"),
             package_ids=data.get("package_ids") or None,
+            original_package_ids=data.get("original_package_ids") or None,
             role_id=data.get("role_id"),
         )
         if session:

--- a/submit-api/src/submit_api/schemas/account_user.py
+++ b/submit-api/src/submit_api/schemas/account_user.py
@@ -34,6 +34,7 @@ class EditRoleSchema(Schema):
 
     role_name = fields.Str()
     package_ids = fields.List(fields.Int(), allow_none=True)
+    original_package_ids = fields.List(fields.Int(), allow_none=True)
 
 
 class EditTermsOfServiceSchema(Schema):

--- a/submit-api/src/submit_api/schemas/invitation.py
+++ b/submit-api/src/submit_api/schemas/invitation.py
@@ -15,6 +15,8 @@ class CreateInvitationSchema(Schema):
     project_ids = fields.List(fields.Int(), required=True, description="List of Project IDs")
     role_name = fields.Str(required=True, description="Role Name")
     package_ids = fields.List(fields.Int(), required=False, allow_none=True)
+    original_package_ids = fields.List(fields.Int(),
+                                       required=False, allow_none=True, description="Original Package IDs")
     email = fields.Email(required=False, description="Optional email for client")
 
 
@@ -25,6 +27,7 @@ class InvitationSchema(Schema):
     account_id = fields.Int()
     project_ids = fields.List(fields.Int())
     package_ids = fields.List(fields.Int(), allow_none=True)
+    original_package_ids = fields.List(fields.Int(), allow_none=True)
     role_id = fields.Int()
     role_name = fields.Str()
     token = fields.Str()

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -278,6 +278,7 @@ class AccountPackageSchema(Schema):
 
         id = fields.Int(data_key="id")
         name = fields.Str(data_key="name")
+        original_package_id = fields.Int(data_key="original_package_id")
 
     project_id = fields.Int(data_key="project_id")
     account_packages = fields.List(fields.Nested(

--- a/submit-api/src/submit_api/schemas/role.py
+++ b/submit-api/src/submit_api/schemas/role.py
@@ -19,6 +19,7 @@ class UserRoleSchema(Schema):
     account_user_id = fields.Int()
     account_project_id = fields.Int(allow_none=True)
     package_ids = fields.List(fields.Int(), allow_none=True)
+    original_package_ids = fields.List(fields.Int(), allow_none=True)
     package_names = fields.List(fields.String(), allow_none=True)
     role_name = fields.Pluck(RoleSchema, "role_name", data_key="role_name", attribute="role")
     permissions = fields.List(fields.Str())

--- a/submit-api/src/submit_api/services/account_user_service.py
+++ b/submit-api/src/submit_api/services/account_user_service.py
@@ -31,8 +31,8 @@ class AccountUserService:
         all_package_ids = set()
         for user in users:
             role = getattr(user, "role", None)
-            if role and role.package_ids:
-                all_package_ids.update(role.package_ids)
+            if role and role.original_package_ids:
+                all_package_ids.update(role.original_package_ids)
 
         # Fetch names for all package_ids at once
         package_name_map = cls._fetch_package_names(list(all_package_ids))
@@ -44,7 +44,7 @@ class AccountUserService:
             # Add package_name to active role if applicable
             role = user_data.get("role")
             user_data["role"] = role if role.get("active") else []
-            if role and role.get("active") and (pkg_ids := role.get("package_ids")):
+            if role and role.get("active") and (pkg_ids := role.get("original_package_ids")):
                 role["package_names"] = [
                     package_name_map[pkg_id] for pkg_id in pkg_ids if pkg_id in package_name_map]
 
@@ -59,9 +59,9 @@ class AccountUserService:
         return user_list
 
     @staticmethod
-    def _fetch_package_names(package_ids: list[int]) -> dict[int, str]:
+    def _fetch_package_names(original_package_ids: list[int]) -> dict[int, str]:
         """Fetch package names for given IDs and return as {id: name}."""
-        packages = PackageModel.get_all_package_by_ids(package_ids)
+        packages = PackageModel.get_all_active_packages_by_original_package_ids(original_package_ids)
         return {pkg.id: pkg.name for pkg in packages}
 
     @staticmethod
@@ -98,7 +98,8 @@ class AccountUserService:
                 "role_id": role.role_id,
                 "role_name": RoleModel.find_by_id(role.role_id).role_name,
                 "account_project_id": role.account_project_id,
-                "package_ids": role.package_ids
+                "package_ids": role.package_ids,
+                "original_package_ids": role.original_package_ids,
             })
         return roles_map
 
@@ -113,8 +114,8 @@ class AccountUserService:
         invited_users = []
         for invite in invitees:
             packages = []
-            if invite.package_ids:
-                packages = PackageModel.get_all_package_by_ids(invite.package_ids)
+            if invite.original_package_ids:
+                packages = PackageModel.get_all_active_packages_by_original_package_ids(invite.original_package_ids)
 
             invited_user = {
                 "id": None,
@@ -128,6 +129,7 @@ class AccountUserService:
                     "role": invite.role.to_dict(),
                     "account_project_id": None,
                     "package_ids": invite.package_ids,
+                    "original_package_ids": invite.original_package_ids,
                     "package_names": [pkg.name for pkg in packages],
                     "project_ids": invite.project_ids
                 } if include_roles else None,
@@ -149,22 +151,24 @@ class AccountUserService:
         role_id = role_data.get("role_id")
         account_project_id = role_data.get("account_project_id")
         package_ids = role_data.get("package_ids")
+        original_package_ids = role_data.get("original_package_ids")
 
         role = RoleModel.find_by_id(role_id)
         if not role:
             raise ValueError(f"Invalid role ID: {role_id}")
 
-        # ideally UI should be passing this.. fetch it if UI doesnt send it..
+        # ideally UI should be passing this. fetch it if UI doesnt send it..
         if not account_project_id:
             account_project_id = cls._fetch_account_project_id(account_user_id)
 
         # only for SPECIFIC_SUBMISSION_CONTRIBUTOR , save package id
-        package_ids = package_ids if role.role_name == RoleEnum.SPECIFIC_SUBMISSION_CONTRIBUTOR.value else None
+        original_package_ids = original_package_ids if role.role_name == RoleEnum.SPECIFIC_SUBMISSION_CONTRIBUTOR.value else None
         role_data = {
             "account_user_id": account_user_id,
             "role_id": role_id,
             "account_project_id": account_project_id,
             "package_ids": package_ids,
+            "original_package_ids": original_package_ids,
             "role_name": role.role_name
         }
 
@@ -173,7 +177,8 @@ class AccountUserService:
             "role_id": role.id,
             "role_name": role.role_name,
             "account_project_id": role_data.get("account_project_id"),
-            "package_ids": role_data.get("package_ids")
+            "package_ids": role_data.get("package_ids"),
+            "original_package_ids": role_data.get("original_package_ids")
         }
 
     @classmethod
@@ -227,11 +232,13 @@ class AccountUserService:
             raise ResourceNotFoundError(f"Item with id {account_user_id} not found.")
 
         new_role_name = updated_role_data.get("role_name")
-        package_ids = updated_role_data.get("package_ids")
+        package_ids = updated_role_data.get("package_ids", None)
+        original_package_ids = updated_role_data.get("original_package_ids", None)
         role = AccountUserService._validate_fetch_role(new_role_name)
 
         user_role.role_id = role.id
         user_role.package_ids = package_ids
+        user_role.original_package_ids = original_package_ids
         db.session.commit()
 
         current_app.logger.info(f"User role {user_role.id} updated successfully.")
@@ -296,9 +303,9 @@ class AccountUserService:
         if not role.get("active"):
             user_dict["role"] = []
         else:
-            package_ids = role.get("package_ids", [])
-            package_name_map = cls._fetch_package_names(package_ids)
-            role["package_names"] = [package_name_map[pid] for pid in package_ids if pid in package_name_map]
+            original_package_ids = role.get("original_package_ids", [])
+            package_name_map = cls._fetch_package_names(original_package_ids)
+            role["package_names"] = [package_name_map[pid] for pid in original_package_ids if pid in package_name_map]
 
         return user_dict
 

--- a/submit-api/src/submit_api/services/account_user_service.py
+++ b/submit-api/src/submit_api/services/account_user_service.py
@@ -61,8 +61,8 @@ class AccountUserService:
     @staticmethod
     def _fetch_package_names(original_package_ids: list[int]) -> dict[int, str]:
         """Fetch package names for given IDs and return as {id: name}."""
-        packages = PackageModel.get_all_active_packages_by_original_package_ids(original_package_ids)
-        return {pkg.id: pkg.name for pkg in packages}
+        packages = PackageModel.get_all_latest_packages_by_original_package_ids(original_package_ids)
+        return {pkg.version.original_package_id: pkg.name for pkg in packages}
 
     @staticmethod
     def _fetch_users(account_id):
@@ -115,8 +115,7 @@ class AccountUserService:
         for invite in invitees:
             packages = []
             if invite.original_package_ids:
-                packages = PackageModel.get_all_active_packages_by_original_package_ids(invite.original_package_ids)
-
+                packages = PackageModel.get_all_latest_packages_by_original_package_ids(invite.original_package_ids)
             invited_user = {
                 "id": None,
                 "invitation_id": invite.id,

--- a/submit-api/src/submit_api/services/account_user_service.py
+++ b/submit-api/src/submit_api/services/account_user_service.py
@@ -162,7 +162,8 @@ class AccountUserService:
             account_project_id = cls._fetch_account_project_id(account_user_id)
 
         # only for SPECIFIC_SUBMISSION_CONTRIBUTOR , save package id
-        original_package_ids = original_package_ids if role.role_name == RoleEnum.SPECIFIC_SUBMISSION_CONTRIBUTOR.value else None
+        original_package_ids = original_package_ids \
+            if role.role_name == RoleEnum.SPECIFIC_SUBMISSION_CONTRIBUTOR.value else None
         role_data = {
             "account_user_id": account_user_id,
             "role_id": role_id,

--- a/submit-api/src/submit_api/services/authorization.py
+++ b/submit-api/src/submit_api/services/authorization.py
@@ -37,7 +37,8 @@ def check_assigned_on_package(package_id):
     if not package_id:
         abort(HTTPStatus.BAD_REQUEST)
 
-    if not PackageModel.find_by_id(package_id):
+    package = PackageModel.find_by_id(package_id)
+    if not package:
         abort(HTTPStatus.NOT_FOUND)
 
     user: UserModel = UserModel.get_by_guid(TokenInfo.get_id())
@@ -60,7 +61,7 @@ def check_assigned_on_package(package_id):
         return
 
     if user_role.role.role_name == RoleEnum.SPECIFIC_SUBMISSION_CONTRIBUTOR.value:
-        if package_id in user_role.package_ids:
+        if package.version.original_package_id in user_role.original_package_ids:
             return
 
     abort(HTTPStatus.FORBIDDEN)

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -227,6 +227,7 @@ class InvitationService:
             created_by=invite_data.get('created_by'),
             role_id=role.id,
             package_ids=invite_data.get('package_ids'),
+            original_package_ids=invite_data.get('original_package_ids'),
             expiry_date=datetime.datetime.utcnow() + datetime.timedelta(days=expiry_days),
             is_first_time=is_first_time
         )
@@ -265,6 +266,7 @@ class InvitationService:
             "role_id": invitation.role_id,
             "account_project_id": account_project_id,
             "package_ids": invitation.package_ids,
+            "original_package_ids": invitation.package_ids
         }, session)
 
     @staticmethod

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -266,7 +266,7 @@ class InvitationService:
             "role_id": invitation.role_id,
             "account_project_id": account_project_id,
             "package_ids": invitation.package_ids,
-            "original_package_ids": invitation.package_ids
+            "original_package_ids": invitation.original_package_ids
         }, session)
 
     @staticmethod

--- a/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
+++ b/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
@@ -44,6 +44,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
 
   const handleConfirm = () => {
     onConfirm();
+    setClose();
   };
 
   const handleSecondaryAction = () => {

--- a/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
+++ b/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
@@ -44,7 +44,6 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
 
   const handleConfirm = () => {
     onConfirm();
-    setClose();
   };
 
   const handleSecondaryAction = () => {

--- a/submit-web/src/components/UserManagement/entity/EditUserProfile/UpdateUserRoleForm.tsx
+++ b/submit-web/src/components/UserManagement/entity/EditUserProfile/UpdateUserRoleForm.tsx
@@ -44,7 +44,7 @@ import { useUserStore } from "./../../entity/userStore";
 
 const userSchema = yup.object().shape({
   role_name: yup.string().required("Please select a role."),
-  package_ids: yup
+  original_package_ids: yup
     .array()
     .of(yup.string())
     .when("role_name", {
@@ -126,8 +126,9 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
 
   const handleConfirm = () => {
     const request = {
-      active: user.status === ACTIVE_STATUS ? false : true,
+      active: user.status !== ACTIVE_STATUS,
     };
+    setIsLoading(true);
     updateUserStatus(request);
   };
 
@@ -147,7 +148,7 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
         }
         confirmText="Confirm"
         cancelText="Cancel"
-      />
+      />,
     );
   };
 
@@ -156,7 +157,7 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
     mode: "onSubmit",
     defaultValues: {
       role_name: user.role?.role_name || "",
-      package_ids: [],
+      original_package_ids: [],
     },
   });
 
@@ -175,8 +176,8 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
   const handleUpdateForm = (formData: UserSchema) => {
     const request = {
       role_name: formData.role_name,
-      package_ids: formData.package_ids
-        ? formData.package_ids.map(Number)
+      original_package_ids: formData.original_package_ids
+        ? formData.original_package_ids.map(Number)
         : undefined,
     };
     updateUser(request);
@@ -186,26 +187,26 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
     () =>
       accountPackages?.flatMap((accountProject) =>
         Object.values(accountProject.packages).map((pkg) => ({
-          value: String(pkg.id),
+          value: String(pkg.original_package_id),
           label: pkg.name,
-        }))
+        })),
       ) || [],
-    [accountPackages]
+    [accountPackages],
   );
 
   useEffect(() => {
     if (
-      user.role?.package_ids &&
+      user.role?.original_package_ids &&
       accountPackages &&
       selectedRole === USER_MANAGEMENT_ROLE.SPECIFIC_SUBMISSION_CONTRIBUTOR
     ) {
       const matchingPackageIds = accountPackages.flatMap((accountProject) =>
         Object.values(accountProject.packages)
-          .filter((pkg) => user.role.package_ids.includes(pkg.id))
-          .map((pkg) => String(pkg.id))
+          .filter((pkg) => user.role.original_package_ids.includes(pkg.id))
+          .map((pkg) => String(pkg.id)),
       );
 
-      methods.setValue("package_ids", matchingPackageIds);
+      methods.setValue("original_package_ids", matchingPackageIds);
     }
   }, [user.role?.package_ids, accountPackages, selectedRole, methods]);
 

--- a/submit-web/src/components/UserManagement/entity/EditUserProfile/UpdateUserRoleForm.tsx
+++ b/submit-web/src/components/UserManagement/entity/EditUserProfile/UpdateUserRoleForm.tsx
@@ -208,7 +208,7 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
 
       methods.setValue("original_package_ids", matchingPackageIds);
     }
-  }, [user.role?.package_ids, accountPackages, selectedRole, methods]);
+  }, [user.role?.original_package_ids, accountPackages, selectedRole, methods]);
 
   return (
     <TableBox mainLabel={"User Management"}>
@@ -337,7 +337,7 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
                 </Typography>
                 <ControlledMultiSelect
                   multiple
-                  name="package_ids"
+                  name="original_package_ids"
                   options={options}
                 />
               </When>

--- a/submit-web/src/components/UserManagement/entity/EditUserProfile/UpdateUserRoleForm.tsx
+++ b/submit-web/src/components/UserManagement/entity/EditUserProfile/UpdateUserRoleForm.tsx
@@ -202,10 +202,11 @@ function UpdateUserRole({ userData }: UpdateUserRoleProps) {
     ) {
       const matchingPackageIds = accountPackages.flatMap((accountProject) =>
         Object.values(accountProject.packages)
-          .filter((pkg) => user.role.original_package_ids.includes(pkg.id))
-          .map((pkg) => String(pkg.id)),
+          .filter((pkg) =>
+            user.role.original_package_ids.includes(pkg.original_package_id),
+          )
+          .map((pkg) => String(pkg.original_package_id)),
       );
-
       methods.setValue("original_package_ids", matchingPackageIds);
     }
   }, [user.role?.original_package_ids, accountPackages, selectedRole, methods]);

--- a/submit-web/src/components/UserManagement/entity/NewUser/NewUserForm.tsx
+++ b/submit-web/src/components/UserManagement/entity/NewUser/NewUserForm.tsx
@@ -33,7 +33,7 @@ import UserManagementModal from "./UserManagementModal";
 const newUser = yup.object().shape({
   email: yup.string().email().required("Please enter a valid email address."),
   role_name: yup.string().required("Please select an option."),
-  package_ids: yup
+  original_package_ids: yup
     .array()
     .of(yup.string()) // Ensures project IDs are strings
     .when("role_name", {
@@ -77,7 +77,7 @@ export default function NewUserForm() {
                   ],
                 }}
                 onClose={() => closeModal()}
-              />
+              />,
             );
           } else if (existing_user.status === "PENDING") {
             setOpenModal(
@@ -94,7 +94,7 @@ export default function NewUserForm() {
                   ],
                 }}
                 onClose={() => closeModal()}
-              />
+              />,
             );
           }
         } else {
@@ -112,7 +112,7 @@ export default function NewUserForm() {
     defaultValues: {
       email: "",
       role_name: "",
-      package_ids: [],
+      original_package_ids: [],
     },
   });
 
@@ -125,7 +125,7 @@ export default function NewUserForm() {
   const selectedRole = watch("role_name");
 
   const getProjectIds = () => {
-    const packageIds = watch("package_ids") || [];
+    const packageIds = watch("original_package_ids") || [];
     const isSpecificSubmission =
       selectedRole === USER_MANAGEMENT_ROLE.SPECIFIC_SUBMISSION_CONTRIBUTOR;
     return (
@@ -133,21 +133,23 @@ export default function NewUserForm() {
         ?.filter(
           ({ packages }) =>
             !isSpecificSubmission ||
-            packages.some(({ id }) => packageIds.includes(id.toString()))
+            packages.some(({ id }) => packageIds.includes(id.toString())),
         )
         .map(({ project_id }) => Number(project_id)) || []
     );
   };
 
   const handleCompleteForm = (formData: NewUserSchema) => {
-    const { email, role_name, package_ids } = formData;
+    const { email, role_name, original_package_ids } = formData;
     const request = {
       proponent_id: proponentId,
       account_id: accountId,
       role_name,
       email,
       project_ids: getProjectIds(),
-      package_ids: package_ids ? package_ids.map(Number) : undefined,
+      original_package_ids: original_package_ids
+        ? original_package_ids.map(Number)
+        : undefined,
     };
     createInvite(request);
   };
@@ -156,11 +158,11 @@ export default function NewUserForm() {
     () =>
       accountPackages?.flatMap((accountProject) =>
         Object.values(accountProject.packages).map((pkg) => ({
-          value: String(pkg.id),
+          value: String(pkg.original_package_id),
           label: pkg.name,
-        }))
+        })),
       ) || [],
-    [accountPackages]
+    [accountPackages],
   );
 
   return (
@@ -264,7 +266,7 @@ export default function NewUserForm() {
                 </Typography>
                 <ControlledMultiSelect
                   multiple
-                  name="package_ids"
+                  name="original_package_ids"
                   options={options}
                 />
               </When>

--- a/submit-web/src/hooks/api/useAccountUsers.ts
+++ b/submit-web/src/hooks/api/useAccountUsers.ts
@@ -86,10 +86,11 @@ export const useSaveUserProfile = ({
 type EditUserRequest = {
   role_name: string;
   package_ids?: number[];
+  original_package_ids?: number[];
 };
 export const editUserRole = (
   account_user_id: number,
-  data: EditUserRequest
+  data: EditUserRequest,
 ) => {
   return submitRequest<AccountUserWithRole>({
     url: `/accounts/user/${account_user_id}/role`,
@@ -138,7 +139,7 @@ type EditUserStatusRequest = {
 };
 export const editUserStatus = (
   account_user_id: number,
-  data: EditUserStatusRequest
+  data: EditUserStatusRequest,
 ) => {
   return submitRequest<AccountUserWithRole>({
     url: `/accounts/user/${account_user_id}/status`,
@@ -196,7 +197,7 @@ const recordUserTermsOfService = ({
 };
 
 export const useRecordUserTermsOfService = (
-  options?: UseMutationOptions<any, AxiosError, TermsUpdateRequest>
+  options?: UseMutationOptions<any, AxiosError, TermsUpdateRequest>,
 ) => {
   return useMutation<any, AxiosError, TermsUpdateRequest>({
     mutationFn: recordUserTermsOfService,

--- a/submit-web/src/hooks/api/useInvitations.ts
+++ b/submit-web/src/hooks/api/useInvitations.ts
@@ -25,6 +25,7 @@ type CreateInvitation = {
   email?: string;
   project_ids: number[];
   package_ids?: number[];
+  original_package_ids?: number[];
 };
 
 const createInvitation = ({
@@ -32,6 +33,7 @@ const createInvitation = ({
   proponent_id,
   project_ids,
   package_ids,
+  original_package_ids,
   email,
   role_name,
 }: CreateInvitation) => {
@@ -45,6 +47,7 @@ const createInvitation = ({
       email,
       project_ids,
       package_ids,
+      original_package_ids,
     },
   });
 };

--- a/submit-web/src/hooks/api/useProjects.ts
+++ b/submit-web/src/hooks/api/useProjects.ts
@@ -10,6 +10,7 @@ interface GetPackagesByAccountIdResponse {
     {
       id: number;
       name: string;
+      original_package_id: number;
     },
   ];
 }

--- a/submit-web/src/models/AccountUser.ts
+++ b/submit-web/src/models/AccountUser.ts
@@ -6,6 +6,7 @@ export type Role = {
   account_project_id: number | null;
   account_user_id: number;
   package_ids: number[];
+  original_package_ids: number[];
   package_names: string[];
   role_id: number;
   role_name: USER_MANAGEMENT_ROLE;

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout.tsx
@@ -42,26 +42,19 @@ export const Route = createFileRoute(
       </Grid>
     </PageGrid>
   ),
-  beforeLoad: ({ context: { account }, params: { submissionPackageId } }) => {
+  beforeLoad: ({ context: { account } }) => {
     if (!account || account.isLoading) return;
     if (!account.userManagementRole) {
       return redirect({
         to: "/error",
       });
     }
-    if (
-      account.userManagementRole.role_name ===
-        USER_MANAGEMENT_ROLE.SPECIFIC_SUBMISSION_CONTRIBUTOR &&
-      account.userManagementRole.package_ids?.includes(
-        Number(submissionPackageId),
-      )
-    ) {
-      return;
-    }
+
     if (
       [
         USER_MANAGEMENT_ROLE.PROJECT_ADMIN,
         USER_MANAGEMENT_ROLE.SUBMISSION_ADMIN,
+        USER_MANAGEMENT_ROLE.SPECIFIC_SUBMISSION_CONTRIBUTOR,
       ].includes(account.userManagementRole?.role_name)
     ) {
       return;


### PR DESCRIPTION
This change modifies how user roles are managed, using `original_package_ids` instead of `package_ids` so the collaborators keep their access to all package versions.

- Updates the database schema to include `original_package_ids` in the `user_roles` and `invitations` tables.
- Modifies queries to filter packages based on `original_package_id`.
- Adjusts the user interface and related services to align with the new data model.