### PR TITLE
SUBMIT-745 Update logic for displaying pending package banner

### DIFF
--- a/submit-web/src/hooks/api/usePackages.ts
+++ b/submit-web/src/hooks/api/usePackages.ts
@@ -188,17 +188,23 @@ const getPackageVersionsByOriginalPackageId = ({
 };
 
 const addIsLatestFlag = (versions: PackageVersion[]): PackageVersion[] => {
-  const seenApprovalStatus = new Set<boolean>();
-  
-  return versions.map((pv) => {
-    const isLatest = !seenApprovalStatus.has(pv.is_approved);
-    seenApprovalStatus.add(pv.is_approved);
-    
-    return {
-      ...pv,
-      is_latest: isLatest,
-    };
-  });
+  // Find the latest approved version
+  const latestApprovedVersion = versions.find((pv) => pv.is_approved);
+
+  // Find the latest unapproved version that's newer than latest approved
+  let latestUnapprovedNewerThanApproved: PackageVersion | undefined;
+  if (latestApprovedVersion) {
+    latestUnapprovedNewerThanApproved = versions.find(
+      (pv) => !pv.is_approved && pv.version > latestApprovedVersion.version,
+    );
+  }
+
+  return versions.map((pv) => ({
+    ...pv,
+    is_latest:
+      pv.id === latestApprovedVersion?.id ||
+      pv.id === latestUnapprovedNewerThanApproved?.id,
+  }));
 };
 
 type UseGetPackageVersionsByOriginalPackageIdParams = {


### PR DESCRIPTION
Ticket: [SUBMIT-745](https://eao-dst.atlassian.net/browse/SUBMIT-745) Entity - Submission Banners

**Description**
- Addresses issue discovered by MA during UX check. Updated the `is_latest` flag logic. Rather than displaying the "Pending" banner on the most recent failed package, we want to only display it on the most recent failed package **that is newer than the latest approved package**.


[SUBMIT-745]: https://eao-dst.atlassian.net/browse/SUBMIT-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