### PR TITLE
SUBMIT-457 Handle CORS_ORIGIN env variable without requiring trailing comma

### DIFF
--- a/submit-api/src/submit_api/resources/proponent/account.py
+++ b/submit-api/src/submit_api/resources/proponent/account.py
@@ -15,7 +15,8 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.exceptions import ResourceNotFoundError
@@ -23,7 +24,7 @@ from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.account import AccountCreateSchema, AccountSchema
 from submit_api.schemas.package import AccountPackageSchema
 from submit_api.services.account_service import AccountService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("accounts", description="Endpoints for Account Management")
@@ -50,7 +51,7 @@ class Accounts(Resource):
     @API.response(code=HTTPStatus.OK, description="Success", model=[account_list_model])
     @ApiHelper.swagger_decorators(API, endpoint_description="Fetch all accounts")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get():
         """Fetch all accounts."""
         accounts = AccountService.get_all_accounts()
@@ -63,7 +64,7 @@ class Accounts(Resource):
     @API.response(code=HTTPStatus.CREATED, model=account_list_model, description="Account Created")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post():
         """Create an account."""
         account_data = AccountCreateSchema().load(API.payload)
@@ -82,7 +83,7 @@ class User(Resource):
     @API.response(code=200, model=account_list_model, description="Success")
     @API.response(404, "Not Found")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(proponent_id):
         """Fetch an account by proponent id."""
         account = AccountService.get_account_by_proponent_id(proponent_id)
