### PR TITLE
SUBMIT-627 Allow registering multiple projects on the same entity account

### DIFF
--- a/submit-api/src/submit_api/models/account_project.py
+++ b/submit-api/src/submit_api/models/account_project.py
@@ -52,6 +52,11 @@ class AccountProject(BaseModel):
         return cls.query.all()
 
     @classmethod
+    def get_all_in_project_ids(cls, ids):
+        """Get all projects in the given IDs."""
+        return cls.query.filter(cls.project_id.in_(ids)).all()
+
+    @classmethod
     def get_by_account_id(cls, account_id: int) -> AccountProject | None:
         """Return the AccountProject object for the given account_id."""
         return cls.query.filter_by(account_id=account_id).first()

--- a/submit-api/src/submit_api/models/account_project.py
+++ b/submit-api/src/submit_api/models/account_project.py
@@ -59,6 +59,12 @@ class AccountProject(BaseModel):
     @classmethod
     def create_account_project(cls, account_id, project_id, session=None) -> AccountProject:
         """Create account project."""
+        existing_account_project = cls.query.filter_by(
+            account_id=account_id,
+            project_id=project_id
+        ).first()
+        if existing_account_project:
+            return existing_account_project
         account_project = AccountProject(
             account_id=account_id,
             project_id=project_id

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -15,6 +15,30 @@ class ProjectQueries:
     """Query module for complex projects queries"""
 
     @classmethod
+    def get_accessible_account_project_ids_for_user(cls, user):
+        """Return all account_project_ids accessible by the user based on their roles."""
+        if user.type == UserType.STAFF:
+            # Staff can access all projects
+            account_project_ids = db.session.query(AccountProject.id).all()
+            return [ap_id for (ap_id,) in account_project_ids]
+
+        if not user.account_user or not user.account_user.role:
+            return []
+
+        # User roles may be single or multiple, but here we assume one role per user (adjust if needed)
+        user_role = user.account_user.role
+
+        if not user_role.active:
+            return []
+
+        # If user has no assigned account_project_id, allow no projects
+        if not user_role.account_project_id:
+            return []
+
+        # Assuming a single account project for each account now
+        return [user_role.account_project_id]
+
+    @classmethod
     def get_projects_by_proponent_id(cls, proponent_id: int):
         """Find projects by proponent_id"""
         return db.session.query(Project).filter(Project.proponent_id == proponent_id).all()
@@ -40,32 +64,56 @@ class ProjectQueries:
         return account_project_dict
 
     @classmethod
-    def get_filtered_package_ids(cls, search_options: AccountProjectSearchOptions) -> list:
+    def get_filtered_package_ids(cls, search_options: AccountProjectSearchOptions, user: User = None) -> list:
         """Retrieve package IDs based on search filters."""
         package_query = cls._filter_by_search_criteria(search_options)
-        package_query = cls._filter_packages_by_user_access(package_query)
+        package_query = cls._filter_packages_by_user_access(package_query, user)
 
         result = [row[0] for row in package_query.with_entities(
             Package.id).all()] if package_query else None
         return result
 
     @classmethod
+    def _filter_account_projects_by_user_access(cls, query=None, user: User = None):
+        """Filter AccountProjects by all accessible projects of the user."""
+        if user is None:
+            user = User.get_by_guid(TokenInfo.get_id())
+
+        if not user:
+            raise ValueError("User not found.")
+
+        if user.type == UserType.STAFF:
+            return query
+
+        if not user.account_user or not user.account_user.role:
+            # No access if no role
+            return query.filter(False)
+
+        accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
+
+        if query is None:
+            query = db.session.query(AccountProject)
+
+        # Filter projects by accessible project ids
+        query = query.filter(AccountProject.id.in_(accessible_project_ids))
+
+        return query
+
+    @classmethod
     def get_paginated_account_project_ids(cls, account_id: int, filtered_package_ids: list,
-                                          page: int, page_size: int) -> tuple:
+                                          page: int, page_size: int, user: User = None) -> tuple:
         """Retrieve paginated AccountProject IDs based on filtering."""
         query = db.session.query(AccountProject)
 
         if account_id is not None:
-            query = query.filter(AccountProject.account_id == account_id)
+            query = cls._filter_account_projects_by_user_access(query, user)
 
