### PR TITLE
SUBMIT-625 Adds tests for approving management plan items

### DIFF
--- a/submit-api/tests/unit/resources/test_item_review.py
+++ b/submit-api/tests/unit/resources/test_item_review.py
@@ -263,7 +263,7 @@ def test_review_iem_package(client, session, jwt):
     auth_guid = claims["sub"]
     set_global_token_info(claims)
     factory_user_model(auth_guid=auth_guid)
-    package = factory_package_model(package_type_id=PackageTypeId.IEM.value)
+    package = factory_package_model(package_type_id=PackageTypeId.IEM.value, submitted_to_eao_for='Approval')
     package.submitted_on = fake.date_time_this_year()
     session.add(package)
     session.flush()

--- a/submit-api/tests/unit/resources/test_item_review.py
+++ b/submit-api/tests/unit/resources/test_item_review.py
@@ -78,3 +78,180 @@ def test_create_review_consultation_record_success(client, session, jwt):
     )
     # Validate that the management plan item status is updated to UNDER_REVIEW
     assert mp_item.status == ItemStatus.UNDER_REVIEW
+
+
+def test_approve_management_plan_item_satisfaction(client, session, jwt):
+    """Test approving a management plan item."""
+    claims = TestJwtClaims.staff_admin_role
+    auth_guid = claims["sub"]
+    set_global_token_info(claims)
+    factory_user_model(auth_guid=auth_guid)
+    package = factory_package_model(package_type_id=PackageTypeId.MANAGEMENT_PLAN.value,
+                                    submitted_to_eao_for='Satisfaction')
+    package.submitted_on = fake.date_time_this_year()
+    session.add(package)
+    session.flush()
+    factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONSULTATION_RECORD.value,
+                       status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    mp_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.MANAGEMENT_PLAN_FORM.value,
+                                 status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+
+    session.flush()
+
+    # Generate authentication headers
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    # Payload for the review
+    payload = {
+        "form_answers": {
+            "question_1": "Answer 1",
+            "question_2": "Answer 2"
+        },
+        "status": SubmissionReviewStatus.APPROVED.value,
+        "type": SubmissionReviewEntryType.MANAGER_CONFIRMATION.value
+    }
+
+    # Make the POST request to approve the management plan item
+    response = client.post(
+        f"/api/staff/items/{mp_item.id}/review",
+        json=payload,
+        headers=headers,
+    )
+
+    # Assertions
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+
+    # Validate response against SubmissionReviewSchema
+    schema = SubmissionReviewSchema()
+    deserialized_data = schema.load(data)
+
+    review_form = next(
+        (entry['entry'] for entry in deserialized_data['entries'] if entry['type'].value == payload['type']),
+        None
+    )
+    assert review_form == payload["form_answers"]
+    assert deserialized_data["status"].value == payload["status"]
+    assert deserialized_data["item_id"] == mp_item.id
+
+    # Validate that the management plan item status is updated to APPROVED
+    assert mp_item.status == ItemStatus.SATISFIED
+    assert package.completed_on is not None
+
+
+def test_approve_management_plan_item_acceptance(client, session, jwt):
+    """Test approving a management plan item."""
+    claims = TestJwtClaims.staff_admin_role
+    auth_guid = claims["sub"]
+    set_global_token_info(claims)
+    factory_user_model(auth_guid=auth_guid)
+    package = factory_package_model(package_type_id=PackageTypeId.MANAGEMENT_PLAN.value,
+                                    submitted_to_eao_for='Acceptance')
+    package.submitted_on = fake.date_time_this_year()
+    session.add(package)
+    session.flush()
+    factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONSULTATION_RECORD.value,
+                       status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    mp_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.MANAGEMENT_PLAN_FORM.value,
+                                 status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+
+    session.flush()
+
+    # Generate authentication headers
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    # Payload for the review
+    payload = {
+        "form_answers": {
+            "question_1": "Answer 1",
+            "question_2": "Answer 2"
+        },
+        "status": SubmissionReviewStatus.APPROVED.value,
+        "type": SubmissionReviewEntryType.MANAGER_CONFIRMATION.value
+    }
+
+    # Make the POST request to approve the management plan item
+    response = client.post(
+        f"/api/staff/items/{mp_item.id}/review",
+        json=payload,
+        headers=headers,
+    )
+
+    # Assertions
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+
+    # Validate response against SubmissionReviewSchema
+    schema = SubmissionReviewSchema()
+    deserialized_data = schema.load(data)
+
+    review_form = next(
+        (entry['entry'] for entry in deserialized_data['entries'] if entry['type'].value == payload['type']),
+        None
+    )
+    assert review_form == payload["form_answers"]
+    assert deserialized_data["status"].value == payload["status"]
+    assert deserialized_data["item_id"] == mp_item.id
+
+    # Validate that the management plan item status is updated to APPROVED
+    assert mp_item.status == ItemStatus.ACCEPTED
+    assert package.completed_on is not None
+
+
+def test_approve_management_plan_item_approval(client, session, jwt):
+    """Test approving a management plan item."""
+    claims = TestJwtClaims.staff_admin_role
+    auth_guid = claims["sub"]
+    set_global_token_info(claims)
+    factory_user_model(auth_guid=auth_guid)
+    package = factory_package_model(package_type_id=PackageTypeId.MANAGEMENT_PLAN.value,
+                                    submitted_to_eao_for='Approval')
+    package.submitted_on = fake.date_time_this_year()
+    session.add(package)
+    session.flush()
+    factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONSULTATION_RECORD.value,
+                       status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    mp_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.MANAGEMENT_PLAN_FORM.value,
+                                 status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+
+    session.flush()
+
+    # Generate authentication headers
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    # Payload for the review
+    payload = {
+        "form_answers": {
+            "question_1": "Answer 1",
+            "question_2": "Answer 2"
+        },
+        "status": SubmissionReviewStatus.APPROVED.value,
+        "type": SubmissionReviewEntryType.MANAGER_CONFIRMATION.value
+    }
+
+    # Make the POST request to approve the management plan item
+    response = client.post(
+        f"/api/staff/items/{mp_item.id}/review",
+        json=payload,
+        headers=headers,
+    )
+
+    # Assertions
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+
+    # Validate response against SubmissionReviewSchema
+    schema = SubmissionReviewSchema()
+    deserialized_data = schema.load(data)
+
+    review_form = next(
+        (entry['entry'] for entry in deserialized_data['entries'] if entry['type'].value == payload['type']),
+        None
+    )
+    assert review_form == payload["form_answers"]
+    assert deserialized_data["status"].value == payload["status"]
+    assert deserialized_data["item_id"] == mp_item.id
+
+    # Validate that the management plan item status is updated to APPROVED
+    assert mp_item.status == ItemStatus.APPROVED
+    assert package.completed_on is not None