@@ -106,7 +107,7 @@ class AccountPackages(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(account_id):
         """Get all account packages."""
         account_packages = AccountService.get_all_account_packages(account_id)

--- a/submit-api/src/submit_api/resources/proponent/account_terms_of_service.py
+++ b/submit-api/src/submit_api/resources/proponent/account_terms_of_service.py
@@ -15,14 +15,15 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.exceptions import ResourceNotFoundError
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.models.account_terms_of_service import TermsOfService as TermsOfServiceModel
 from submit_api.schemas.account_terms_of_service import TermsOfServiceSchema
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("terms-of-service", description="Endpoints for Terms of service")
@@ -44,7 +45,7 @@ class TermsOfService(Resource):
     @API.response(code=200, model=terms_of_service_model, description="Success")
     @API.response(404, "Not Found")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get():
         """Fetch active terms of service."""
         terms_of_service = TermsOfServiceModel.get_active_terms_of_service()
@@ -58,7 +59,7 @@ class TermsOfService(Resource):
     @API.response(code=HTTPStatus.CREATED, model=terms_of_service_model, description="Term of service created")
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post():
         """Create a term of service."""
         term_of_service = TermsOfServiceSchema().load(API.payload)

--- a/submit-api/src/submit_api/resources/proponent/account_user.py
+++ b/submit-api/src/submit_api/resources/proponent/account_user.py
@@ -16,14 +16,15 @@
 from http import HTTPStatus
 
 from flask import jsonify, request
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.exceptions import PermissionDeniedError, ResourceNotFoundError
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.account_user import AccountUserSchema, EditRoleSchema, EditTermsOfServiceSchema
 from submit_api.services.account_user_service import AccountUserService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 API = Namespace("accounts", description="Endpoints for Account User Management")
 """Custom exception messages
@@ -49,7 +50,7 @@ class AccountUsers(Resource):
     @API.response(code=HTTPStatus.OK, description="Success", model=[account_user_list_model])
     @API.response(HTTPStatus.NOT_FOUND, "Account not found")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(account_id):
         """Fetch all users of a specific account."""
         include_roles = request.args.get("include_roles", "false").lower() == "true"
@@ -72,7 +73,7 @@ class AccountUser(Resource):
     @API.response(code=HTTPStatus.OK, description="Success", model=[account_user_list_model])
     @API.response(HTTPStatus.NOT_FOUND, "User not found")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(guid):
         """Fetch an user for a user id."""
         user = AccountUserService.get_account_user(guid)
@@ -88,7 +89,7 @@ class AccountUser(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def patch(guid):
         """Edit a account user."""
         edit_account_user_data = AccountUserSchema().load(API.payload)
@@ -109,7 +110,7 @@ class EditUserRole(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def patch(account_user_id):
         """Edit a user's role."""
         user_guid = auth.sub
@@ -137,7 +138,7 @@ class EditUserStatus(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def patch(account_user_id):
         """Edit a user's status."""
         user_guid = auth.sub
@@ -168,7 +169,7 @@ class EditUserTermsOfService(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def patch(account_user_id):
         """Edit a user's terms of service."""
         update_data = EditTermsOfServiceSchema().load(API.payload)

--- a/submit-api/src/submit_api/resources/proponent/activity_log.py
+++ b/submit-api/src/submit_api/resources/proponent/activity_log.py
@@ -15,12 +15,13 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.activity_log import ActivityLogSchema
 from submit_api.services.activity_log_service import ActivityLogService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("activity-logs", description="Endpoints for Activity Log Management")
@@ -45,7 +46,7 @@ class ActivityLog(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(entity_type, entity_id):
         """Retrieve activity logs for a specific entity type and ID."""
         # Retrieve logs

--- a/submit-api/src/submit_api/resources/proponent/invitation.py
+++ b/submit-api/src/submit_api/resources/proponent/invitation.py
@@ -16,7 +16,8 @@
 from http import HTTPStatus
 
 from flask import request
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.enums.role import ProponentPermissionsEnum
@@ -25,7 +26,7 @@ from submit_api.schemas.account import AccountCreateSchema
 from submit_api.schemas.invitation import InvitationSchema, CreateInvitationSchema
 from submit_api.services.invitation_service import InvitationService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 API = Namespace("invitations", description="Endpoints for Invitation Management")
 
@@ -57,7 +58,7 @@ class InvitationsResource(Resource):
     @API.response(HTTPStatus.CONFLICT, "User already exists")
     @auth.require
     @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value, EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post():
         """Generate and persist an invitation token."""
         payload = CreateInvitationSchema().load(request.json)

--- a/submit-api/src/submit_api/resources/proponent/item.py
+++ b/submit-api/src/submit_api/resources/proponent/item.py
@@ -15,13 +15,14 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.item import ItemSchema
 from submit_api.services.item import ItemService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("items", description="Endpoints for item Management")
@@ -46,7 +47,7 @@ class Item(Resource):
         code=HTTPStatus.OK, model=item_model, description="Submission item"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def get(item_id):
         """Get item by id."""

--- a/submit-api/src/submit_api/resources/proponent/package.py
+++ b/submit-api/src/submit_api/resources/proponent/package.py
@@ -15,7 +15,8 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.enums.role import ProponentPermissionsEnum
@@ -24,7 +25,7 @@ from submit_api.schemas.package import PackageSchema, PostPackageRequestSchema, 
     CreateUpdateRequestNoteSchema
 from submit_api.services.package import PackageService
 from submit_api.services import authorization
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("packages", description="Endpoints for Package Management")
@@ -56,7 +57,7 @@ class Package(Resource):
         code=HTTPStatus.OK, model=package_model, description="Submission Package"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def get(package_id):
         """Get package by id."""
@@ -81,7 +82,7 @@ class PackageByAccountProject(Resource):
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
     @auth.has_one_of_roles([ProponentPermissionsEnum.CREATE_PACKAGE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post(account_project_id):
         """Create a submission package."""
         create_package_data = PostPackageRequestSchema().load(API.payload)
@@ -102,7 +103,7 @@ class PackageState(Resource):
         code=HTTPStatus.OK, model=package_model, description="Updated Package"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def post(package_id):
         """Update package state."""
@@ -128,7 +129,7 @@ class PackageUpdateRequestNote(Resource):
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post(package_id, update_request_id):
         """Create an update request note."""
         create_update_request_data = CreateUpdateRequestNoteSchema().load(API.payload)

--- a/submit-api/src/submit_api/resources/proponent/project.py
+++ b/submit-api/src/submit_api/resources/proponent/project.py
@@ -16,7 +16,8 @@
 from http import HTTPStatus
 
 from flask import request, abort
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions
@@ -24,7 +25,7 @@ from submit_api.models.package import PackageStatus, NonCanonicalPackageStatus
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.project import AccountProjectSchema, AddProjectSchema, ProjectSchema
 from submit_api.services.project_service import ProjectService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("projects", description="Endpoints for Project Management")
@@ -53,7 +54,7 @@ class ProjectsByAccount(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(account_id):
         """Get projects by account id."""
         args = request.args
@@ -85,7 +86,7 @@ class ProjectsByAccount(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post(account_id):
         """Add projects in bulk."""
         projects_data = AddProjectSchema().load(API.payload)
@@ -108,7 +109,7 @@ class Project(Resource):
         code=HTTPStatus.OK, model=project_list_model, description="Get project"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(proponent_id):
         """Get projects by proponent id."""
         projects = ProjectService.get_projects_by_proponent_id(proponent_id)
@@ -130,7 +131,7 @@ class Projects(Resource):
         code=HTTPStatus.CREATED, model=project_list_model, description="Get project"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def get(account_project_id):
         """Get projects by proponent id."""
@@ -154,7 +155,7 @@ class ProjectsByAccountUser(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(user_id):
         """Get projects by user id."""
         projects = ProjectService.get_account_projects_by_user_id(user_id)

--- a/submit-api/src/submit_api/resources/proponent/submission.py
+++ b/submit-api/src/submit_api/resources/proponent/submission.py
@@ -15,13 +15,14 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.submission import CreateSubmissionRequestSchema, SubmissionSchema
 from submit_api.services.submission import SubmissionService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 API = Namespace("submissions", description="Endpoints for Submission Management")
 """Custom exception messages
@@ -47,7 +48,7 @@ class SubmissionByItem(Resource):
         code=HTTPStatus.CREATED, model=submission_model, description="Submission"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def post(submission_item_id):
         """Create a submission."""
@@ -68,7 +69,7 @@ class Submissions(Resource):
         code=HTTPStatus.OK, model=submission_model, description="Submission"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def patch(submission_id):
         """Edit a submission."""
@@ -90,7 +91,7 @@ class SubmissionVersions(Resource):
         description="List of submission versions"
     )
     @API.response(HTTPStatus.NOT_FOUND, "Submission not found")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def get(submission_id):
         """Fetch all versions of a submission based on its root submission ID."""
@@ -110,7 +111,7 @@ class DocumentSubmission(Resource):
         code=HTTPStatus.OK, model=submission_model, description="Submission"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def post(submission_id):
         """Replace a submission document."""
@@ -125,7 +126,7 @@ class DocumentSubmission(Resource):
         code=HTTPStatus.OK, model=submission_model, description="Submission"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def delete(submission_id):
         """Delete a submission document."""
@@ -145,7 +146,7 @@ class DocumentSubmissionMove(Resource):
         code=HTTPStatus.OK, model=submission_model, description="Submission moved"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.require
     def post(submission_id):
         """Move a submission document."""

--- a/submit-api/src/submit_api/resources/proponent/user.py
+++ b/submit-api/src/submit_api/resources/proponent/user.py
@@ -15,14 +15,15 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.exceptions import ResourceNotFoundError
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.user import UserSchema
 from submit_api.services.user_service import UserService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("users", description="Endpoints for Account Management")
@@ -45,7 +46,7 @@ class User(Resource):
     @API.response(code=200, model=user_model, description="Success")
     @API.response(404, "Not Found")
     @auth.require
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(guid):
         """Fetch an account by id."""
         user = UserService.get_by_auth_guid(guid)

--- a/submit-api/src/submit_api/resources/staff/activity_log.py
+++ b/submit-api/src/submit_api/resources/staff/activity_log.py
@@ -15,12 +15,13 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.activity_log import ActivityLogSchema
 from submit_api.services.activity_log_service import ActivityLogService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("activity-logs", description="Endpoints for Activity Log Management")
@@ -45,7 +46,7 @@ class ActivityLog(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(entity_type, entity_id):
         """Retrieve activity logs for a specific entity type and ID."""
         logs = ActivityLogService.get_activity_logs(entity_type, entity_id)

--- a/submit-api/src/submit_api/resources/staff/internal_document.py
+++ b/submit-api/src/submit_api/resources/staff/internal_document.py
@@ -15,14 +15,15 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.internal_staff_document import InternalStaffDocumentSchema, PostInternalStaffDocument
 from submit_api.services.internal_staff_document_service import InternalStaffDocumentService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("internal-staff-documents", description="Endpoints for Internal Staff Document Management")
@@ -50,7 +51,7 @@ class InternalStaffDocuments(Resource):
     )
     @API.response(HTTPStatus.NOT_FOUND, "Not found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post(package_id):
         """Create an internal staff document."""
         create_document_data = PostInternalStaffDocument().load(API.payload)
@@ -65,7 +66,7 @@ class InternalStaffDocuments(Resource):
     )
     @API.response(HTTPStatus.NOT_FOUND, "Not found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def delete(internal_staff_document_id):
         """Delete an internal staff document."""
         deleted_document = (InternalStaffDocumentService
@@ -85,7 +86,7 @@ class InternalStaffDocument(Resource):
     )
     @API.response(HTTPStatus.NOT_FOUND, "Not found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def delete(internal_staff_document_id):
         """Delete an internal staff document."""
         deleted_document = (InternalStaffDocumentService

--- a/submit-api/src/submit_api/resources/staff/item.py
+++ b/submit-api/src/submit_api/resources/staff/item.py
@@ -15,7 +15,8 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
@@ -24,7 +25,7 @@ from submit_api.schemas.submission_review import SaveSubmissionReviewRequestSche
 from submit_api.services.item import ItemService
 from submit_api.services.submission_review import SubmissionReviewService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("items", description="Endpoints for item Management")
@@ -49,7 +50,7 @@ class Item(Resource):
         code=HTTPStatus.OK, model=item_model, description="Submission item"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
     def get(item_id):
         """Get item by id."""
@@ -70,7 +71,7 @@ class ItemReview(Resource):
         code=HTTPStatus.OK, model=item_model, description="Submission item review"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
     def post(item_id):
         """Save submission review."""

--- a/submit-api/src/submit_api/resources/staff/package.py
+++ b/submit-api/src/submit_api/resources/staff/package.py
@@ -15,7 +15,8 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
@@ -23,7 +24,7 @@ from submit_api.schemas.package import CreateUpdateRequestSchema, PackageUpdateR
     PackageVersionSchema, CreatePackageVersionSchema, PackageSchema
 from submit_api.services.package import PackageService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("packages", description="Endpoints for Package Management")
@@ -58,7 +59,7 @@ class Package(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(package_id):
         """Get a package."""
         package = PackageService.get_package_by_id(package_id)
@@ -81,7 +82,7 @@ class PackageVersions(Resource):
         code=HTTPStatus.OK, model=package_model, description="Get package versions"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(original_package_id):
         """Get a package."""
         package_versions = PackageService.get_all_package_versions_by_original_package_id(original_package_id)
@@ -94,7 +95,7 @@ class PackageVersions(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
     def post(original_package_id):
         """Create a new package version."""
@@ -122,7 +123,7 @@ class PackageUpdateRequests(Resource):
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post(package_id):
         """Create an update request."""
         create_update_request_data = CreateUpdateRequestSchema().load(API.payload)
@@ -148,7 +149,7 @@ class PackageUpdateRequest(Resource):
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def patch(package_id, update_request_id):
         """Accept an update request."""
         accept_update_request = PackageService.accept_update_request(package_id, update_request_id)

--- a/submit-api/src/submit_api/resources/staff/project.py
+++ b/submit-api/src/submit_api/resources/staff/project.py
@@ -16,7 +16,8 @@
 from http import HTTPStatus
 from flask import request, abort
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions
@@ -25,7 +26,7 @@ from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.project import StaffAccountProjectSchema
 from submit_api.services.project_service import ProjectService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 DEFAULT_PAGE_SIZE = 3
 DEFAULT_PAGE = 1
@@ -51,7 +52,7 @@ class AccountProjects(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get():
         """Get paginated account projects."""
         args = request.args
@@ -105,7 +106,7 @@ class AccountProject(Resource):
         code=HTTPStatus.CREATED, model=project_list_model, description="Get project"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
     def get(account_project_id):
         """Get project by id."""

--- a/submit-api/src/submit_api/resources/staff/proponent.py
+++ b/submit-api/src/submit_api/resources/staff/proponent.py
@@ -16,12 +16,13 @@
 from http import HTTPStatus
 
 from flask import request
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.proponent import ProponentSchema
 from submit_api.services.proponent_service import ProponentService
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("proponents", description="Endpoints for Proponent fetching")
@@ -47,7 +48,7 @@ class Proponents(Resource):
         code=HTTPStatus.OK, model=proponent_model, description="Get proponents"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get():
         """Get all proponents."""
         proponents = ProponentService.get_proponents()
@@ -68,7 +69,7 @@ class Proponent(Resource):
         code=HTTPStatus.OK, model=proponent_model, description="Get proponents"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(proponent_id):
         """Get a proponent by id."""
         include_invitations = request.args.get("include-invitations", "false").lower() == "true"

--- a/submit-api/src/submit_api/resources/staff/staff_user.py
+++ b/submit-api/src/submit_api/resources/staff/staff_user.py
@@ -16,7 +16,8 @@
 from http import HTTPStatus
 
 from flask import request
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.exceptions import ResourceNotFoundError
@@ -24,7 +25,7 @@ from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.staff_user import StaffUserSchema, CreateStaffUserRequest
 from submit_api.services.staff_user_service import StaffUserService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 API = Namespace("staff-user", description="Endpoints for Staff Management")
 """Custom exception messages
@@ -50,7 +51,7 @@ class StaffUser(Resource):
     @API.response(code=200, model=user_model, description="Success")
     @API.response(404, "Not Found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(guid):
         """Fetch a staff by id."""
         staff = StaffUserService.get_staff_by_id(guid)
@@ -71,7 +72,7 @@ class StaffUserCreate(Resource):
     @API.response(code=400, description="Invalid input")
     @API.response(code=500, description="Internal server error")
     @auth.has_one_of_staff_roles([EpicSubmitRole.MANAGE_USERS.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post():
         """Create a staff user and assign a Keycloak role."""
         request_data = request.get_json()

--- a/submit-api/src/submit_api/resources/staff/submission.py
+++ b/submit-api/src/submit_api/resources/staff/submission.py
@@ -15,14 +15,15 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.submission import CreateSubmissionRequestSchema, SubmissionSchema
 from submit_api.services.submission import SubmissionService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 API = Namespace("submissions", description="Endpoints for Submission Management")
 """Custom exception messages
@@ -48,7 +49,7 @@ class DocumentSubmission(Resource):
         code=HTTPStatus.OK, model=submission_model, description="Submission"
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_EDIT.value])
     def delete(submission_id):
         """Delete a submission document."""

--- a/submit-api/src/submit_api/resources/staff/submission_item_note.py
+++ b/submit-api/src/submit_api/resources/staff/submission_item_note.py
@@ -15,14 +15,15 @@
 
 from http import HTTPStatus
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.submission_item_note import PostSubmissionItemNote, SubmissionItemNote
 from submit_api.services.submission_item_note import SubmissionItemNoteService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("notes", description="Endpoints for staff notes")
@@ -50,7 +51,7 @@ class SubmissionItemNoteResource(Resource):
     )
     @API.response(HTTPStatus.NOT_FOUND, "Not found")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def post(submission_item_id):
         """Create a staff note."""
         create_note_data = PostSubmissionItemNote().load(API.payload)

--- a/submit-api/src/submit_api/resources/staff/submitted_document.py
+++ b/submit-api/src/submit_api/resources/staff/submitted_document.py
@@ -16,7 +16,8 @@
 from http import HTTPStatus
 from flask import request
 
-from flask_restx import Namespace, Resource, cors
+from flask_cors import cross_origin
+from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
 from submit_api.models.account_project_search_options import DocumentSearchOptions
@@ -24,7 +25,7 @@ from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.submission import SubmittedDocumentByProjectSchema, SubmissionSchema
 from submit_api.services.submitted_document_service import DocumentService
 from submit_api.utils.roles import EpicSubmitRole
-from submit_api.utils.util import cors_preflight
+from submit_api.utils.util import allowedorigins, cors_preflight
 
 
 API = Namespace("documents", description="Endpoints for Submitted Document Management")
@@ -51,7 +52,7 @@ class AccountDocuments(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get():
         """Get all submitted documents."""
         args = request.args
@@ -79,7 +80,7 @@ class ItemFailedDocuments(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(item_id):
         """Get all failed documents by item id."""
         documents = DocumentService.get_failed_documents_by_item_id(item_id)
@@ -101,7 +102,7 @@ class SubmittedDocuments(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_VIEW.value])
-    @cors.crossdomain(origin="*")
+    @cross_origin(origins=allowedorigins())
     def get(package_id):
         """Get all submitted documents by package id."""
         documents = DocumentService.get_submissions_by_package_id(package_id)

--- a/submit-api/src/submit_api/utils/util.py
+++ b/submit-api/src/submit_api/utils/util.py
@@ -56,12 +56,9 @@ def snake2camelback(snake_dict: dict):
 def allowedorigins():
     """Return allowed origin."""
     _allowedcors = os.getenv('CORS_ORIGIN')
-    allowedcors = []
-    if _allowedcors and ',' in _allowedcors:
-        for entry in re.split(',', _allowedcors):
-            if entry:
-                allowedcors.append(entry)
-    return allowedcors
+    if not _allowedcors:
+        return []
+    return [entry.strip() for entry in re.split(r',\s*', _allowedcors) if entry.strip()]
 
 
 class Singleton(type):


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/SUBMIT-457

- Replaced @cors.crossdomain(origin="*") with @cross_origin(origins=allowedorigins()) across all API endpoints.
- Updated allowedorigins() logic to handle CORS_ORIGIN env variable without requiring a trailing comma.

