### PR TITLE
SUBMIT-700 EAO - View and Manage Onboarded and Eligible Projects/Works

### DIFF
--- a/submit-api/src/submit_api/resources/proponent/proponent.py
+++ b/submit-api/src/submit_api/resources/proponent/proponent.py
@@ -19,10 +19,12 @@ from flask import request
 from flask_cors import cross_origin
 from flask_restx import Namespace, Resource
 
+from submit_api.auth import auth
 from submit_api.exceptions import ResourceNotFoundError
 from submit_api.resources.apihelper import Api as ApiHelper
-from submit_api.schemas.proponent import ProponentSchema
+from submit_api.schemas.proponent import ProponentSchema, EnableProponentProjectsSchema
 from submit_api.services.proponent_service import ProponentService
+from submit_api.utils.roles import EpicSubmitRole
 from submit_api.utils.util import allowedorigins, cors_preflight
 
 
@@ -30,6 +32,9 @@ API = Namespace("proponents", description="Endpoints for Proponent fetching")
 
 proponent_model = ApiHelper.convert_ma_schema_to_restx_model(
     API, ProponentSchema(), "Proponent"
+)
+post_proponent_account_projects_model = ApiHelper.convert_ma_schema_to_restx_model(
+    API, EnableProponentProjectsSchema(), "EnableProjects"
 )
 
 
@@ -87,3 +92,29 @@ class Proponent(Resource):
         if not proponent:
             raise ResourceNotFoundError(f"Proponent with id {proponent_id} not found")
         return proponent, HTTPStatus.OK
+
+@cors_preflight("POST, OPTIONS")
+@API.route(
+    "/<int:proponent_id>/projects",
+    methods=["POST", "OPTIONS"],
+)
+class ProponentProject(Resource):
+    """Resource for managing proponent projects."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(API, endpoint_description="Enable proponent project in EPIC.submit")
+    @API.expect(post_proponent_account_projects_model)
+    @API.response(
+        code=HTTPStatus.CREATED, model=proponent_model, description="Enable proponent project in EPIC.submit"
+    )
+    @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
+    @API.response(HTTPStatus.NOT_FOUND, "Not Found")
+    @auth.require
+    @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
+    @cross_origin(origins=allowedorigins())
+    def post(proponent_id):
+        """Create new account_project(s) for proponent."""
+        payload = EnableProponentProjectsSchema().load(request.json)
+        ProponentService.add_eligible_account_projects(proponent_id, payload)
+        proponent = ProponentService.get_proponent(proponent_id, True, True)
+        return proponent, HTTPStatus.CREATED

--- a/submit-api/src/submit_api/resources/proponent/proponent.py
+++ b/submit-api/src/submit_api/resources/proponent/proponent.py
@@ -93,6 +93,7 @@ class Proponent(Resource):
             raise ResourceNotFoundError(f"Proponent with id {proponent_id} not found")
         return proponent, HTTPStatus.OK
 
+
 @cors_preflight("POST, OPTIONS")
 @API.route(
     "/<int:proponent_id>/projects",

--- a/submit-api/src/submit_api/schemas/proponent.py
+++ b/submit-api/src/submit_api/schemas/proponent.py
@@ -22,6 +22,7 @@ class ProponentSchema(Schema):
     invitations = fields.List(fields.Int(), data_key="invitations", required=False, default=[])
     projects = fields.List(fields.Int(), data_key="projects", required=False, default=[])
 
+
 class EnableProponentProjectsSchema(Schema):
     """Schema for adding account_projects to proponent."""
 

--- a/submit-api/src/submit_api/schemas/proponent.py
+++ b/submit-api/src/submit_api/schemas/proponent.py
@@ -21,3 +21,13 @@ class ProponentSchema(Schema):
     is_deleted = fields.Bool(data_key="is_deleted", allow_none=False)
     invitations = fields.List(fields.Int(), data_key="invitations", required=False, default=[])
     projects = fields.List(fields.Int(), data_key="projects", required=False, default=[])
+
+class EnableProponentProjectsSchema(Schema):
+    """Schema for adding account_projects to proponent."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Exclude unknown fields in the deserialized output."""
+
+        unknown = EXCLUDE
+
+    projects = fields.List(fields.Int(), data_key="projects")

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -208,7 +208,6 @@ class InvitationService:
                 roles.append(role)
             InvitationsModel.mark_used(token, account_user.user_id, session)
 
-
             # Update proponent status
             InvitationService._update_proponent_status_by_account(invitation.account_id, ProponentStatus.ONBOARDED)
 

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -208,6 +208,10 @@ class InvitationService:
                 roles.append(role)
             InvitationsModel.mark_used(token, account_user.user_id, session)
 
