### PR TITLE
Fix Flask-RESTX schema registration error for InvitationSchema

### DIFF
--- a/submit-api/src/submit_api/resources/proponent/invitation.py
+++ b/submit-api/src/submit_api/resources/proponent/invitation.py
@@ -102,7 +102,7 @@ class InvitationDetailResource(Resource):
             return {}, HTTPStatus.NO_CONTENT
         return {"error": "Invitation not found or already used"}, HTTPStatus.NOT_FOUND
 
-    @API.response(code=HTTPStatus.CREATED, model=InvitationSchema, description="User created and role assigned")
+    @API.response(code=HTTPStatus.CREATED, model=invitation_response_schema, description="User created and role assigned")
     @API.response(code=HTTPStatus.BAD_REQUEST, description="Invalid Token or Data")
     def post(self, token):
         """Accept an invitation and create a user."""


### PR DESCRIPTION
Summary: 
Fixes the schema rendering error in the invitations API endpoint.

Error :
The error "Model <class 'submit_api.schemas.invitation.InvitationSchema'> not registered" occurred because Flask-RESTX requires models to be registered via convert_ma_schema_to_restx_model() before they can be used in response decorators.

Changes:
- Replace direct usage of Marshmallow InvitationSchema class with the registered Flask-RESTX model (invitation_response_schema) in the @API.response decorator.



