### PR TITLE
CENTR-48:Approve/Deny Request from email

### DIFF
--- a/submit-cron/templates/centre/access_request_received_notification.html
+++ b/submit-cron/templates/centre/access_request_received_notification.html
@@ -82,15 +82,13 @@
       </div>
 
       <p>This user is requesting access to <strong>{{ application_name }}</strong>.</p>
-      <p>Please review this request based on the user's role and responsibilities.</p>
+      <p>Please click the link below to review this request based on the user’s role and responsibilities.</p>
 
       <div class="grey-box">
         <a href="{{ auth_link }}">Review Request in EPIC.centre</a>
       </div>
 
-      <p>If you approve this request, the user will receive an automatic notification when their access level changes.</p>
-
-      <p>Please action this request within 5 business days. If no action is taken, a reminder will be sent.</p>
+      <p>A confirmation email will be sent to the requester when their access level is updated in EPIC.centre.</p>
 
       <p>Thank you,</p>
     </div>


### PR DESCRIPTION
Description:
Approve or deny an access request from a link in an email so that admins can quickly process requests without navigating to the request queue.

Changes Included :
- Added a link to the User Profile
    - Link text: Review Request in EPIC.centre
- Updated the instructional line above the link
    - Changed to:
    - “Please click the link below to review this request based on the user’s role and responsibilities.”
- Updated the paragraphs below the link
    - Replaced the previous text with:
    - “A confirmation email will be sent to the requester when their access level is updated in EPIC.centre.”
- Removed the line about the reminder email.