+
+            # Update proponent status
+            InvitationService._update_proponent_status_by_account(invitation.account_id, ProponentStatus.ONBOARDED)
+
             return {
                 "message": "User access granted successfully",
                 "user_id": account_user.user_id,

--- a/submit-api/src/submit_api/services/proponent_service.py
+++ b/submit-api/src/submit_api/services/proponent_service.py
@@ -1,4 +1,9 @@
 """Service for proponent management."""
+from submit_api.exceptions import BadRequestError, ResourceNotFoundError
+from submit_api.enums.proponent_status import ProponentStatus
+from submit_api.models.account_project import AccountProject
+from submit_api.models.account import Account
+from submit_api.models.db import session_scope
 from submit_api.models.proponent import Proponent
 
 
@@ -21,3 +26,22 @@ class ProponentService:
             include_deleted=include_deleted,
             approved_conditions_only=approved_conditions_only
         )
+
+    @classmethod
+    def add_eligible_account_projects(cls, proponent_id, proponent_data):
+        """Add eligible projects for proponent id."""
+        project_ids = proponent_data.get("projects")
+
+        proponent = Proponent.find_by_id(proponent_id)
+
+        if not proponent:
+            raise ResourceNotFoundError(f"Proponent with id {proponent_id} not found")
+        if not proponent.status is ProponentStatus.ONBOARDED:
+            raise BadRequestError("Can only enable projects for onboarded proponents.")
+
+        account = Account.get_by_proponent_id(proponent_id)
+
+        with session_scope() as session:
+            for pid in project_ids:
+                AccountProject.create_account_project(account_id=account.id, project_id=pid)
+            session.flush()

--- a/submit-api/src/submit_api/services/proponent_service.py
+++ b/submit-api/src/submit_api/services/proponent_service.py
@@ -36,7 +36,7 @@ class ProponentService:
 
         if not proponent:
             raise ResourceNotFoundError(f"Proponent with id {proponent_id} not found")
-        if not proponent.status is ProponentStatus.ONBOARDED:
+        if proponent.status is not ProponentStatus.ONBOARDED:
             raise BadRequestError("Can only enable projects for onboarded proponents.")
 
         account = Account.get_by_proponent_id(proponent_id)

--- a/submit-api/tests/unit/resources/test_proponent.py
+++ b/submit-api/tests/unit/resources/test_proponent.py
@@ -173,7 +173,7 @@ def test_enable_proponent_projects_success(client, session, jwt):
         status=ProponentStatus.ONBOARDED,
         is_deleted=False
     )
-    account = factory_account_model(proponent_id=proponent.id)
+    factory_account_model(proponent_id=proponent.id)
 
     project1 = factory_project_model(name="Project 1", proponent_id=proponent.id)
     project2 = factory_project_model(name="Project 2", proponent_id=proponent.id)
@@ -191,7 +191,7 @@ def test_enable_proponent_projects_success(client, session, jwt):
     assert data["name"] == "Onboarded Proponent"
     assert "account_projects" in data
     assert len(data["account_projects"]) == 2
-    
+
     # Verify the account_projects were created with correct IDs
     account_project_ids = [ap["project_id"] for ap in data["account_projects"]]
     assert project1.id in account_project_ids
@@ -224,7 +224,7 @@ def test_enable_proponent_projects_not_onboarded(client, session, jwt):
         status=ProponentStatus.ELIGIBLE,
         is_deleted=False
     )
-    account = factory_account_model(proponent_id=proponent.id)
+    factory_account_model(proponent_id=proponent.id)
     project = factory_project_model(name="Project", proponent_id=proponent.id)
 
     payload = {

--- a/submit-api/tests/unit/resources/test_proponent.py
+++ b/submit-api/tests/unit/resources/test_proponent.py
@@ -6,9 +6,11 @@ Tests for proponents.
 from http import HTTPStatus
 
 from submit_api.enums.proponent_status import ProponentStatus
+from tests.utilities.factory_scenarios import TestJwtClaims
 from tests.utilities.factory_utils import (
-    factory_account_model, factory_invitation_model, factory_project_with_proponent,
-    factory_proponent_model)
+    factory_account_model, factory_auth_header, factory_invitation_model,
+    factory_project_model, factory_project_with_proponent,
+    factory_proponent_model, factory_user_model)
 
 
 def test_get_all_proponents_with_approved_conditions(client, session):
@@ -158,3 +160,78 @@ def test_get_all_proponents_empty(client, session):
     data = response.get_json()
     assert isinstance(data, list)
     assert len(data) == 0
