### PR TITLE
CENTR-51: Display Last Accessed

### DIFF
--- a/submit-web/package.json
+++ b/submit-web/package.json
@@ -17,6 +17,7 @@
   "dependencies": {
     "@emotion/react": "^11.11.4",
     "@emotion/styled": "^11.11.5",
+    "@epic/centre-analytics": "git+https://github.com/bcgov/EPIC.analytics.git#main",
     "@hookform/resolvers": "^3.9.0",
     "@mui/icons-material": "^5.15.21",
     "@mui/material": "^5.15.20",

--- a/submit-web/sample.env
+++ b/submit-web/sample.env
@@ -3,6 +3,7 @@ VITE_OBJECT_STORAGE_URL=http://localhost:3201/api
 VITE_ENV=local
 VITE_APP_TITLE=EPIC.submit
 VITE_APP_URL=http://localhost:5173
+VITE_CENTRE_API_URL=http://localhost:3300
 VITE_OIDC_AUTHORITY=
 VITE_CLIENT_ID=epic-submit
 VITE_CONDITIONS_LIBRARY_URL=http://localhost:5173/conditions-library

--- a/submit-web/src/router.tsx
+++ b/submit-web/src/router.tsx
@@ -5,6 +5,8 @@ import { useCallback, useEffect, useState } from "react";
 import { getAccount } from "./hooks/api/useAccounts";
 import { notify } from "./components/Shared/Snackbar/snackbarStore";
 import { isAxiosError } from "axios";
+import { trackAnalytics } from "@epic/centre-analytics";
+import { AppConfig } from "./utils/config";
 
 type RouterProviderWithAuthContextProps = Readonly<{
   router: any;
@@ -13,6 +15,13 @@ export default function RouterProviderWithAuthContext({
   router,
 }: RouterProviderWithAuthContextProps) {
   const authentication = useAuth();
+
+  // Record user login analytics
+  trackAnalytics({
+    appName: 'epic_submit',
+    centreApiUrl: AppConfig.centreApiUrl,
+    enabled: authentication.isAuthenticated && !!authentication.user,
+  });
 
   const account = useAccount();
   const { setAccount } = account;

--- a/submit-web/src/utils/config.ts
+++ b/submit-web/src/utils/config.ts
@@ -12,6 +12,7 @@ declare global {
       VITE_CLIENT_ID: string;
       VITE_OBJECT_STORAGE_URL: string;
       VITE_CONDITIONS_LIBRARY_URL: string;
+      VITE_CENTRE_API_URL: string;
       VITE_USER_GUIDE: string;
     };
   }
@@ -25,6 +26,10 @@ const OBJECT_STORAGE_URL =
 const CONDITIONS_LIBRARY_URL =
   window._env_?.VITE_CONDITIONS_LIBRARY_URL ||
   import.meta.env.VITE_CONDITIONS_LIBRARY_URL ||
+  "";
+const CENTRE_API_URL =
+  window._env_?.VITE_CENTRE_API_URL ||
+  import.meta.env.VITE_CENTRE_API_URL ||
   "";
 const APP_ENVIRONMENT =
   window._env_?.VITE_ENV || import.meta.env.VITE_ENV || "";
@@ -46,6 +51,7 @@ export const AppConfig = {
   apiUrl: `${API_URL}`,
   documentUrl: `${OBJECT_STORAGE_URL}`,
   conditionsLibraryUrl: `${CONDITIONS_LIBRARY_URL}`,
+  centreApiUrl: `${CENTRE_API_URL}`,
   environment: APP_ENVIRONMENT,
   version: APP_VERSION,
   appTitle: APP_TITLE,


### PR DESCRIPTION
### Summary

Integrate the shared `@epic/centre-analytics` library into EPIC.submit to record login analytics to EPIC.centre, gated to IDIR users and using a configurable Centre API URL.

### Changes

- **Analytics integration**
  - Added dependency on `@epic/centre-analytics` from the official repo:  
    `git+https://github.com/bcgov/EPIC.analytics.git#main` ([repo link](https://github.com/bcgov/EPIC.analytics.git)).
  - In `router.tsx`, call `trackAnalytics` on app load with:
    - `appName: 'epic_submit'`
    - `centreApiUrl: AppConfig.centreApiUrl`
    - `enabled` tied to OIDC authentication state.
- **Configuration**
  - Added `VITE_CENTRE_API_URL` to `submit-web` environment configuration (e.g. `sample.env`).
  - Exposed `centreApiUrl` via `AppConfig.centreApiUrl` in `src/utils/config.ts` so it can be injected into `trackAnalytics`.