-        # If no filtering applied, return all projects
         if filtered_package_ids is None:
             account_project_ids_query = query.distinct(AccountProject.id)
         else:
             account_project_ids_query = (query.join(Package).filter(Package.id.in_(filtered_package_ids))
                                          .distinct(AccountProject.id))
 
-        # Apply pagination
         if page and page_size:
             paginated_result = (account_project_ids_query.with_entities(AccountProject.id)
                                 .paginate(page=page, per_page=page_size))
@@ -81,14 +129,12 @@ class ProjectQueries:
         account_projects = (
             db.session.query(AccountProject)
             .filter(AccountProject.id.in_(account_project_ids))
-            # Ensure packages are loaded
             .options(joinedload(AccountProject.packages))
         ).all()
 
         schema_class = AccountProjectSchema if is_proponent else StaffAccountProjectSchema
         account_projects_list = schema_class(many=True).dump(account_projects)
 
-        # Filter packages only if filtering was applied
         if filtered_package_ids:
             for account_project in account_projects_list:
                 account_project['packages'] = [package for package in account_project['packages']
@@ -104,15 +150,19 @@ class ProjectQueries:
             page: int = None,
             page_size: int = None,
             is_proponent: bool = True,
+            user: User = None
     ) -> tuple:
         """Main method to orchestrate filtered and paginated retrieval of AccountProjects."""
-        filtered_package_ids = cls.get_filtered_package_ids(search_options)
+        if user is None:
+            user = User.get_by_guid(TokenInfo.get_id())
+
+        filtered_package_ids = cls.get_filtered_package_ids(search_options, user)
 
         account_project_ids, total = cls.get_paginated_account_project_ids(account_id, filtered_package_ids,
-                                                                           page, page_size)
+                                                                           page, page_size, user)
 
         if not account_project_ids:
-            return [], 0  # Return empty list if no matching projects
+            return [], 0
 
         account_projects_list = cls.get_full_account_projects(
             account_project_ids, is_proponent, filtered_package_ids)
@@ -141,10 +191,10 @@ class ProjectQueries:
         return query
 
     @classmethod
-    def _filter_packages_by_user_access(cls, package_query=None):
-        """Filter packages by user access."""
-        auth_guid = TokenInfo.get_id()
-        user = User.get_by_guid(auth_guid)
+    def _filter_packages_by_user_access(cls, package_query=None, user: User = None):
+        """Filter packages by all accessible packages of the user."""
+        if user is None:
+            user = User.get_by_guid(TokenInfo.get_id())
 
         if not user:
             raise ValueError("User not found.")
@@ -152,16 +202,18 @@ class ProjectQueries:
         if user.type == UserType.STAFF:
             return package_query
 
-        if not user.account_user:
-            raise ValueError("User account not found.")
+        if not user.account_user or not user.account_user.role:
+            return package_query.filter(False)
 
         user_role = user.account_user.role
-        if not user_role:
-            raise ValueError("User role not found.")
+
+        if not user_role.active:
+            return package_query.filter(False)
+
         if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value]:
             return package_query
 