+
+
+def test_enable_proponent_projects_success(client, session, jwt):
+    """Test successfully enabling projects for an onboarded proponent."""
+    auth_guid = TestJwtClaims.staff_admin_role['sub']
+    factory_user_model(auth_guid=auth_guid)
+
+    proponent = factory_proponent_model(
+        id=1234,
+        name="Onboarded Proponent",
+        status=ProponentStatus.ONBOARDED,
+        is_deleted=False
+    )
+    account = factory_account_model(proponent_id=proponent.id)
+
+    project1 = factory_project_model(name="Project 1", proponent_id=proponent.id)
+    project2 = factory_project_model(name="Project 2", proponent_id=proponent.id)
+
+    payload = {
+        "projects": [project1.id, project2.id]
+    }
+
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    response = client.post(f"/api/proponents/{proponent.id}/projects", json=payload, headers=headers)
+
+    assert response.status_code == HTTPStatus.CREATED
+    data = response.get_json()
+    assert data["id"] == proponent.id
+    assert data["name"] == "Onboarded Proponent"
+    assert "account_projects" in data
+    assert len(data["account_projects"]) == 2
+    
+    # Verify the account_projects were created with correct IDs
+    account_project_ids = [ap["project_id"] for ap in data["account_projects"]]
+    assert project1.id in account_project_ids
+    assert project2.id in account_project_ids
+
+
+def test_enable_proponent_projects_not_found(client, session, jwt):
+    """Test enabling projects for a non-existent proponent."""
+    auth_guid = TestJwtClaims.staff_admin_role['sub']
+    factory_user_model(auth_guid=auth_guid)
+
+    payload = {
+        "projects": [1, 2, 3]
+    }
+
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    response = client.post("/api/proponents/99999/projects", json=payload, headers=headers)
+
+    assert response.status_code == HTTPStatus.NOT_FOUND
+
+
+def test_enable_proponent_projects_not_onboarded(client, session, jwt):
+    """Test enabling projects for a proponent that is not onboarded."""
+    auth_guid = TestJwtClaims.staff_admin_role['sub']
+    factory_user_model(auth_guid=auth_guid)
+
+    proponent = factory_proponent_model(
+        id=2222,
+        name="Eligible Proponent",
+        status=ProponentStatus.ELIGIBLE,
+        is_deleted=False
+    )
+    account = factory_account_model(proponent_id=proponent.id)
+    project = factory_project_model(name="Project", proponent_id=proponent.id)
+
+    payload = {
+        "projects": [project.id]
+    }
+
+    headers = factory_auth_header(jwt=jwt, claims=TestJwtClaims.staff_admin_role)
+    response = client.post(f"/api/proponents/{proponent.id}/projects", json=payload, headers=headers)
+
+    assert response.status_code == HTTPStatus.BAD_REQUEST

--- a/submit-web/src/components/App/Proponents/EnableProjectsButton/EnableProjectsButton.tsx
+++ b/submit-web/src/components/App/Proponents/EnableProjectsButton/EnableProjectsButton.tsx
@@ -1,0 +1,119 @@
+import { LoadingButton } from "@/components/Shared/LoadingButton";
+import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
+import { useModal } from "@/components/Shared/Modals/modalStore";
+import { notify } from "@/components/Shared/Snackbar/snackbarStore";
+import { useEnableProponentProject } from "@/hooks/api/useProponents";
+import { useProponentStore } from "@/store/proponentStore";
+import { List, ListItem, ListItemText, Typography } from "@mui/material";
+import { useParams } from "@tanstack/react-router";
+import { BCDesignTokens } from "epic.theme";
+
+type EnableProjectsButtonProps = {
+  onEnableProjects: () => void;
+};
+
+export const EnableProjectsButton = ({
+  onEnableProjects
+}: EnableProjectsButtonProps) => {
+  const { proponentId } = useParams({
+    from: "/staff/_staffLayout/proponents/$proponentId",
+  });
+  const {
+    setOpen: setOpenModal,
+    setClose: setCloseModal,
+  } = useModal();
+
+  const proponent = useProponentStore((state) => state.proponent);
+  const selectedProjectsIds = useProponentStore((state) => state.selectedProjectsIds);
+  const eligibleProjects = useProponentStore((state) => state.eligibleProjects);
+
+  const { mutate: enableProjects, isPending: isEnablingProjects } =
+    useEnableProponentProject({
+      onSuccess: () => {
+        onEnableProjects();
+        notify.success("Enabled project(s) successfully");
+      },
+      onError: () => {
+        notify.error("Error enabling project(s)");
+      },
+    });
+
+  const openConfirmationModal = () => {
+    setOpenModal(
+      <ConfirmationModal
+        onConfirm={() => {
+          enableProjects({
+            proponentId: proponentId,
+            projectIds: selectedProjectsIds,
+          });
+        }}
+        title="Enable Project/Work in EPIC.submit"
+        description={
+          <>
+            <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+              You will be enabling the following Project(s)/Work(s) in EPIC.submit:
+            </Typography>
+            <List>
+              {eligibleProjects
+                .filter(project => selectedProjectsIds.includes(project.id))
+                .map(project => (
+                  <ListItem
+                    key={project.id}
+                    sx={{ m: 0, py: 0 }}
+                  >
+                    <ListItemText
+                      primary={"- " + project.name}
+                      primaryTypographyProps={{
+                        fontWeight: 'bold',
+                        lineHeight: 1.2,
+                      }} 
+                />
+                  </ListItem>
+                ))}
+            </List>
+            <Typography variant="body1" sx={{ whiteSpace: "pre-line" }}>
+              When you click the Confirm button below, the Account Administrator for {proponent?.name} will receive an email notification and assigned users will be able to submit documents in EPIC.submit.
+            </Typography>
+          </>
+        }
+      />,
+    );
+  };
+
+  const openErrorModal = () => {
+    setOpenModal(
+      <ConfirmationModal
+        onConfirm={() => {
+          setCloseModal();
+        }}
+        title="Select Project(s)/Works(s)"
+        description="Please select the Project(s)/Work(s) you want to enable in EPIC.submit."
+        confirmText="Close"
+        hideSecondary
+      />,
+    );
+  };
+      
+  const handleClick = () => {
+    if (selectedProjectsIds.length === 0) {
+      openErrorModal();
+      return;
+    }
+    openConfirmationModal();
+  };
+  
+  return (
+    <LoadingButton
+        variant="contained"
+        color="primary"
+        loading={isEnablingProjects}
+        onClick={handleClick}
+        sx={{ 
+        whiteSpace: "nowrap",
+        my: BCDesignTokens.layoutMarginXlarge
+        }}
+    >
+        Enable in EPIC.submit
+    </LoadingButton>
+  );
+};

