### PR TITLE
SUBMIT-627 Enforces project-level authorization

### DIFF
--- a/submit-api/src/submit_api/models/account_project.py
+++ b/submit-api/src/submit_api/models/account_project.py
@@ -62,6 +62,11 @@ class AccountProject(BaseModel):
         return cls.query.filter_by(account_id=account_id).first()
 
     @classmethod
+    def get_by_project_id(cls, project_id: int) -> AccountProject | None:
+        """Return the AccountProject object for the given project_id."""
+        return cls.query.filter_by(project_id=project_id).first()
+
+    @classmethod
     def create_account_project(cls, account_id, project_id, session=None) -> AccountProject:
         """Create account project."""
         existing_account_project = cls.query.filter_by(

--- a/submit-api/src/submit_api/resources/proponent/invitation.py
+++ b/submit-api/src/submit_api/resources/proponent/invitation.py
@@ -130,7 +130,7 @@ class ResendInvitationResource(Resource):
     @API.response(HTTPStatus.NO_CONTENT, "Invitation resent")
     @API.response(HTTPStatus.NOT_FOUND, "Invitation not found")
     @auth.require
-    @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value, EpicSubmitRole.PROPONENT_CREATE.value])
+    @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value])
     def post(invitation_id):
         """Resend an invitation token."""
         invitation = InvitationService.get_invitation_by_id(invitation_id)
@@ -150,7 +150,7 @@ class InvitationByIdResource(Resource):
     @API.response(HTTPStatus.OK, "Invitation found")
     @API.response(HTTPStatus.NOT_FOUND, "Invitation not found")
     @auth.require
-    @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value, EpicSubmitRole.PROPONENT_CREATE.value])
+    @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value])
     def get(invitation_id):
         """Retrieve invitation by ID."""
         invitation = InvitationService.get_invitation_by_id(invitation_id)
@@ -163,7 +163,7 @@ class InvitationByIdResource(Resource):
     @API.response(HTTPStatus.NO_CONTENT, "Invitation revoked")
     @API.response(HTTPStatus.NOT_FOUND, "Invitation not found")
     @auth.require
-    @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value, EpicSubmitRole.PROPONENT_CREATE.value])
+    @auth.has_one_of_roles([ProponentPermissionsEnum.INVITE_USERS.value])
     def delete(invitation_id):
         """Revoke an invitation by ID."""
         invitation = InvitationService.get_invitation_by_id(invitation_id)

--- a/submit-api/src/submit_api/resources/proponent/package.py
+++ b/submit-api/src/submit_api/resources/proponent/package.py
@@ -19,7 +19,6 @@ from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
 from submit_api.auth import auth
-from submit_api.enums.role import ProponentPermissionsEnum
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.package import PackageSchema, PostPackageRequestSchema, PostPackageState, \
     CreateUpdateRequestNoteSchema

--- a/submit-api/src/submit_api/resources/proponent/package.py
+++ b/submit-api/src/submit_api/resources/proponent/package.py
@@ -81,7 +81,6 @@ class PackageByAccountProject(Resource):
     )
     @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
     @auth.require
-    @auth.has_one_of_roles([ProponentPermissionsEnum.CREATE_PACKAGE.value])
     @cross_origin(origins=allowedorigins())
     def post(account_project_id):
         """Create a submission package."""

--- a/submit-api/src/submit_api/services/authorization.py
+++ b/submit-api/src/submit_api/services/authorization.py
@@ -17,19 +17,29 @@ from submit_api.models.user import UserType
 from submit_api.utils.token_info import TokenInfo
 
 
-# pylint: disable=unused-argument
-def check_has_permission(required_permissions):
-    """Check if user is authorized to perform action on the service."""
-    user = UserModel.get_by_guid(TokenInfo.get_id())
+def check_has_permissions_on_project(permissions, account_project_id):
+    """Check if user is assigned to the project."""
+    if not account_project_id:
+        abort(HTTPStatus.BAD_REQUEST)
+
+    user: UserModel = UserModel.get_by_guid(TokenInfo.get_id())
+    if user.type == UserType.STAFF:
+        return
     if not user or not user.account_user or not user.account_user.role:
         abort(HTTPStatus.UNAUTHORIZED)
 