-        if package_query is None:
+        if not package_query:
             package_query = db.session.query(Package)
 
         if user_role.original_package_ids:

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -1,3 +1,18 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Model to handle all complex queries related to Account Project."""
+
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload, aliased
 from submit_api.enums.role import RoleEnum

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -1,18 +1,3 @@
-# Copyright © 2024 Province of British Columbia
-#
-# Licensed under the Apache License, Version 2.0 (the "License");
-# you may not use this file except in compliance with the License.
-# You may obtain a copy of the License at
-#
-#     http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
-"""Model to handle all complex queries related to Account Project."""
-
 from sqlalchemy import or_
 from sqlalchemy.orm import joinedload, aliased
 from submit_api.enums.role import RoleEnum
@@ -189,7 +174,7 @@ class ProjectQueries:
 
     @classmethod
     def _filter_by_search_text(cls, query, search_text):
-        """Filter by search text across package name."""
+        """Filter by search text across package and project name."""
         return query.filter(
             or_(
                 Package.name.ilike(f"%{search_text}%"),
@@ -199,7 +184,7 @@ class ProjectQueries:
 
     @classmethod
     def _filter_by_submission_status(cls, query, statuses):
-        """Filter by submission status, with special handling for revision required and update flags."""
+        """Filter by submission status with revision and update handling."""
         revision_required_value = PackageStatus.REVISION_REQUIRED.value
         revision_requested_value = NonCanonicalPackageStatus.REVISION_REQUESTED.value
         update_requested_value = NonCanonicalPackageStatus.UPDATE_REQUESTED.value
@@ -236,7 +221,7 @@ class ProjectQueries:
 
     @classmethod
     def _revision_required_filter(cls, query):
-        """Joins updateRequest with alias and filters for packages requiring revision."""
+        """Filter packages requiring revision."""
         review_request = aliased(UpdateRequest)
         return query.join(
             review_request, review_request.submission_package_id == Package.id
@@ -251,7 +236,7 @@ class ProjectQueries:
 
     @classmethod
     def _update_status_filter(cls, query, include_update_requested, include_updated):
-        """Join updateRequest with alias and apply appropriate update filters."""
+        """Filter packages with update requests."""
         update_request = aliased(UpdateRequest)
         conditions = [
             update_request.type == UpdateRequestType.UPDATE.value,
@@ -270,7 +255,7 @@ class ProjectQueries:
 
     @classmethod
     def _filter_by_submission_dates(cls, query, submitted_on_start, submitted_on_end):
-        """Filter by the submitted_on date range."""
+        """Filter by submission date range."""
         if submitted_on_start:
             query = query.filter(Package.submitted_on >= submitted_on_start)
         if submitted_on_end:

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -146,7 +146,7 @@ class PackageQueries:
             session.add(package)
 
     @classmethod
-    def get_latest_account_project_packages(cls, account_id: int):
+    def get_latest_account_project_packages(cls, account_id: int, account_project_ids: int = None):
         """Fetch project_id and related packages (id, name) for a given account_id.
 
         Only includes packages with the latest version_id matching the highest version
@@ -173,23 +173,24 @@ class PackageQueries:
                         "name", PackageModel.name,
                         "original_package_id", PackageVersion.original_package_id,
                     )
-                ).label('packages')  # Aggregate packages as a JSON array
+                ).label("packages")  # Aggregate packages as a JSON array
             )
             .join(PackageModel, PackageModel.account_project_id == AccountProject.id)
-            .join(
-                PackageVersion,
-                PackageModel.version_id == PackageVersion.id
-            )  # Join with PackageVersion to filter by version_id
-            .join(
-                latest_versions_subquery,
-                PackageModel.version_id == latest_versions_subquery.c.latest_version_id
-            )  # Only fetch packages with the latest version_id
+            .join(PackageVersion,
+                  PackageModel.version_id == PackageVersion.id)  # Join with PackageVersion to filter by version_id
+            .join(latest_versions_subquery,
+                  PackageModel.version_id == latest_versions_subquery.c.latest_version_id)  # Only fetch packages with the latest version_id
             .filter(AccountProject.account_id == account_id)
-            .group_by(AccountProject.project_id)  # Group by project_id
-            .all()
         )
+
+        if account_project_ids:
+            query = query.filter(AccountProject.id.in_(account_project_ids))
+
+        query = query.group_by(AccountProject.project_id)  # Group by project_id
+
+        account_projects = query.all()
 
         return [
             {"project_id": project_id, "account_packages": packages}
-            for project_id, packages in query
+            for project_id, packages in account_projects
         ]

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -179,7 +179,8 @@ class PackageQueries:
             .join(PackageVersion,
                   PackageModel.version_id == PackageVersion.id)  # Join with PackageVersion to filter by version_id
             .join(latest_versions_subquery,
-                  PackageModel.version_id == latest_versions_subquery.c.latest_version_id)  # Only fetch packages with the latest version_id
+                  # Only fetch packages with the latest version_id
+                  PackageModel.version_id == latest_versions_subquery.c.latest_version_id)
             .filter(AccountProject.account_id == account_id)
         )
 

--- a/submit-api/src/submit_api/services/account_service.py
+++ b/submit-api/src/submit_api/services/account_service.py
@@ -8,6 +8,7 @@ from submit_api.models.db import session_scope
 from submit_api.models.queries.package import PackageQueries
 from submit_api.models.user import User as UserModel
 from submit_api.models.user import UserType
+from submit_api.utils.token_info import TokenInfo
 
 
 class AccountService:
@@ -100,4 +101,8 @@ class AccountService:
     @classmethod
     def get_all_account_packages(cls, account_id):
         """Get packages by account id."""