--- a/submit-web/src/components/App/Proponents/ProjectsTable/EligibleProjectsTable.tsx
+++ b/submit-web/src/components/App/Proponents/ProjectsTable/EligibleProjectsTable.tsx
@@ -1,0 +1,78 @@
+import { BarBlueTitle } from "@/components/Shared/Text/BarTitle";
+import { useProponentStore } from "@/store/proponentStore";
+import { InfoOutlined } from "@mui/icons-material";
+import { Box, IconButton, Tooltip, Typography } from "@mui/material";
+import { BCDesignTokens } from "epic.theme";
+import { ProjectsTable } from "./ProjectsTable";
+
+export const EligibleProjectsTable = () => {
+  const proponent = useProponentStore((state) => state.proponent);
+  const eligibleProjects = useProponentStore((state) => state.eligibleProjects);
+  const pendingInvitation = useProponentStore((state) => state.pendingInvitation);
+  const isLoading = useProponentStore((state) => state.isLoading);
+  const isError = useProponentStore((state) => state.isError);
+
+  return (
+    <>
+      <BarBlueTitle
+        title="Eligible Project(s)/Work(s)"
+        bold={false}
+        variant="h5"
+        tooltip={
+          <Tooltip
+            title="Project(s)/Work(s) for this Proponent/Holder will be added to this list as they become eligible to submit in EPIC.submit and can be added manually once the Proponent/Holder created their account."
+            arrow
+          >
+            <IconButton sx={{ p: 0, ml: 1, mb: 0.5 }}>
+              <InfoOutlined fontSize="small" />
+            </IconButton>
+          </Tooltip>
+        }
+      />
+      {proponent?.status == "ONBOARDED" && eligibleProjects.length > 0 && (
+        <Typography
+          variant="body1"
+          sx={{
+            fontWeight: "bold",
+            whiteSpace: "pre-line",
+            mt: BCDesignTokens.layoutMarginMedium
+          }}
+        >
+          {`Select the Eligible Project(s)/Work(s) you want to enable for ${proponent?.name} and click the "Enable in EPIC.submit" button.
+          
+          The Account Administrator(s) for ${proponent?.name} will receive an email to inform them they can now access and submit documents for this project.`}
+        </Typography>
+      )}
+      {proponent?.status == "INELIGIBLE" || eligibleProjects.length == 0 ? (
+        <Box
+          sx={{
+            mt: BCDesignTokens.layoutMarginXlarge,
+            border: 1,
+            borderColor: BCDesignTokens.surfaceColorBorderDefault,
+          }}
+        >
+          <Typography
+            variant="body1"
+            sx={{
+              lineHeight: BCDesignTokens.typographyLineHeightsRegular,
+              px: BCDesignTokens.layoutPaddingSmall,
+            }}
+          >
+            No other Project/Work for this Proponent/Holder is currently
+            eligible to be onboarded in EPIC.submit
+          </Typography>
+        </Box>
+      ) : (
+        <ProjectsTable
+          projects={eligibleProjects}
+          pendingProjectIds={pendingInvitation?.project_ids}
+          isLoading={isLoading}
+          isError={isError}
+          sx={{
+            mt: BCDesignTokens.layoutMarginLarge,
+          }}
+        />
+      )}
+    </>
+  );
+};

