### PR TITLE
CENTR-86:Access Request Email should specify environment (Dev/Test/Prod)

### DIFF
--- a/submit-cron/config.py
+++ b/submit-cron/config.py
@@ -108,6 +108,8 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     CONDITION_API_BASE_URL = os.getenv('CONDITION_API_BASE_URL')
 
+    ENVIRONMENT = os.getenv('ENVIRONMENT', os.getenv('ENV_NAME', ''))
+
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
     """Dev Config."""

--- a/submit-cron/src/submit_cron/services/ches_service.py
+++ b/submit-cron/src/submit_cron/services/ches_service.py
@@ -1,6 +1,7 @@
 """Service for integrating with the Common Hosted Email Service."""
 import base64
 import json
+import os
 from datetime import datetime, timedelta
 
 import requests
@@ -76,6 +77,20 @@ class ChesApiService:
         # this is like submit web hosts the logo and the email uses it as a static server to get the logo image.
         body_args['logo_url'] = f'{current_app.config.get("WEB_URL")}/assets/EAO_Logo-BZOR9oRj.png'
         rendered_body = template.render(body_args)
+
+        # Append environment message for centre templates
+        if template_sub_directory == 'centre':
+            env_name = os.getenv('ENVIRONMENT', os.getenv('ENV_NAME', ''))
+            if env_name and env_name.lower() != 'production':
+                env_message = f'''
+    <div style="background-color: #fff3cd; border: 1px solid #ffc107; padding: 10px; margin: 20px 0; text-align: center; font-size: 14px; color: #856404;">
+      <strong>You are using {env_name} environment</strong>
+    </div>
+'''
+                if '</body>' in rendered_body:
+                    rendered_body = rendered_body.replace('</body>', env_message + '  </body>')
+                else:
+                    rendered_body += env_message
 
         return rendered_body
 

--- a/submit-cron/src/submit_cron/services/ches_service.py
+++ b/submit-cron/src/submit_cron/services/ches_service.py
@@ -1,7 +1,6 @@
 """Service for integrating with the Common Hosted Email Service."""
 import base64
 import json
-import os
 from datetime import datetime, timedelta
 
 import requests
@@ -64,7 +63,7 @@ class ChesApiService:
 
     @staticmethod
     def _get_email_body_from_template(template_name: str, body_args: dict, template_sub_directory: str = None):
-        """Get email body from a template."""
+        """Get email body from a template with optional environment message for centre templates."""
         if not template_name:
             raise ValueError('Template name is required')
 
@@ -78,21 +77,32 @@ class ChesApiService:
         body_args['logo_url'] = f'{current_app.config.get("WEB_URL")}/assets/EAO_Logo-BZOR9oRj.png'
         rendered_body = template.render(body_args)
 
-        # Append environment message for centre templates
+        # Add environment notification for centre templates in non-production
         if template_sub_directory == 'centre':
-            env_name = os.getenv('ENVIRONMENT', os.getenv('ENV_NAME', ''))
+            env_name = current_app.config.get('ENVIRONMENT', '')
             if env_name and env_name.lower() != 'production':
-                env_message = f'''
-                    <div style="background-color: #fff3cd; border: 1px solid #ffc107; padding: 10px; margin: 20px 0; text-align: center; font-size: 14px; color: #856404;">
-                    <strong>You are using {env_name} environment</strong>
-                    </div>
-                '''
-                if '</body>' in rendered_body:
-                    rendered_body = rendered_body.replace('</body>', env_message + '  </body>')
-                else:
-                    rendered_body += env_message
+                env_message = ChesApiService._create_environment_banner(env_name)
+                rendered_body = ChesApiService._inject_environment_banner(rendered_body, env_message)
 
         return rendered_body
+
+    @staticmethod
+    def _create_environment_banner(env_name: str) -> str:
+        """Create HTML banner showing the current environment."""
+        return f'''
+            <div style="background-color: #fff3cd; border: 1px solid #ffc107; padding: 10px; 
+                        margin: 20px 0; text-align: center; font-size: 14px; color: #856404;">
+                <strong>You are using {env_name} environment</strong>
+            </div>
+        '''
+
+    @staticmethod
+    def _inject_environment_banner(rendered_body: str, env_message: str) -> str:
+        """Inject environment banner into the email body."""
+        if '</body>' in rendered_body:
+            return rendered_body.replace('</body>', f'{env_message}</body>')
+        else:
+            return rendered_body + env_message
 
     def _get_email_body(self, email_details: EmailDetails, template_sub_directory: str = None):
         """Get email body based on details or template."""

--- a/submit-cron/src/submit_cron/services/ches_service.py
+++ b/submit-cron/src/submit_cron/services/ches_service.py
@@ -83,10 +83,10 @@ class ChesApiService:
             env_name = os.getenv('ENVIRONMENT', os.getenv('ENV_NAME', ''))
             if env_name and env_name.lower() != 'production':
                 env_message = f'''
-    <div style="background-color: #fff3cd; border: 1px solid #ffc107; padding: 10px; margin: 20px 0; text-align: center; font-size: 14px; color: #856404;">
-      <strong>You are using {env_name} environment</strong>
-    </div>
-'''
+                    <div style="background-color: #fff3cd; border: 1px solid #ffc107; padding: 10px; margin: 20px 0; text-align: center; font-size: 14px; color: #856404;">
+                    <strong>You are using {env_name} environment</strong>
+                    </div>
+                '''
                 if '</body>' in rendered_body:
                     rendered_body = rendered_body.replace('</body>', env_message + '  </body>')
                 else:


### PR DESCRIPTION
Summary
Adds automatic environment message to centre email templates without modifying template files. The message "You are using {ENVIRONMENT} environment" appears at the bottom of emails sent from `templates/centre/` in non-production environments.

Changes
  - Added logic to dynamically append environment message for centre templates
  - Reads `ENVIRONMENT` or `ENV_NAME` environment variables
  - Automatically suppresses message for production environments