### PR TITLE
SUBMIT-636 Fix banner on older package versions for proponent

### DIFF
--- a/submit-api/tests/unit/resources/test_proponent.py
+++ b/submit-api/tests/unit/resources/test_proponent.py
@@ -14,7 +14,11 @@ from tests.utilities.factory_utils import (
 
 def test_get_all_proponents(client, session):
     """Test all get proponents."""
-    factory_project_with_proponent(proponent_id=1234, proponent_name="TestProponent")
+    factory_project_with_proponent(
+        proponent_id=1234,
+        proponent_name="TestProponent",
+        has_approved_condition=True,
+    )
 
     response = client.get("/api/staff/proponents")
 

--- a/submit-api/tests/unit/resources/test_proponent.py
+++ b/submit-api/tests/unit/resources/test_proponent.py
@@ -14,11 +14,7 @@ from tests.utilities.factory_utils import (
 
 def test_get_all_proponents(client, session):
     """Test all get proponents."""
-    factory_project_with_proponent(
-        proponent_id=1234,
-        proponent_name="TestProponent",
-        has_approved_condition=True,
-    )
+    factory_project_with_proponent(proponent_id=1234, proponent_name="TestProponent")
 
     response = client.get("/api/staff/proponents")
 

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -84,9 +84,10 @@ export default function SubmissionPage() {
   );
 
   const isNewerThanLastApprovedButNotApproved = Boolean(
-    latestApprovedVersion > 0 &&
+    (latestApprovedVersion > 0 &&
       !submissionPackage?.version?.is_approved &&
-      (submissionPackage?.version?.version ?? 0) > latestApprovedVersion,
+      submissionPackage?.version?.version) ??
+      0 > latestApprovedVersion,
   );
 
   const {


### PR DESCRIPTION
Ticket: https://eao-dst.atlassian.net/browse/SUBMIT-636

- Aligned the logic with the staff side to ensure the correct banner is displayed for proponents when viewing older packages.