--- a/submit-web/src/components/App/Proponents/ProjectsTable/OnboardedProjectsTable.tsx
+++ b/submit-web/src/components/App/Proponents/ProjectsTable/OnboardedProjectsTable.tsx
@@ -1,0 +1,30 @@
+import { BarBlueTitle } from "@/components/Shared/Text/BarTitle";
+import { ProjectsTable } from "./ProjectsTable";
+import { BCDesignTokens } from "epic.theme";
+import { useProponentStore } from "@/store/proponentStore";
+
+export const OnboardedProjectsTable = () => {
+  const onboardedProjects = useProponentStore((state) => state.onboardedProjects);
+  const isLoading = useProponentStore((state) => state.isLoading);
+  const isError = useProponentStore((state) => state.isError);
+
+  const onboardedProjectsIds = onboardedProjects?.map(op => op.id);
+
+  return (
+    <>
+      <BarBlueTitle title="Onboarded Project(s)/Works" bold={false} variant="h5" />
+      <ProjectsTable
+        projects={onboardedProjects}
+        pendingProjectIds={onboardedProjectsIds}
+        selectedProjectsIds={onboardedProjectsIds}
+        readonly
+        isLoading={isLoading}
+        isError={isError}
+        sx={{
+          mt: BCDesignTokens.layoutMarginXxlarge,
+          mb: BCDesignTokens.layoutMarginXxxlarge,
+        }}
+      />
+    </>
+  );
+};

--- a/submit-web/src/components/App/Proponents/ProjectsTable/ProjectsTable.tsx
+++ b/submit-web/src/components/App/Proponents/ProjectsTable/ProjectsTable.tsx
@@ -3,14 +3,15 @@ import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { Project } from "@/models/Project";
 import { TableProps } from "@mui/material";
 import { useEffect } from "react";
