### PR TITLE
 SUBMIT-745 Entity - Fix Submission Banners [v2]

### DIFF
--- a/submit-web/src/hooks/api/usePackages.ts
+++ b/submit-web/src/hooks/api/usePackages.ts
@@ -187,6 +187,20 @@ const getPackageVersionsByOriginalPackageId = ({
   });
 };
 
+const addIsLatestFlag = (versions: PackageVersion[]): PackageVersion[] => {
+  const seenApprovalStatus = new Set<boolean>();
+  
+  return versions.map((pv) => {
+    const isLatest = !seenApprovalStatus.has(pv.is_approved);
+    seenApprovalStatus.add(pv.is_approved);
+    
+    return {
+      ...pv,
+      is_latest: isLatest,
+    };
+  });
+};
+
 type UseGetPackageVersionsByOriginalPackageIdParams = {
   originalPackageId?: number;
   enabled?: boolean;
@@ -198,6 +212,7 @@ export const getPackageVersionsByOriginalPackageIdQueryOptions = ({
   queryOptions({
     queryKey: [QUERY_KEY.PACKAGE_VERSIONS, originalPackageId],
     queryFn: () => getPackageVersionsByOriginalPackageId({ originalPackageId }),
+    select: (data) => addIsLatestFlag(data),
     enabled: enabled && Boolean(originalPackageId),
   });
 

--- a/submit-web/src/models/Package.ts
+++ b/submit-web/src/models/Package.ts
@@ -128,6 +128,7 @@ export type PackageVersion = {
   version: number;
   original_package_id: number;
   is_approved: boolean;
+  is_latest: boolean;
 };
 
 export type SubmissionPackage = {

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -71,24 +71,17 @@ export default function SubmissionPage() {
     enabled: Boolean(submissionPackage?.version?.original_package_id),
   });
 
-  const isLatestApprovedPackageVersion = packageVersions?.find(
-    (packageVersion) =>
-      packageVersion.is_approved &&
-      packageVersion.package_id === submissionPackageId,
+  const currentPackageVersion = packageVersions?.find(
+    (pv) => pv.package_id === submissionPackageId
   );
 
-  const latestApprovedVersion = Math.max(
-    ...(packageVersions
-      ?.filter((pv) => pv.is_approved)
-      .map((pv) => pv.version) || [0]),
-  );
+  const isLatestApprovedPackageVersion = 
+    currentPackageVersion?.is_latest && 
+    currentPackageVersion?.is_approved;
 
-  const isNewerThanLastApprovedButNotApproved = Boolean(
-    (latestApprovedVersion > 0 &&
-      !submissionPackage?.version?.is_approved &&
-      submissionPackage?.version?.version) ??
-      0 > latestApprovedVersion,
-  );
+  const isNewerThanLastApprovedButNotApproved = 
+    currentPackageVersion?.is_latest && 
+    !currentPackageVersion?.is_approved;
 
   const {
     mutate: updateStateSubmissionPackage,


### PR DESCRIPTION
Ticket: [SUBMIT-745](https://eao-dst.atlassian.net/browse/SUBMIT-745) Entity - Submission Banners

Note: This PR targets V2. See https://github.com/bcgov/EPIC.submit/pull/776 for V1 fix

**Description**
- Fixes bug where the submission banners displays for all package versions
- Updated `getPackageVersionsByOriginalPackageIdQueryOptions` to add an `is_latest` flag, which is used in the component to determine if the banner should display or not. The flag is true if:
  - The package version is the most recent **approved** package
  - The package version is the most recent **pending** package

**Screenshots**
See https://github.com/bcgov/EPIC.submit/pull/776

[SUBMIT-745]: https://eao-dst.atlassian.net/browse/SUBMIT-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