-        return PackageQueries.get_latest_account_project_packages(account_id)
+        user = UserModel.get_by_guid(TokenInfo.get_id())
+        if not user:
+            raise ResourceNotFoundError("User not found")
+        account_project_ids = [user.account_user.role.account_project_id] if user.account_user else None
+        return PackageQueries.get_latest_account_project_packages(account_id, account_project_ids)

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -125,17 +125,19 @@ class InvitationService:
             account_user = InvitationService._create_account_user(
                 user.id, invitation.account_id, payload, session)
 
-            account_project: AccountProjectModel = AccountProjectModel.get_by_account_id(invitation.account_id)
-
-            role = InvitationService._assign_user_role(
-                account_user.id, account_project.id, invitation, session)
-
+            account_projects = AccountProjectModel.get_all_in_project_ids(invitation.project_ids)
+            print(f"Account Projects: {account_projects}")
+            roles = []
+            for account_project in account_projects:
+                role = InvitationService._assign_user_role(
+                    account_user.id, account_project.id, invitation, session)
+                roles.append(role)
             InvitationsModel.mark_used(token, account_user.user_id, session)
 
             return {
                 "message": "User access granted successfully",
                 "user_id": account_user.user_id,
-                "role": role,
+                "roles": roles,
                 "account_id": invitation.account_id,
             }
 
@@ -203,8 +205,8 @@ class InvitationService:
         if not account:
             account_data = {'proponent_id': proponent_id}
             account = AccountModel.create_account(account_data, session)
-            InvitationService._create_account_projects(
-                account.id, project_ids, session)
+        InvitationService._create_account_projects(
+            account.id, project_ids, session)
         return account
 
     @staticmethod

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -126,7 +126,6 @@ class InvitationService:
                 user.id, invitation.account_id, payload, session)
 
             account_projects = AccountProjectModel.get_all_in_project_ids(invitation.project_ids)
-            print(f"Account Projects: {account_projects}")
             roles = []
             for account_project in account_projects:
                 role = InvitationService._assign_user_role(

--- a/submit-api/src/submit_api/services/project_service.py
+++ b/submit-api/src/submit_api/services/project_service.py
@@ -1,3 +1,5 @@
+"""Service for project management."""
+
 from submit_api.exceptions import PermissionDeniedError, BadRequestError
 from submit_api.models import User as UserModel
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions

--- a/submit-api/src/submit_api/services/project_service.py
+++ b/submit-api/src/submit_api/services/project_service.py
@@ -2,6 +2,7 @@
 
 from submit_api.exceptions import PermissionDeniedError, BadRequestError
 from submit_api.models import User as UserModel
+from submit_api.models.account_project import AccountProject as AccountProjectModel
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions
 from submit_api.models.project import Project as ProjectModel
 from submit_api.models.queries.account_project import ProjectQueries
@@ -62,7 +63,6 @@ class ProjectService:
             {"account_id": account_id, "project_id": project.id} for project in projects
         ]
         # Note: bulk add bypasses access control, assumed to be staff-only operation
-        from submit_api.models.account_project import AccountProject as AccountProjectModel
         AccountProjectModel.add_projects_bulk(projects_to_add)
         return projects
 
@@ -76,7 +76,6 @@ class ProjectService:
     @classmethod
     def get_all_account_projects_with_latest_packages(cls):
         """Get all account projects with latest packages."""
-        from submit_api.models.account_project import AccountProject as AccountProjectModel
         return AccountProjectModel.get_all_with_latest_packages()
 
     @classmethod

--- a/submit-api/src/submit_api/services/project_service.py
+++ b/submit-api/src/submit_api/services/project_service.py
@@ -19,8 +19,21 @@ class ProjectService:
     def get_projects_by_account_id(cls, account_id, search_options: AccountProjectSearchOptions = None,
                                    is_proponent=True):
         """Get projects by account id."""
+        guid = TokenInfo.get_id()
+        user = UserModel.get_by_guid(guid)
+
+        if not user:
+            raise PermissionDeniedError("User not found")
+
+        if user.type != UserType.PROPONENT:
+            raise BadRequestError("User is not a certificate holder")
+
+        if user.account_user.account_id != account_id:
+            raise PermissionDeniedError("User does not belong to this account")
+
         projects, _ = ProjectQueries.get_filtered_account_projects_paginated(
-            account_id, search_options, is_proponent)
+            account_id, search_options, None, None, is_proponent, user
+        )
         return projects
 
     @classmethod
