### PR TITLE
CENTR-92:Email content tweaks

### DIFF
--- a/submit-cron/templates/centre/access_request_submitted_confirmation.html
+++ b/submit-cron/templates/centre/access_request_submitted_confirmation.html
@@ -63,22 +63,18 @@
     <div class="content">
       <p>Hello <strong>{{ user_name }}</strong>,</p>
 
-      <p>Your request for access to <a href="{{ application_url }}" class="cta-link">{{ application_name }}</a> has been submitted successfully.</p>
+      <p>Your request for access to {{ application_name }} has been submitted successfully.</p>
 
       <p><strong>Request Details:</strong></p>
 
       <div class="grey-box">
-        <p><strong>Application:</strong> <a href="{{ application_url }}">{{ application_name }}</a></p>
+        <p><strong>Application:</strong>{{ application_name }}</p>
         <p><strong>Requested on:</strong> {{ requested_at }}</p>
       </div>
 
       <p>
         Super Users for this application have been notified and will review your request.
         You will receive an email when your request has been processed.
-      </p>
-
-      <p>
-        You can view the status of your request on the <a href="{{ epic_centre_link }}" class="cta-link">Request Access</a> page in EPIC.centre.
       </p>
 
       <p>Thank you,</p>


### PR DESCRIPTION
Summary:
Updated Access Request emails by removing unnecessary links and outdated instructions. Requester email no longer includes app links or the status-view line, and the admin email no longer includes the 5-day action reminder.

Chanages:
Access Request confirmation to the requester: 
- Application Name shouldn’t be a link to the app (they don’t have access yet AND should go through .centre, not directly to the app.) Remove both links. 
- Remove the line: “You can view the status of your request on the Request Access page in EPIC.centre.” 

User Access Request to Admins: 
- Remove the line “Please action this request within 5 business days. If no action is taken, a reminder will be sent.”