### PR TITLE
SUBMIT-591 Adds tests for item review workflows

### DIFF
--- a/submit-api/tests/unit/resources/test_item_review.py
+++ b/submit-api/tests/unit/resources/test_item_review.py
@@ -11,7 +11,7 @@ from submit_api.schemas.submission_review import SubmissionReviewSchema
 from tests.utilities.factory_utils import (
     factory_item_model,
     factory_user_model,
-    factory_auth_header, factory_package_model, set_global_token_info,
+    factory_auth_header, factory_package_model, set_global_token_info, create_contact_info_submission,
 )
 from tests.utilities.factory_scenarios import TestJwtClaims
 
@@ -78,6 +78,62 @@ def test_create_review_consultation_record_success(client, session, jwt):
     )
     # Validate that the management plan item status is updated to UNDER_REVIEW
     assert mp_item.status == ItemStatus.UNDER_REVIEW
+
+
+def test_create_review_consultation_record_fail(client, session, jwt):
+    """Test creating a review for a submission item."""
+    claims = TestJwtClaims.staff_admin_role
+    auth_guid = claims["sub"]
+    set_global_token_info(claims)
+    factory_user_model(auth_guid=auth_guid)
+    package = factory_package_model(package_type_id=PackageTypeId.MANAGEMENT_PLAN.value)
+    package.submitted_on = fake.date_time_this_year()
+    session.add(package)
+    session.flush()
+    cr_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONSULTATION_RECORD.value,
+                                 status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    factory_item_model(package=package, item_type_id=SubmissionItemTypeId.MANAGEMENT_PLAN_FORM.value,
+                       status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+
+    session.flush()
+
+    # Generate authentication headers
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    # Payload for the review
+    payload = {
+        "form_answers": {
+            "passedConsultationCheck": "NO",
+            "reason": fake.paragraph(),
+            "submission_item_types": [SubmissionItemTypeId.CONSULTATION_RECORD.value]
+        },
+        "status": SubmissionReviewStatus.REJECTED.value,
+        "type": SubmissionReviewEntryType.MANAGER_CONFIRMATION.value
+    }
+
+    # Make the POST request to create a review
+    response = client.post(
+        f"/api/staff/items/{cr_item.id}/review",
+        json=payload,
+        headers=headers,
+    )
+
+    # Assertions
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+
+    # Validate response against SubmissionReviewSchema
+    schema = SubmissionReviewSchema()
+    deserialized_data = schema.load(data)
+
+    review_form = next(
+        (entry['entry'] for entry in deserialized_data['entries'] if entry['type'].value == payload['type']),
+        None
+    )
+    assert review_form == payload["form_answers"]
+    assert deserialized_data["status"].value == payload["status"]
+    assert deserialized_data["item_id"] == cr_item.id
+    assert len(package.update_requests) == 1
 
 
 def test_approve_management_plan_item_satisfaction(client, session, jwt):
@@ -312,3 +368,71 @@ def test_review_iem_package(client, session, jwt):
 
     # Validate that the IEM item status is updated to APPROVED
     assert iem_item.status == ItemStatus.APPROVED
+
+
+def test_fail_management_plan_item(client, session, jwt):
+    """Test approving a management plan item."""
+    claims = TestJwtClaims.staff_admin_role
+    auth_guid = claims["sub"]
+    set_global_token_info(claims)
+    factory_user_model(auth_guid=auth_guid)
+    package = factory_package_model(package_type_id=PackageTypeId.MANAGEMENT_PLAN.value,
+                                    submitted_to_eao_for='Satisfaction')
+    package.submitted_on = fake.date_time_this_year()
+    session.add(package)
+    session.flush()
+    contact_info_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONTACT_INFORMATION.value,
+                                           status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    factory_item_model(package=package, item_type_id=SubmissionItemTypeId.CONSULTATION_RECORD.value,
+                       status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    mp_item = factory_item_model(package=package, item_type_id=SubmissionItemTypeId.MANAGEMENT_PLAN_FORM.value,
+                                 status=ItemStatus.SUBMITTED.value, submitted_by=auth_guid)
+    create_contact_info_submission(item_id=contact_info_item.id)
+    session.flush()
+
+    # Generate authentication headers
+    headers = factory_auth_header(jwt=jwt, claims=claims)
+
+    # Payload for the review
+    payload = {
+        "form_answers": {
+            "passed": "NO",
+            "reason": fake.paragraph(),
+            "submission_item_types": [SubmissionItemTypeId.MANAGEMENT_PLAN_FORM.value]
+        },
+        "status": SubmissionReviewStatus.REJECTED.value,
+        "type": SubmissionReviewEntryType.MANAGER_CONFIRMATION.value
+    }
+
+    # Make the POST request to reject the management plan item
+    response = client.post(
+        f"/api/staff/items/{mp_item.id}/review",
+        json=payload,
+        headers=headers,
+    )
+
+    # Assertions
+    assert response.status_code == HTTPStatus.OK
+    data = response.get_json()
+
+    # Validate response against SubmissionReviewSchema
+    schema = SubmissionReviewSchema()
+    deserialized_data = schema.load(data)
+
+    review_form = next(
+        (entry['entry'] for entry in deserialized_data['entries'] if entry['type'].value == payload['type']),
+        None
+    )
+    assert review_form == payload["form_answers"]
+    assert deserialized_data["status"].value == payload["status"]
+    assert deserialized_data["item_id"] == mp_item.id
+    versions_response = client.get(
+        f"/api/staff/packages/{package.version.original_package_id}/versions",
+        json=payload,
+        headers=headers,
+    )
+
+    versions = versions_response.get_json()
+
+    assert versions_response.status_code == HTTPStatus.OK
+    assert len(versions) == 2

--- a/submit-api/tests/utilities/factory_utils.py
+++ b/submit-api/tests/utilities/factory_utils.py
@@ -25,13 +25,14 @@ from flask import g
 from src.submit_api.config import get_named_config
 from submit_api.enums.item_status import ItemStatus
 from submit_api.enums.role import RoleEnum
-from submit_api.models import User, AccountUser, UserRole, Role, PackageVersion
+from submit_api.models import User, AccountUser, UserRole, Role, PackageVersion, Submission, SubmittedForm
 from submit_api.models import db, Item, ItemType
 from submit_api.models.account import Account
 from submit_api.models.account_project import AccountProject
 from submit_api.models.invitations import InvitationStatus
 from submit_api.models.invitations import Invitations
 from submit_api.models.project import Project
+from submit_api.models.submission import SubmissionType, SubmissionStatus
 from submit_api.models.user import UserType
 from tests.utilities.factory_scenarios import TestJwtClaims
 
@@ -304,3 +305,35 @@ def setup_authenticated_proponent(session, jwt, role=RoleEnum.PROJECT_ADMIN.valu
     headers = factory_auth_header(jwt, claims)
 
     return headers, account_project
+
+
+def create_contact_info_submission(
+    item_id
+):
+    """Create a contact information submission."""
+    submitted_form = SubmittedForm(
+        submission_json={
+            'q_1': 'John Doe',  # Replace with actual JSON data
+            'q_2': 'Fake'
+        },  # Replace with actual JSON data
+    )
+    db.session.add(submitted_form)
+    db.session.flush()
+
+    submission = Submission(
+        submitted_form_id=submitted_form.id,  # Replace with the appropriate submitted form ID or None
+        item_id=item_id,  # Assuming package_id corresponds to the item_id
+        type=SubmissionType.FORM,  # Replace with the appropriate SubmissionType
+        submitted_document_id=None,  # Replace with the appropriate document ID or None
+        created_by=fake.uuid4(),  # Replace with the appropriate user ID
+        major_version=1,
+        minor_version=1,
+        active=True,
+        deleted=False,
+        status=SubmissionStatus.SUBMITTED,  # Replace with the appropriate status
+        root_submission_id=None  # Replace with the root submission ID or None
+    )
+    db.session.add(submission)
+    db.session.flush()
+    db.session.commit()
+    return submission

--- a/submit-web/src/routes/need-access.tsx
+++ b/submit-web/src/routes/need-access.tsx
@@ -1,5 +1,11 @@
-import { Box, Link, Stack, Toolbar } from "@mui/material";
-import { Container, Typography } from "@mui/material";
+import {
+  Box,
+  Link,
+  Stack,
+  Toolbar,
+  Container,
+  Typography,
+} from "@mui/material";
 import { createFileRoute } from "@tanstack/react-router";
 import { BCDesignTokens } from "epic.theme";
 import { YellowBar } from "@/components/Shared/YellowBar";


### PR DESCRIPTION
Adds tests to cover different scenarios for item review workflows.

- Includes tests for creating reviews, handling different item statuses, and validation of review responses.
-test coverage for management plan rejection processes.