### PR TITLE
CENTR-51: Display Last Accessed

### DIFF
--- a/submit-web/package-lock.json
+++ b/submit-web/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.4",
         "@emotion/styled": "^11.11.5",
+        "@epic/centre-analytics": "git+https://github.com/bcgov/EPIC.analytics.git#main",
         "@hookform/resolvers": "^3.9.0",
         "@mui/icons-material": "^5.15.21",
         "@mui/material": "^5.15.20",
@@ -485,6 +486,17 @@
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.4.0.tgz",
       "integrity": "sha512-snKqtPW01tN0ui7yu9rGv69aJXr/a/Ywvl11sUjNtEcRc+ng/mQriFL0wLXMef74iHa/EkftbDzU9F8iFbH+zg=="
+    },
+    "node_modules/@epic/centre-analytics": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/bcgov/EPIC.analytics.git#9d4fc416a1527231e6d03dd18dde7dcc6218b178",
+      "dependencies": {
+        "axios": "^1.7.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-oidc-context": "^3.0.0"
+      }
     },
     "node_modules/@esbuild/aix-ppc64": {
       "version": "0.21.5",


### PR DESCRIPTION
---

### Summary

Integrate `@epic/centre-analytics` into EPIC.submit to record login analytics to EPIC.centre. Analytics are only sent for IDIR-authenticated users. The analytics package now builds as a single bundled file using tsup.

### Changes

#### EPIC.analytics (`@epic/centre-analytics`)

- **IDIR-only filtering**
  - Added a check in `useEaoAnalytics.ts` to only send analytics when `identity_provider === "idir"` in the user's token.
  - Non-IDIR users are skipped with a debug log.

- **Build configuration**
  - Switched from `tsc` to `tsup` to generate a single bundled ESM file (`dist/index.mjs`).
  - Updated `package.json` entry points:
    - `main`: `dist/index.mjs`
    - `module`: `dist/index.mjs`
    - `types`: `dist/index.d.mts`
    - `exports`: includes `import`, `types`, and `default` for Vite compatibility.

- **Dependencies**
  - Added `tsup` as a dev dependency.

#### EPIC.submit (submit-web)

- **Analytics integration**
  - Added `@epic/centre-analytics` dependency: `git+https://github.com/bcgov/EPIC.analytics.git#main`.
  - Integrated `trackAnalytics` in `src/router.tsx` with:
    - `appName: 'epic_submit'`
    - `centreApiUrl: AppConfig.centreApiUrl`
    - `enabled` tied to OIDC authentication state.

- **Configuration**
  - Added `VITE_CENTRE_API_URL` environment variable to `sample.env`.
  - Added `centreApiUrl` to `AppConfig` in `src/utils/config.ts`:
    - Reads from `window._env_.VITE_CENTRE_API_URL` or `import.meta.env.VITE_CENTRE_API_URL`.
    - Exposed as `AppConfig.centreApiUrl` for the analytics integration.

