### PR TITLE
SUBMIT-695 Adds curl for health checks

### DIFF
--- a/submit-web/Dockerfile.dev
+++ b/submit-web/Dockerfile.dev
@@ -2,6 +2,9 @@ FROM node:18-alpine
 
 WORKDIR /app
 
+# Install curl for healthcheck
+RUN apk add --no-cache curl
+
 # Copy package files
 COPY package.json package-lock.json ./
 


### PR DESCRIPTION
Installs curl in the development Dockerfile. This enables the use of `curl` within the container for health check commands, ensuring the application's readiness can be properly monitored.

Relates to SUBMIT-task-#695
