### PR TITLE
SUBMIT-630 Enables account project ID based invitations

### DIFF
--- a/submit-api/src/submit_api/models/account_project.py
+++ b/submit-api/src/submit_api/models/account_project.py
@@ -52,6 +52,11 @@ class AccountProject(BaseModel):
         return cls.query.all()
 
     @classmethod
+    def get_all_in_ids(cls, ids):
+        """Get all projects in the given IDs."""
+        return cls.query.filter(cls.id.in_(ids)).all()
+
+    @classmethod
     def get_all_in_project_ids(cls, ids):
         """Get all projects in the given IDs."""
         return cls.query.filter(cls.project_id.in_(ids)).all()

--- a/submit-api/src/submit_api/schemas/invitation.py
+++ b/submit-api/src/submit_api/schemas/invitation.py
@@ -12,7 +12,8 @@ class CreateInvitationSchema(Schema):
 
     proponent_id = fields.Int(required=True, description="Proponent ID")
     account_id = fields.Int(required=False, description="Account ID")
-    project_ids = fields.List(fields.Int(), required=True, description="List of Project IDs")
+    project_ids = fields.List(fields.Int(), required=False, description="List of Project IDs")
+    account_project_ids = fields.List(fields.Int(), required=False, description="List of Account Project IDs")
     role_name = fields.Str(required=True, description="Role Name")
     package_ids = fields.List(fields.Int(), required=False, allow_none=True)
     original_package_ids = fields.List(fields.Int(),

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -51,13 +51,18 @@ class InvitationService:
         return None
 
     @staticmethod
-    def _check_action_authorized(project_ids, permissions=None):
+    def _check_action_authorized(project_ids, account_projects=None, permissions=None):
         """Check if the user has permissions on the provided project IDs."""
-        account_projects = AccountProjectModel.get_all_in_project_ids(project_ids)
+        if not account_projects:
+            account_projects = AccountProjectModel.get_all_in_project_ids(project_ids)
+            account_project_ids = [ap.id for ap in account_projects]
+        else:
+            account_project_ids = [ap.id for ap in account_projects]
+
         # assume one project for now, can be extended for multiple projects
         authorization.check_has_permissions_on_project(
             permissions=permissions or [ProponentPermissionsEnum.INVITE_USERS.value],
-            account_project_id=account_projects[0].id if account_projects else None
+            account_project_id=account_project_ids[0] if account_project_ids else None
         )
 
     @staticmethod
@@ -80,8 +85,18 @@ class InvitationService:
         role_name = invite_data.get('role_name')
         proponent_id = invite_data.get('proponent_id')
         project_ids = invite_data.get('project_ids')
+        account_project_ids = invite_data.get('account_project_ids')
+        account_projects = None
 
-        InvitationService._check_action_authorized(project_ids)
+        if not project_ids and not account_project_ids:
+            raise ResourceNotFoundError("No project IDs or account project IDs provided.")
+
+        if not project_ids and account_project_ids:
+            account_projects = AccountProjectModel.get_all_in_ids(account_project_ids)
+            project_ids = [ap.project_id for ap in account_projects]
+            invite_data['project_ids'] = project_ids
+
+        InvitationService._check_action_authorized(project_ids, account_projects=account_projects)
 
         role = InvitationService._validate_fetch_role(role_name)
 

--- a/submit-web/src/components/UserManagement/entity/NewUser/NewUserForm.tsx
+++ b/submit-web/src/components/UserManagement/entity/NewUser/NewUserForm.tsx
@@ -50,7 +50,7 @@ const newUser = yup.object().shape({
 type NewUserSchema = yup.InferType<typeof newUser>;
 
 export default function NewUserForm() {
-  const { accountId, proponentId } = useAccount();
+  const { accountId, proponentId, userManagementRole } = useAccount();
   const navigate = useNavigate();
   const { setOpen: setOpenModal, setClose: closeModal } = useModal();
 
@@ -130,29 +130,21 @@ export default function NewUserForm() {
 
   const selectedRole = watch("role_name");
 
-  const getProjectIds = () => {
-    const packageIds = watch("original_package_ids") || [];
-    const isSpecificSubmission =
-      selectedRole === USER_MANAGEMENT_ROLE.SPECIFIC_SUBMISSION_CONTRIBUTOR;
-    return (
-      accountPackages
-        ?.filter(
-          ({ packages }) =>
-            !isSpecificSubmission ||
-            packages.some(({ id }) => packageIds.includes(id.toString())),
-        )
-        .map(({ project_id }) => Number(project_id)) || []
-    );
-  };
-
   const handleCompleteForm = (formData: NewUserSchema) => {
     const { email, role_name, original_package_ids } = formData;
+    const account_project_id = userManagementRole?.account_project_id;
+
+    if (!account_project_id) {
+      notify.error("Error: you do not have access to any project.");
+      return;
+    }
+
     const request = {
       proponent_id: proponentId,
       account_id: accountId,
       role_name,
       email,
-      project_ids: getProjectIds(),
+      account_project_ids: [account_project_id],
       original_package_ids: original_package_ids
         ? original_package_ids.map(Number)
         : undefined,

--- a/submit-web/src/hooks/api/useInvitations.ts
+++ b/submit-web/src/hooks/api/useInvitations.ts
@@ -23,7 +23,8 @@ type CreateInvitation = {
   proponent_id: number;
   role_name: string;
   email?: string;
-  project_ids: number[];
+  project_ids?: number[];
+  account_project_ids?: number[];
   package_ids?: number[];
   original_package_ids?: number[];
 };
@@ -32,6 +33,7 @@ const createInvitation = ({
   account_id,
   proponent_id,
   project_ids,
+  account_project_ids,
   package_ids,
   original_package_ids,
   email,
@@ -48,6 +50,7 @@ const createInvitation = ({
       project_ids,
       package_ids,
       original_package_ids,
+      account_project_ids,
     },
   });
 };


### PR DESCRIPTION
Allows invitations to be created using account project IDs instead of project IDs. 

- Adds support for `account_project_ids` in the invitation schema and API.
- Modifies the invitation service to handle both `project_ids` and `account_project_ids`.
- Updates the web application to send the `account_project_id` when creating an invitation.