+import { useProponentStore } from "@/store/proponentStore";
 
 type ProjectsTableProps = TableProps & {
   projects?: Project[];
   pendingProjectIds?: number[];
   isLoading?: boolean;
   isError?: boolean;
-  selectedProjectsIds: (string | number)[];
-  onSelectionChange: (selected: (string | number)[]) => void;
+  selectedProjectsIds?: (string | number)[]; // Can be overridden for read-only tables
+  readonly?: boolean;
 };
 
 export const ProjectsTable = ({
@@ -18,10 +19,17 @@ export const ProjectsTable = ({
   pendingProjectIds = [],
   isLoading = false,
   isError = false,
-  selectedProjectsIds,
-  onSelectionChange,
+  selectedProjectsIds: externalSelectedProjectsIds,
+  readonly = false,
   ...tableProps
 }: ProjectsTableProps) => {
+  // Use store for selection unless explicitly overridden (for read-only tables like OnboardedProjectsTable)
+  const storeSelectedProjectsIds = useProponentStore((state) => state.selectedProjectsIds);
+  const setSelectedProjectsIds = useProponentStore((state) => state.setSelectedProjectsIds);
+  
+  const selectedProjectsIds = externalSelectedProjectsIds ?? storeSelectedProjectsIds;
+  const onSelectionChange = readonly ? undefined : setSelectedProjectsIds;
+
   useEffect(() => {
     if (isError) {
       notify.error("Error fetching projects");

--- a/submit-web/src/components/App/Proponents/ProjectsTable/index.tsx
+++ b/submit-web/src/components/App/Proponents/ProjectsTable/index.tsx
@@ -1,0 +1,3 @@
+export { EligibleProjectsTable } from "./EligibleProjectsTable";
+export { OnboardedProjectsTable } from "./OnboardedProjectsTable";
+export { ProjectsTable } from "./ProjectsTable";

--- a/submit-web/src/components/App/Proponents/RegistrationUrl/RegistrationUrl.tsx
+++ b/submit-web/src/components/App/Proponents/RegistrationUrl/RegistrationUrl.tsx
@@ -3,8 +3,8 @@ import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
 import { useModal } from "@/components/Shared/Modals/modalStore";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import { useCreateNewAccountProjectInvitation } from "@/hooks/api/useInvitations";
-import { Invitation } from "@/models/Invitation";
 import { USER_MANAGEMENT_ROLE } from "@/models/Role";
+import { useProponentStore } from "@/store/proponentStore";
 import { AppConfig } from "@/utils/config";
 import ContentCopyIcon from "@mui/icons-material/ContentCopy";
 import { Grid, IconButton, TextField, Tooltip } from "@mui/material";
@@ -13,17 +13,17 @@ import { BCDesignTokens } from "epic.theme";
 import { useState } from "react";
 
 type RegistrationUrlProps = {
-  pendingInvitation?: Invitation;
-  selectedProjectsIds: (string | number)[];
   onInvitationCreated: () => void;
 };
 
 export const RegistrationUrl = ({
-  pendingInvitation,
-  selectedProjectsIds,
   onInvitationCreated
 }: RegistrationUrlProps) => {
   const [tooltipText, setTooltipText] = useState("Copy");
+  
+  const pendingInvitation = useProponentStore((state) => state.pendingInvitation);
+  const selectedProjectsIds = useProponentStore((state) => state.selectedProjectsIds);
+  
   const { proponentId } = useParams({
     from: "/staff/_staffLayout/proponents/$proponentId",
   });
@@ -83,7 +83,8 @@ export const RegistrationUrl = ({
       container
       spacing={2}
       sx={{ 
-        mb: BCDesignTokens.layoutMarginXxlarge 
+        mb: BCDesignTokens.layoutMarginXxlarge,
+        mt: BCDesignTokens.layoutMarginXlarge
       }}
     >
       <Grid item sm={12} md={5}>

--- a/submit-web/src/hooks/api/useProponents.ts
+++ b/submit-web/src/hooks/api/useProponents.ts
@@ -1,7 +1,7 @@
 import { Proponent } from "@/models/Proponent";
-import { submitRequest } from "@/utils/axiosUtils";
+import { OnErrorType, submitRequest } from "@/utils/axiosUtils";
 import { QUERY_KEY } from "./constants";
-import { useQuery } from "@tanstack/react-query";
+import { useQuery, useMutation } from "@tanstack/react-query";
 
 const getProponents = () => {
   return submitRequest<Proponent[]>({
@@ -74,5 +74,32 @@ export const useGetProponent = (
     enabled: !!proponentId,
     staleTime: 30 * 60 * 1000, // 30 minutes
     gcTime: 30 * 60 * 1000, // 30 minutes
+  });
+};
+
+const enableProponentProjects = ({
+  proponentId,
+  projectIds,
+}: {
+  proponentId: number;
+  projectIds: (string | number)[];
+}) => {
+  return submitRequest<Proponent>({
+    url: `proponents/${proponentId}/projects`,
+    method: "post",
+    data: {
+      projects: projectIds
+    },
+  });
+};
+
+type EnableProponentProjectOptions = {
+  onSuccess?: (data: Proponent) => void;
+  onError?: OnErrorType;
+};
+export const useEnableProponentProject = (options: EnableProponentProjectOptions) => {
+  return useMutation({
+    mutationFn: enableProponentProjects,
+    ...options,
   });
 };

--- a/submit-web/src/routes/staff/_staffLayout/proponents/$proponentId.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/proponents/$proponentId.tsx
@@ -1,22 +1,20 @@
-import { ProjectsTable } from "@/components/App/Proponents/ProjectsTable/ProjectsTable";
+import { EnableProjectsButton } from "@/components/App/Proponents/EnableProjectsButton/EnableProjectsButton";
+import { EligibleProjectsTable, OnboardedProjectsTable } from "@/components/App/Proponents/ProjectsTable";
 import { RegistrationUrl } from "@/components/App/Proponents/RegistrationUrl/RegistrationUrl";
 import { ProponentStatusChip } from "@/components/App/ProponentStatusChip";
 import { ContentBox } from "@/components/Shared/Layouts/ContentBox";
 import { ContentBoxSkeleton } from "@/components/Shared/Layouts/ContentBox/ContentBoxSkeleton";
 import { PageGrid } from "@/components/Shared/PageGrid";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
-import { BarBlueTitle } from "@/components/Shared/Text/BarTitle";
 import { getProponentOptions } from "@/hooks/api/useProponents";
-import { InvitationStatus } from "@/models/Invitation";
+import { useProponentStore } from "@/store/proponentStore";
 import { HTTP_STATUS } from "@/utils/constants";
-import { InfoOutlined } from "@mui/icons-material";
-import { Grid, IconButton, Tooltip, Typography } from "@mui/material";
+import { Grid, Typography } from "@mui/material";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { createFileRoute, notFound, useParams } from "@tanstack/react-router";
 import { isAxiosError } from "axios";
 import { BCDesignTokens } from "epic.theme";
-import { useEffect, useState } from "react";
-import { Box } from "@mui/material";
+import { useEffect } from "react";
 
 export const Route = createFileRoute(
   "/staff/_staffLayout/proponents/$proponentId",
@@ -57,12 +55,10 @@ export const Route = createFileRoute(
 });
 
 function ProponentPage() {
-  const [selectedProjectsIds, setSelectedProjectsIds] = useState<
-    (string | number)[]
-  >([]);
   const { proponentId } = useParams({
     from: "/staff/_staffLayout/proponents/$proponentId",
   });
+  
   const {
     data: proponent,
     isPending,
@@ -75,19 +71,37 @@ function ProponentPage() {
     }),
   );
 
-  // Ideally there is only 1 pending invitation per proponent, but just in case we grab the most recent pending invite.
-  const pendingInvitation = proponent?.invitations
-    ?.filter((invitation) => invitation.status === InvitationStatus.PENDING)
-    .sort(
-      (a, b) =>
-        new Date(b.expiry_date).getTime() - new Date(a.expiry_date).getTime(),
-    )[0];
+  // Zustand store actions
+  const { 
+    eligibleProjects,
+    setProponent, 
+    setIsLoading, 
+    setIsError,
+    reset 
+  } = useProponentStore();
+
+  // Sync query data to store
+  useEffect(() => {
+    if (proponent) {
+      setProponent(proponent);
+    }
+  }, [proponent, setProponent]);
 
   useEffect(() => {
+    setIsLoading(isPending);
+  }, [isPending, setIsLoading]);
+
+  useEffect(() => {
+    setIsError(isError);
     if (isError) {
       notify.error("Error fetching proponent");
     }
-  }, [isError]);
+  }, [isError, setIsError]);
+
+  // Reset store on unmount
+  useEffect(() => {
+    return () => reset();
+  }, [reset]);
 
   return (
     <PageGrid>
@@ -98,75 +112,30 @@ function ProponentPage() {
           sx={{ width: "100%", minHeight: "43.75em" }}
           contentBoxVariant="secondary"
         >
-          <Typography
-            variant="body1"
-            sx={{
-              mb: BCDesignTokens.layoutMarginXxxlarge,
-              fontWeight: "bold",
-              whiteSpace: "pre-line",
-            }}
-          >
-            {`1. Select the project(s)/Work(s) you want to enable in EPIC.submit
-              2. Generate an invite link
-              3. Send it to the Proponent/Holder
-              
-              Once they create their account, those Project(s)/Work(s) will be ready for submissions.`}
-          </Typography>
-          <BarBlueTitle
-            title="Eligible Project(s)/Work(s)"
-            bold={false}
-            variant="h5"
-            tooltip={
-              <Tooltip
-                title="Project(s)/Work(s) for this Proponent/Holder will be added to this list as they become eligible to submit in EPIC.submit and can be added manually once the Proponent/Holder created their account."
-                arrow
-              >
-                <IconButton sx={{ p: 0, ml: 1, mb: 0.5 }}>
-                  <InfoOutlined fontSize="small" />
-                </IconButton>
-              </Tooltip>
-            }
-          />
-          {proponent?.status == "INELIGIBLE" ||
-          proponent?.projects?.length == 0 ? (
-            <Box
+          {proponent?.status == "ONBOARDED" ? (
+            <OnboardedProjectsTable />
+          ) : (
+            <Typography
+              variant="body1"
               sx={{
-                mt: BCDesignTokens.layoutMarginXlarge,
-                border: 1,
-                borderColor: BCDesignTokens.surfaceColorBorderDefault,
+                mb: BCDesignTokens.layoutMarginXxxlarge,
+                fontWeight: "bold",
+                whiteSpace: "pre-line",
               }}
             >
-              <Typography
-                variant="body1"
-                sx={{
-                  lineHeight: BCDesignTokens.typographyLineHeightsRegular,
-                  px: BCDesignTokens.layoutPaddingSmall,
-                }}
-              >
-                No other Project/Work for this Proponent/Holder is currently
-                eligible to be onboarded in EPIC.submit
-              </Typography>
-            </Box>
-          ) : (
-            <>
-              <ProjectsTable
-                projects={proponent?.projects}
-                pendingProjectIds={pendingInvitation?.project_ids}
-                selectedProjectsIds={selectedProjectsIds}
-                onSelectionChange={setSelectedProjectsIds}
-                isLoading={isPending}
-                isError={isError}
-                sx={{
-                  mt: BCDesignTokens.layoutMarginXxlarge,
-                  mb: BCDesignTokens.layoutMarginXxxlarge,
-                }}
-              />
-              <RegistrationUrl
-                pendingInvitation={pendingInvitation}
-                selectedProjectsIds={selectedProjectsIds}
-                onInvitationCreated={refetch}
-              />
-            </>
+              {`1. Select the project(s)/Work(s) you want to enable in EPIC.submit
+                2. Generate an invite link
+                3. Send it to the Proponent/Holder
+                
+                Once they create their account, those Project(s)/Work(s) will be ready for submissions.`}
+            </Typography>
+          )}
+          <EligibleProjectsTable />
+          {proponent?.status == "ONBOARDED" && eligibleProjects.length > 0 && (
+            <EnableProjectsButton onEnableProjects={refetch} />
+          )}
+          {proponent?.status != "ONBOARDED" && eligibleProjects.length > 0 && (
+            <RegistrationUrl onInvitationCreated={refetch} />
           )}
         </ContentBox>
       </Grid>

--- a/submit-web/src/store/proponentStore.ts
+++ b/submit-web/src/store/proponentStore.ts
@@ -1,0 +1,74 @@
+import { Invitation, InvitationStatus } from "@/models/Invitation";
+import { Project } from "@/models/Project";
+import { Proponent } from "@/models/Proponent";
+import { create } from "zustand";
+
+interface ProponentState {
+  proponent: Proponent | null;
+  selectedProjectsIds: (string | number)[];
+  isLoading: boolean;
+  isError: boolean;
+  
+  // Computed/derived properties
+  onboardedProjects: Project[];
+  eligibleProjects: Project[];
+  pendingInvitation: Invitation | undefined;
+  
+  // Actions
+  setProponent: (proponent: Proponent | null) => void;
+  setSelectedProjectsIds: (ids: (string | number)[]) => void;
+  setIsLoading: (loading: boolean) => void;
+  setIsError: (error: boolean) => void;
+  reset: () => void;
+}
+
+const initialState = {
+  proponent: null,
+  selectedProjectsIds: [],
+  isLoading: false,
+  isError: false,
+  pendingInvitation: undefined,
+  onboardedProjects: [],
+  eligibleProjects: [],
+};
+
+export const useProponentStore = create<ProponentState>((set, get) => ({
+  ...initialState,
+  
+  setProponent: (proponent) => {
+    set({ proponent });
+    
+    if (proponent) {
+      // Ideally there is only 1 pending invitation per proponent, but just in case we grab the most recent pending invite.
+      const pendingInvitation = proponent.invitations
+        ?.filter((invitation) => invitation.status === InvitationStatus.PENDING)
+        .sort(
+          (a, b) =>
+            new Date(b.expiry_date).getTime() - new Date(a.expiry_date).getTime(),
+        )[0];  
+
+      const accountProjectIds = new Set(
+        proponent.account_projects?.map(ap => ap.project_id) || []
+      );
+
+      const onboardedProjects = (proponent.projects || [])
+        .filter(project => accountProjectIds.has(project.id))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      const eligibleProjects = proponent.status != "ONBOARDED" 
+      ? proponent.projects 
+      : (proponent.projects || [])
+        .filter(project => !accountProjectIds.has(project.id))
+        .sort((a, b) => a.name.localeCompare(b.name));
+
+      set({ pendingInvitation, onboardedProjects, eligibleProjects });
+    } else {
+      set({ onboardedProjects: [], eligibleProjects: [] });
+    }
+  },
+  
+  setSelectedProjectsIds: (selectedProjectsIds) => set({ selectedProjectsIds }),
+  setIsLoading: (isLoading) => set({ isLoading }),
+  setIsError: (isError) => set({ isError }),
+  reset: () => set(initialState),
+}));

--- a/submit-web/src/store/proponentStore.ts
+++ b/submit-web/src/store/proponentStore.ts
@@ -32,7 +32,7 @@ const initialState = {
   eligibleProjects: [],
 };
 
-export const useProponentStore = create<ProponentState>((set, get) => ({
+export const useProponentStore = create<ProponentState>((set) => ({
   ...initialState,
   
   setProponent: (proponent) => {


### PR DESCRIPTION
Ticket: [SUBMIT-700](https://eao-dst.atlassian.net/browse/SUBMIT-700) EAO - View and Manage Onboarded and Eligible Projects/Works

**Description**
- Added `POST /api/proponent/<int:proponent_id>/projects` endpoint to add `account_projects` for already onboarded proponents.
- Updated frontend `$proponentId.tsx` route file:
  - Refactored into smaller components `EligibleProjectsTable.tsx` and `OnboardedProjectsTable.tsx`. The complexity of the route file was growing quite a bit as we need to handle different views for different `proponent.status` values and for the number of `eligibleProjects`.
  - Created a `useProponentStore` Zustand store to handle the general state of `$proponentId.tsx` and it's children components, and to prevent excessive prop drilling.

**Screenshots**

1. The view for an `ONBOARDED` proponent that has 1 onboarded project and 3 eligible projects selected.
<img width="1470" height="710" alt="onboarded w eligible" src="https://github.com/user-attachments/assets/b98eeb4c-19b8-4a5f-85aa-579d66b8de4d" />

2. Clicking the "Enable in EPIC.submit" button opens the modal.
<img width="1469" height="716" alt="modal" src="https://github.com/user-attachments/assets/f3d85f34-a70d-4243-a811-982361e171d9" />

3. Clicking "Confirm" calls the new `POST /api/proponent/<int:proponent_id>/projects` endpoint. 3 new `account_project` table entries are created, and the page updates to show them in the "Onboarded Projects" section.
<img width="1464" height="687" alt="onboarded wo eligible" src="https://github.com/user-attachments/assets/3f382b68-4c29-459b-aadf-93631c4a6c94" />


[SUBMIT-700]: https://eao-dst.atlassian.net/browse/SUBMIT-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