@@ -46,17 +59,25 @@ class ProjectService:
         projects_to_add = [
             {"account_id": account_id, "project_id": project.id} for project in projects
         ]
+        # Note: bulk add bypasses access control, assumed to be staff-only operation
+        from submit_api.models.account_project import AccountProject as AccountProjectModel
         AccountProjectModel.add_projects_bulk(projects_to_add)
         return projects
 
     @classmethod
     def get_all_account_projects_paginated(cls, search_options: AccountProjectSearchOptions,
                                            page: int = 1, page_size: int = 10, is_proponent: bool = True):
-        """Get projects by proponent id."""
-        return ProjectQueries.get_filtered_account_projects_paginated(None, search_options, page,
-                                                                      page_size, is_proponent)
+        """Get projects with pagination."""
+        return ProjectQueries.get_filtered_account_projects_paginated(
+            None, search_options, page, page_size, is_proponent)
 
     @classmethod
     def get_all_account_projects_with_latest_packages(cls):
         """Get all account projects with latest packages."""
+        from submit_api.models.account_project import AccountProject as AccountProjectModel
         return AccountProjectModel.get_all_with_latest_packages()
+
+    @classmethod
+    def get_user_accessible_account_project_ids(cls, user):
+        """Get all account project IDs accessible by the user."""
+        return ProjectQueries.get_accessible_account_project_ids_for_user(user)

--- a/submit-api/src/submit_api/services/project_service.py
+++ b/submit-api/src/submit_api/services/project_service.py
@@ -1,10 +1,10 @@
-"""Service for project management."""
-
+from submit_api.exceptions import PermissionDeniedError, BadRequestError
 from submit_api.models import User as UserModel
-from submit_api.models.account_project import AccountProject as AccountProjectModel
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions
 from submit_api.models.project import Project as ProjectModel
 from submit_api.models.queries.account_project import ProjectQueries
+from submit_api.models.user import UserType
+from submit_api.utils.token_info import TokenInfo
 
 
 class ProjectService:

--- a/submit-cron/src/submit_cron/services/invitation_email_service.py
+++ b/submit-cron/src/submit_cron/services/invitation_email_service.py
@@ -76,6 +76,7 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
 
         package_id = package_ids[0]
 
