### PR TITLE
Add missing pytz dependency to production requirements

### DIFF
--- a/submit-cron/requirements/prod.txt
+++ b/submit-cron/requirements/prod.txt
@@ -26,3 +26,4 @@ requests
 flask_cors
 pyhumps
 importlib-resources
+pytz


### PR DESCRIPTION
Change: Add pytz to requirements/prod.txt to fix ModuleNotFoundError whenrunning email jobs. The datetime utility module requires pytz but it was not included in the production requirements.