-    user_permissions = set(user.account_user.role.permissions)
-    has_valid_permissions = user_permissions & set(required_permissions)
+    account_user: AccountUserModel = user.account_user
+    user_role: UserRoleModel = account_user.role
+
+    if user_role.account_project_id != account_project_id:
+        abort(HTTPStatus.FORBIDDEN)
+
+    user_permissions = set(user_role.permissions)
+    has_valid_permissions = user_permissions & set(permissions)
     if not has_valid_permissions:
         abort(HTTPStatus.FORBIDDEN)
 
-    return True
+    return
 
 
 def check_assigned_on_package(package_id):

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -17,10 +17,8 @@ from submit_api.models.account_terms_of_service import TermsOfService as TermsOf
 from submit_api.models.user import UserType
 from submit_api.services import authorization
 from submit_api.services.account_user_service import AccountUserService
-from submit_api.services.authorization import check_has_permissions_on_project
 from submit_api.services.user_service import UserService
 from submit_api.utils.constants import NEW_USER_INVITATION_EMAIL_TEMPLATE
-from submit_api.utils.roles import EpicSubmitRole
 from submit_api.utils.token_info import TokenInfo
 from submit_api.models.user_role import UserRole as UserRoleModel
 
@@ -53,7 +51,7 @@ class InvitationService:
         return None
 
     @staticmethod
-    def _check_action_authorized(project_ids, permissions):
+    def _check_action_authorized(project_ids, permissions=None):
         """Check if the user has permissions on the provided project IDs."""
         account_projects = AccountProjectModel.get_by_project_ids(project_ids)
         if not account_projects:

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -4,7 +4,7 @@ import uuid
 from urllib.parse import urljoin
 from flask import current_app
 
-from submit_api.enums.role import RoleEnum
+from submit_api.enums.role import RoleEnum, ProponentPermissionsEnum
 from submit_api.exceptions import ResourceNotFoundError
 from submit_api.models import AccountProject as AccountProjectModel, User
 from submit_api.models.account import Account as AccountModel
@@ -15,9 +15,12 @@ from submit_api.models.invitations import Invitations as InvitationsModel, Invit
 from submit_api.models.role import Role as RoleModel
 from submit_api.models.account_terms_of_service import TermsOfService as TermsOfServiceModel
 from submit_api.models.user import UserType
+from submit_api.services import authorization
 from submit_api.services.account_user_service import AccountUserService
+from submit_api.services.authorization import check_has_permissions_on_project
 from submit_api.services.user_service import UserService
 from submit_api.utils.constants import NEW_USER_INVITATION_EMAIL_TEMPLATE
+from submit_api.utils.roles import EpicSubmitRole
 from submit_api.utils.token_info import TokenInfo
 from submit_api.models.user_role import UserRole as UserRoleModel
 
@@ -50,6 +53,19 @@ class InvitationService:
         return None
 
     @staticmethod
+    def _check_action_authorized(project_ids, permissions):
+        """Check if the user has permissions on the provided project IDs."""
+        account_projects = AccountProjectModel.get_by_project_ids(project_ids)
+        if not account_projects:
+            raise ResourceNotFoundError("No projects found for the provided IDs.")
+
+        # assume one project for now, can be extended for multiple projects
+        authorization.check_has_permissions_on_project(
+            permissions=permissions or [ProponentPermissionsEnum.INVITE_USERS.value],
+            account_project_id=account_projects[0].id if account_projects else None
+        )
+
+    @staticmethod
     def create_invitation(invite_data):
         """Create and persist a new invitation token."""
         email = invite_data.get('email')
@@ -69,6 +85,8 @@ class InvitationService:
         role_name = invite_data.get('role_name')
         proponent_id = invite_data.get('proponent_id')
         project_ids = invite_data.get('project_ids')
+
+        InvitationService._check_action_authorized(project_ids)
 
         role = InvitationService._validate_fetch_role(role_name)
 
@@ -152,6 +170,7 @@ class InvitationService:
     def get_invitation_by_id(invitation_id):
         """Retrieve an invitation by invitation_id."""
         invitation = InvitationsModel.find_by_id(invitation_id)
