### PR TITLE
SUBMIT-752 [Bugfix] Update latest migration down_revision

### DIFF
--- a/submit-api/migrations/versions/77862b346adf_add_requested_by_eao_package_status.py
+++ b/submit-api/migrations/versions/77862b346adf_add_requested_by_eao_package_status.py
@@ -11,7 +11,7 @@ import sqlalchemy as sa
 
 # revision identifiers, used by Alembic.
 revision = '77862b346adf'
-down_revision = 'e27054af162b'
+down_revision = 'f1d8ab8c2d30'
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
Ticket: [SUBMIT-752](https://eao-dst.atlassian.net/browse/SUBMIT-752) Entity - Display Assessment Early Engagement Card on Projects Page

Both PRs #806 and #808 had database migrations that had the dame `down_revision` causing an issue when both got merged. Assigning this to ticket SUBMIT-752 as it was the originator of the bug.

**Before**
Running `flask db migrate` locally:
```
ERROR [flask_migrate] Error: Multiple head revisions are present for given argument 'head'; please specify a specific target revision, '<branchname>@head' to narrow to a specific head, or 'heads' for all heads
```

**After**
Running `flask db migrate` locally:
```
INFO  [alembic.runtime.migration] Running upgrade f1d8ab8c2d30 -> 77862b346adf, Add REQUESTED_BY_EAO package status
```



[SUBMIT-752]: https://eao-dst.atlassian.net/browse/SUBMIT-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