+        # assuming only package ids of one project are provided in one invitation
         return (
             db.session.query(ProjectModel)
             .join(AccountProjectModel, ProjectModel.id == AccountProjectModel.project_id)

--- a/submit-cron/src/submit_cron/services/invitation_email_service.py
+++ b/submit-cron/src/submit_cron/services/invitation_email_service.py
@@ -27,14 +27,11 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
 
         bc_service_card_url = current_app.config.get('BC_SERVICE_CARD_URL', 'https://id.gov.bc.ca')
         project = None
-        project_name = None
 
         if invitation.project_ids:
             project = cls.get_project_from_project_ids(invitation.project_ids)
         elif invitation.package_ids:
             project = cls.get_project_from_package_id(invitation.package_ids)
-        elif invitation.account_id:
-            project = cls.get_project_for_account_id(invitation.account_id)
 
         if not project:
             raise BadRequestError(f"Project was not found for invitation id: {invitation.id}")
@@ -62,6 +59,8 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
     def get_project_from_project_ids(project_ids: str) -> ProjectModel:
         """Return the first matching project from a list of project IDs."""
         project_id_list = [int(pid) for pid in project_ids if isinstance(pid, (int, str)) and str(pid).isdigit()]
+
+        # assuming one project ID is provided in one invitation
         return (
             db.session.query(ProjectModel)
             .filter(ProjectModel.id.in_(project_id_list))

--- a/submit-cron/src/submit_cron/services/invitation_email_service.py
+++ b/submit-cron/src/submit_cron/services/invitation_email_service.py
@@ -26,12 +26,13 @@ class InvitationEmailService:  # pylint: disable=too-few-public-methods
             invitation_action_text = "collaborate on"
 
         bc_service_card_url = current_app.config.get('BC_SERVICE_CARD_URL', 'https://id.gov.bc.ca')
-        project = None
 
         if invitation.project_ids:
             project = cls.get_project_from_project_ids(invitation.project_ids)
         elif invitation.package_ids:
             project = cls.get_project_from_package_id(invitation.package_ids)
+        else:
+            raise BadRequestError("No project or package IDs provided in the invitation.")
 
         if not project:
             raise BadRequestError(f"Project was not found for invitation id: {invitation.id}")

--- a/submit-cron/src/submit_cron/services/package_submission_email_service.py
+++ b/submit-cron/src/submit_cron/services/package_submission_email_service.py
@@ -1,8 +1,8 @@
-from datetime import datetime
 
 from flask import current_app
 from submit_api.data_classes.email_details import EmailDetails
 from submit_api.exceptions import BadRequestError
+from submit_api.models import AccountProject
 from submit_api.models.project import Project as ProjectModel
 from submit_api.models.package import Package as PackageModel
 from submit_api.models.user import User as UserModel
@@ -30,9 +30,9 @@ class PackageSubmissionEmailService:  # pylint: disable=too-few-public-methods
         if not sender_email:
             raise BadRequestError(f"Sender email not found for package type: {package.type.name}")
 
-        project = cls._get_project(submitter.account.proponent_id)
+        project = cls._get_project(submitter.account.account_project_id)
         if not project:
-            raise BadRequestError(f"Proponent with ID {submitter.account.proponent_id} not found")
+            raise BadRequestError(f"Project not found for account project ID: {submitter.account.account_project_id}")
 
         document_submissions = cls._get_document_submissions_from_package(package)
         email_template_name = template_name or MANAGEMENT_PLAN_SUBMISSION_CONFIRMATION_EMAIL_TEMPLATE
@@ -92,6 +92,7 @@ class PackageSubmissionEmailService:  # pylint: disable=too-few-public-methods
         )
 
     @staticmethod
-    def _get_project(proponent_id: int) -> ProjectModel:
-        """Retrieve the Project by proponent ID."""
-        return db.session.query(ProjectModel).filter(ProjectModel.proponent_id == proponent_id).first()
+    def _get_project(account_project_id: int) -> ProjectModel:
+        """Retrieve the project associated with the account project ID."""
+        account_project = db.session.query(AccountProject).filter(AccountProject.id == account_project_id).first()
+        return db.session.query(ProjectModel).filter(ProjectModel.id == account_project.project_id).first()

--- a/submit-web/src/components/registration/createAccountForm/index.tsx
+++ b/submit-web/src/components/registration/createAccountForm/index.tsx
@@ -48,7 +48,7 @@ const createAccountSchema = yup.object().shape({
     .test(
       "phone-validation",
       "Please enter a complete phone number in this format: (xxx) xxx-xxxx.",
-      validatePhoneNumber
+      validatePhoneNumber,
     ),
   email: yup
     .string()
@@ -90,14 +90,14 @@ function CreateAccountForm() {
   }, [userId, navigateToNextStep]);
 
   const { data: projects } = useLoadProjectsByProponentId(
-    invitation?.proponent_id
+    invitation?.proponent_id,
   );
 
   const onCreateAccountSuccess = (data: AcceptInvitationResponse) => {
     setAccount({
       userId: data.user_id,
-      userManagementRole: data.role,
-      roles: data.role.permissions,
+      userManagementRole: data.roles[0],
+      roles: data.roles[0].permissions,
       userType: USER_TYPE.PROPONENT,
       accountId: data.account_id,
     });

--- a/submit-web/src/hooks/api/useInvitations.ts
+++ b/submit-web/src/hooks/api/useInvitations.ts
@@ -81,7 +81,7 @@ type CreateAccountRequest = {
 export type AcceptInvitationResponse = {
   message: string;
   user_id: number;
-  role: Role;
+  roles: Role[];
   account_id: number;
 };
 

--- a/submit-web/src/store/accountStore.ts
+++ b/submit-web/src/store/accountStore.ts
@@ -17,6 +17,7 @@ export type AccountStoreState = {
   hasAgreedToTerms: boolean;
   roles?: string[];
   userManagementRole?: Role;
+  userManagementRoles?: Role[];
   error?: AxiosError;
 };
 


### PR DESCRIPTION
Implements registering multiple projects on the same entity account:

- Introduces granular access control for projects and packages based on user roles.
- Supports multi-project assignments during invitation acceptance.
- Filters package queries to return only packages accessible to the current user.