--- a/submit-api/tests/unit/resources/test_item_review.py
+++ b/submit-api/tests/unit/resources/test_item_review.py
@@ -255,3 +255,60 @@ def test_approve_management_plan_item_approval(client, session, jwt):
     # Validate that the management plan item status is updated to APPROVED
     assert mp_item.status == ItemStatus.APPROVED
     assert package.completed_on is not None
+
+
+def test_review_iem_package(client, session, jwt):
+    """Test reviewing an IEM package."""
+    claims = TestJwtClaims.staff_admin_role
+    auth_guid = claims["sub"]
+    set_global_token_info(claims)
+    factory_user_model(auth_guid=auth_guid)
+    package = factory_package_model(package_type_id=PackageTypeId.IEM.value)
+    package.submitted_on = fake.date_time_this_year()
+    session.add(package)
+    session.flush()
+    factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONSULTATION_RECORD.value,
+                       status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    iem_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.IEM.value,
+                                  status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+
+    session.flush()
+
+    # Generate authentication headers
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    # Payload for the review
+    payload = {
+        "form_answers": {
+            "question_1": "Answer 1",
+            "question_2": "Answer 2"
+        },
+        "status": SubmissionReviewStatus.APPROVED.value,
+        "type": SubmissionReviewEntryType.MANAGER_CONFIRMATION.value
+    }
+
+    # Make the POST request to review the IEM package
+    response = client.post(
+        f"/api/staff/items/{iem_item.id}/review",
+        json=payload,
+        headers=headers,
+    )
+
+    # Assertions
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+
+    # Validate response against SubmissionReviewSchema
+    schema = SubmissionReviewSchema()
+    deserialized_data = schema.load(data)
+
+    review_form = next(
+        (entry['entry'] for entry in deserialized_data['entries'] if entry['type'].value == payload['type']),
+        None
+    )
+    assert review_form == payload["form_answers"]
+    assert deserialized_data["status"].value == payload["status"]
+    assert deserialized_data["item_id"] == iem_item.id
+
+    # Validate that the IEM item status is updated to APPROVED
+    assert iem_item.status == ItemStatus.APPROVED

