### PR TITLE
CENTRE-695: Enhances CORS debugging and adds curl

### DIFF
--- a/submit-api/src/submit_api/config.py
+++ b/submit-api/src/submit_api/config.py
@@ -97,6 +97,9 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     INVITATION_EXPIRY_DAYS = int(os.getenv('INVITATION_EXPIRY_DAYS', '7'))  # Default to 7 days
 
+    # CORS
+    CORS_ORIGIN = os.getenv('CORS_ORIGIN', '')
+
 
 class DevConfig(_Config):  # pylint: disable=too-few-public-methods
     """Dev Config."""

--- a/submit-api/src/submit_api/utils/util.py
+++ b/submit-api/src/submit_api/utils/util.py
@@ -56,7 +56,9 @@ def snake2camelback(snake_dict: dict):
 def allowedorigins():
     """Return allowed origin."""
     _allowedcors = os.getenv('CORS_ORIGIN')
+    print(f'CORS_ORIGIN environment variable: {_allowedcors}')
     if not _allowedcors:
+        print('No CORS_ORIGIN set, defaulting to empty list')
         return []
     allowed_origins = [entry.strip() for entry in re.split(r',\s*', _allowedcors) if entry.strip()]
     print(f'Allowed origins: {allowed_origins}')


### PR DESCRIPTION
Improves the debugging capabilities for Cross-Origin Resource Sharing (CORS) configurations, particularly within the E2E workflow.

- Enhances the E2E GitHub Actions workflow by introducing steps to debug CORS. This includes verifying the `CORS_ORIGIN` environment variable, inspecting API startup logs for allowed origins, and performing direct `curl` tests against the API to check CORS headers.
- Adds logging to the API's `allowedorigins` utility function to clearly display the origins that are configured, aiding in real-time debugging.
- Installs `curl` in the `submit-web` development Dockerfile, providing a crucial utility for making HTTP requests during development and for potential health checks.

Relates to SUBMIT-695