+        InvitationService._check_action_authorized(invitation.project_ids)
         InvitationService._validate_invitation_access(invitation)
         return invitation
 
@@ -314,6 +333,7 @@ class InvitationService:
         """Revoke an invitation by updating its status."""
         invitation = InvitationsModel.query.filter_by(
             token=token, status=InvitationStatus.PENDING.value).first()
+        InvitationService._check_action_authorized(invitation.project_ids)
         if invitation:
             invitation.status = InvitationStatus.REVOKED.value
             InvitationsModel.commit()
@@ -326,6 +346,7 @@ class InvitationService:
         with session_scope() as session:
             invitation = InvitationsModel.query.filter_by(token=token).first()
 
+            InvitationService._check_action_authorized(invitation.project_ids)
             if not invitation or invitation.status != InvitationStatus.PENDING.value:
                 return False
 

--- a/submit-api/src/submit_api/services/package.py
+++ b/submit-api/src/submit_api/services/package.py
@@ -53,6 +53,10 @@ class PackageService:
     @classmethod
     def create_first_package(cls, account_project_id, request_data):
         """Create a new package."""
+        authorization.check_has_permissions_on_project(
+            [ProponentPermissionsEnum.CREATE_PACKAGE.value],
+            account_project_id
+        )
         with session_scope() as session:
             package_type = PackageTypeModel.find_by_name(
                 request_data.get("type"))
@@ -343,9 +347,12 @@ class PackageService:
     def submit_package(cls, package_id):
         """Submit the package by updating its status and items."""
         cls._validate_account_user()
-        authorization.check_has_permission([ProponentPermissionsEnum.SUBMIT_PACKAGE.value])
         with session_scope() as session:
             package = cls._get_and_validate_complete_package(package_id)
+            authorization.check_has_permissions_on_project(
+                permissions=[ProponentPermissionsEnum.SUBMIT_PACKAGE.value],
+                account_project_id=package.account_project_id
+            )
             if package.submitted_on:
                 submitted_package: PackageModel = cls._resubmit_package(package, session)
             else:

--- a/submit-api/src/submit_api/utils/roles.py
+++ b/submit-api/src/submit_api/utils/roles.py
@@ -22,5 +22,4 @@ class EpicSubmitRole(Enum):
     EAO_VIEW = "eao_view"
     EAO_CREATE = "eao_create"
     EXTENDED_EAO_EDIT = "extended_eao_edit"
-    PROPONENT_CREATE = "proponent_create"
     MANAGE_USERS = "manage-users"

--- a/submit-web/src/components/UserManagement/staff/ProjectsTable/RegistrationUrlCell.tsx
+++ b/submit-web/src/components/UserManagement/staff/ProjectsTable/RegistrationUrlCell.tsx
@@ -31,7 +31,7 @@ export const RegistrationUrlCell = ({
       ? usedProjectInvitations.sort(
           (a, b) =>
             new Date(b.created_date).getTime() -
-            new Date(a.created_date).getTime()
+            new Date(a.created_date).getTime(),
         )[0]
       : null;
 

--- a/submit-web/src/models/Role.tsx
+++ b/submit-web/src/models/Role.tsx
@@ -2,8 +2,7 @@ export type EpicSubmitRole =
   | "eao_edit"
   | "eao_view"
   | "eao_create"
-  | "extended_eao_edit"
-  | "proponent_create";
+  | "extended_eao_edit";
 
 export const EPIC_SUBMIT_ROLE = Object.freeze<
   Record<EpicSubmitRole, EpicSubmitRole>
@@ -12,7 +11,6 @@ export const EPIC_SUBMIT_ROLE = Object.freeze<
   eao_view: "eao_view",
   eao_create: "eao_create",
   extended_eao_edit: "extended_eao_edit",
-  proponent_create: "proponent_create",
 });
 
 export enum USER_MANAGEMENT_ROLE {


### PR DESCRIPTION
Improves security by enforcing project-level authorization for key API endpoints.

- Removes unused `PROPONENT_CREATE` role
- Introduces `check_has_permissions_on_project` to verify user authorization based on the project.
- Updates Invitation and Package services to use project-level authorization.