--- a/submit-api/tests/utilities/factory_utils.py
+++ b/submit-api/tests/utilities/factory_utils.py
@@ -171,7 +171,7 @@ def factory_item_model(package=None, item_type_id=1, status="NEW", submitted_by=
 
 
 def factory_package_model(account_project=None, name=None, status=None, package_type_id=1,
-                          original_package_id=None, version=1):
+                          original_package_id=None, version=1, submitted_to_eao_for=None):
     """Factory package model using hardcoded package_type_id."""
     from submit_api.models.package import Package, PackageStatus
 
@@ -191,11 +191,54 @@ def factory_package_model(account_project=None, name=None, status=None, package_
 
     package_version = create_package_version(package, original_package_id, version)
     package.version_id = package_version.id
-
     db.session.add(package)
+
+    factory_package_metadata_model(package.id, submitted_to_eao_for=submitted_to_eao_for)
+
     db.session.flush()
     db.session.commit()
     return package
+
+
+def factory_package_metadata_model(package_id, metadata: dict = None, submitted_to_eao_for=None):
+    """Factory package metadata model."""
+    from submit_api.models.package_metadata import PackageMetadata
+
+    if not metadata:
+        metadata = {
+            "cc_completed_on": fake.iso8601(),
+            "cc_start_date": fake.iso8601(),
+            "main_condition": {
+                "condition_name": "Construction Environmental Management Plan",
+                "condition_number": fake.random_int(1),
+                "condition_text": fake.text(max_nb_chars=500),
+                "condition_attributes": {
+                    "deliverable_name": ["Construction Environmental Management Plan"],
+                    "milestone_related_to_plan_submission": "Construction",
+                    "milestones_related_to_plan_implementation": ["Operations"],
+                    "parties_required_to_be_consulted": [
+                        "Participating Indigenous Nations", "EMLI", "ENV", "NHA", "MOF"
+                    ],
+                    "requires_consultation": "true",
+                    "requires_iem_terms_of_engagement": "true",
+                    "requires_management_plan": "true",
+                    "submitted_to_eao_for": submitted_to_eao_for or "Satisfaction",
+                    "time_associated_with_submission_milestone": "60",
+                },
+            },
+            "supporting_conditions": [],
+            "review_completed_on": fake.iso8601(),
+            "review_start_date": fake.iso8601(),
+        }
+    package_metadata = PackageMetadata(
+        package_id=package_id,
+        json={
+            **metadata,
+        }
+    )
+    db.session.add(package_metadata)
+    db.session.flush()
+    return package_metadata
 
 
 def create_package_version(package, original_package_id=None, version=1):


### PR DESCRIPTION
Adds tests to verify the approval workflow for management plan items.

- Introduces tests for 'Satisfaction', 'Acceptance', and 'Approval' submission types.
- Verifies the correct status updates and completion timestamps after approval.