### PR TITLE
SUBMIT-700 Allow enabling and managing multiple projects

### DIFF
--- a/submit-api/src/submit_api/models/project.py
+++ b/submit-api/src/submit_api/models/project.py
@@ -22,6 +22,7 @@ class Project(db.Model):
     has_approved_condition = Column(db.Boolean, nullable=True, default=False)
 
     proponent = db.relationship('Proponent', foreign_keys=[proponent_id], lazy='joined')
+    works = db.relationship('TrackWork', back_populates='project', viewonly=True, lazy='select')
 
     __table_args__ = (
         db.Index('ix_projects_proponent_id', 'proponent_id'),
@@ -35,6 +36,7 @@ class Project(db.Model):
             "name": self.name,
             "proponent_id": self.proponent_id,
             "proponent": self.proponent.to_dict() if self.proponent else None,
+            "works": [work.to_dict() for work in self.works],
             "ea_certificate": self.ea_certificate,
             "epic_guid": self.epic_guid,
         }

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -37,21 +37,20 @@ class ProjectQueries:
             account_project_ids = db.session.query(AccountProject.id).all()
             return [ap_id for (ap_id,) in account_project_ids]
 
-        if not user.account_user or not user.account_user.role:
+        if not user.account_user or not user.account_user.roles:
             return []
 
-        # User roles may be single or multiple, but here we assume one role per user (adjust if needed)
-        user_role = user.account_user.role
-
-        if not user_role.active:
+        active_roles = [role for role in user.account_user.roles if role.active]
+        if not active_roles:
             return []
 
-        # If user has no assigned account_project_id, allow no projects
-        if not user_role.account_project_id:
-            return []
+        account_project_ids = [
+            role.account_project_id
+            for role in active_roles
+            if role.account_project_id
+        ]
 
-        # Assuming a single account project for each account now
-        return [user_role.account_project_id]
+        return account_project_ids
 
     @classmethod
     def get_projects_by_proponent_id(cls, proponent_id: int):

--- a/submit-api/src/submit_api/models/track_phase.py
+++ b/submit-api/src/submit_api/models/track_phase.py
@@ -43,6 +43,20 @@ class TrackPhase(BaseModel):
         db.Index('idx_track_phases_name', 'name'),
     )
 
+    def to_dict(self):
+        """Convert object to dictionary."""
+        return {
+            "id": self.id,
+            "name": self.name,
+            "ea_act_id": self.ea_act_id,
+            "work_type_id": self.work_type_id,
+            "work_type_name": self.work_type_name,
+            "sort_order": self.sort_order,
+            "number_of_days": self.number_of_days,
+            "display_name": self.display_name,
+            "legislated": self.legislated,
+        }
+
     @classmethod
     def find_by_work_type(cls, work_type_id: int):
         """Return phases by work type id."""

--- a/submit-api/src/submit_api/models/track_work.py
+++ b/submit-api/src/submit_api/models/track_work.py
@@ -37,6 +37,17 @@ class TrackWork(BaseModel):
         db.Index('idx_track_works_work_state', 'work_state'),
     )
 
+    def to_dict(self):
+        """Convert object to dictionary."""
+        return {
+            "id": self.id,
+            "project_id": self.project_id,
+            "current_phase_id": self.current_phase_id,
+            "current_phase": self.current_phase.to_dict() if self.current_phase else None,
+            "work_state": self.work_state,
+            "title": self.title,
+        }
+
     @classmethod
     def find_by_project_id(cls, project_id: int):
         """Return works by project id."""

--- a/submit-api/src/submit_api/services/invitation_service.py
+++ b/submit-api/src/submit_api/services/invitation_service.py
@@ -24,6 +24,8 @@ from submit_api.services.user_service import UserService
 from submit_api.utils.constants import NEW_USER_INVITATION_EMAIL_TEMPLATE
 from submit_api.utils.token_info import TokenInfo
 from submit_api.models.user_role import UserRole as UserRoleModel
+from submit_api.models.track_work import TrackWork
+from submit_api.models.account_project_work import AccountProjectWork
 
 
 class InvitationService:
@@ -200,15 +202,22 @@ class InvitationService:
                 user.id, invitation.account_id, payload, session)
 
             # Create account projects if they don't exist (handles concurrent invitations gracefully)
-            InvitationService._create_account_projects(
+            InvitationService.create_account_projects(
                 invitation.account_id, invitation.project_ids, session)
 
             account_projects = AccountProjectModel.get_all_in_project_ids(invitation.project_ids)
             roles = []
             for account_project in account_projects:
+                # Assign user role
                 role = InvitationService._assign_user_role(
                     account_user.id, account_project.id, invitation, session)
                 roles.append(role)
+
+                # Create account_project_works
+                works = TrackWork.find_by_project_id(account_project.project_id)
+                for work in works:
+                    AccountProjectWork.create_or_get(account_project.id, work.id)
+
             InvitationsModel.mark_used(token, account_user.user_id, session)
 
             # Update proponent status
@@ -296,7 +305,7 @@ class InvitationService:
         return account
 
     @staticmethod
-    def _create_account_projects(account_id, project_ids, session):
+    def create_account_projects(account_id, project_ids, session):
         """Create account projects."""
         for project_id in project_ids:
             AccountProjectModel.create_account_project(

--- a/submit-api/src/submit_api/services/proponent_service.py
+++ b/submit-api/src/submit_api/services/proponent_service.py
@@ -1,10 +1,16 @@
 """Service for proponent management."""
 from submit_api.exceptions import BadRequestError, ResourceNotFoundError
 from submit_api.enums.proponent_status import ProponentStatus
+from submit_api.models.account_project_work import AccountProjectWork
 from submit_api.models.account_project import AccountProject
+from submit_api.models.account_user import AccountUser
 from submit_api.models.account import Account
 from submit_api.models.db import session_scope
 from submit_api.models.proponent import Proponent
+from submit_api.models.track_work import TrackWork
+from submit_api.services.invitation_service import InvitationService
+from submit_api.services.account_user_service import AccountUserService
+from submit_api.enums.role import RoleEnum
 
 
 class ProponentService:
@@ -47,8 +53,35 @@ class ProponentService:
             raise BadRequestError("Can only enable projects for onboarded proponents.")
 
         account = Account.get_by_proponent_id(proponent_id)
+        account_users = AccountUser.get_users_by_account_id(account.id)
 
         with session_scope() as session:
-            for pid in project_ids:
-                AccountProject.create_account_project(account_id=account.id, project_id=pid)
+            # Create account projects if they don't exist
+            InvitationService.create_account_projects(
+                account.id, project_ids, session)
+
+            account_projects = AccountProject.get_all_in_project_ids(project_ids)
+
+            for account_project in account_projects:
+                # Assign user role(s)
+                for account_user in account_users:
+                    user_role = getattr(account_user, "role", None)
+                    if (
+                        user_role and
+                        user_role.role.role_name in [
+                            RoleEnum.ACCOUNT_PRIMARY_ADMIN.value,
+                            RoleEnum.PROJECT_ADMIN.value
+                        ] and
+                        user_role.active
+                    ):
+                        AccountUserService.assign_role({
+                            "account_user_id": account_user.id,
+                            "role_id": user_role.role.id,
+                            "account_project_id": account_project.id,
+                        }, session)
+
+                # Create account_project_works
+                works = TrackWork.find_by_project_id(account_project.project_id)
+                for work in works:
+                    AccountProjectWork.create_or_get(account_project.id, work.id)
             session.flush()

--- a/submit-web/src/components/App/Projects/Project.tsx
+++ b/submit-web/src/components/App/Projects/Project.tsx
@@ -38,7 +38,7 @@ export const Project = ({ accountProject }: ProjectParam) => {
       topLabel={accountProject.project.proponent?.name || ""}
       bottomLabel={ea_certificate ? `EAC # ${ea_certificate}` : ""}
     >
-      {currentPhase?.work_type_name == "ASSESSMENT" ? (
+      {currentPhase?.work_type_name == "Assessment" ? (
         <ProjectSubmissionsCard
           title={`${name} - Assessment`}
           status={PROJECT_STATUS.EARLY_ENGAGEMENT}

--- a/submit-web/src/components/App/Projects/Project.tsx
+++ b/submit-web/src/components/App/Projects/Project.tsx
@@ -38,7 +38,7 @@ export const Project = ({ accountProject }: ProjectParam) => {
       topLabel={accountProject.project.proponent?.name || ""}
       bottomLabel={ea_certificate ? `EAC # ${ea_certificate}` : ""}
     >
-      {currentPhase?.work_type_name == "Assessment" ? (
+      {currentPhase?.work_type_name?.toUpperCase() == "ASSESSMENT" ? (
         <ProjectSubmissionsCard
           title={`${name} - Assessment`}
           status={PROJECT_STATUS.EARLY_ENGAGEMENT}

--- a/submit-web/src/components/App/Proponents/ProjectsTable/ProjectsTable.tsx
+++ b/submit-web/src/components/App/Proponents/ProjectsTable/ProjectsTable.tsx
@@ -24,10 +24,15 @@ export const ProjectsTable = ({
   ...tableProps
 }: ProjectsTableProps) => {
   // Use store for selection unless explicitly overridden (for read-only tables like OnboardedProjectsTable)
-  const storeSelectedProjectsIds = useProponentStore((state) => state.selectedProjectsIds);
-  const setSelectedProjectsIds = useProponentStore((state) => state.setSelectedProjectsIds);
-  
-  const selectedProjectsIds = externalSelectedProjectsIds ?? storeSelectedProjectsIds;
+  const storeSelectedProjectsIds = useProponentStore(
+    (state) => state.selectedProjectsIds,
+  );
+  const setSelectedProjectsIds = useProponentStore(
+    (state) => state.setSelectedProjectsIds,
+  );
+
+  const selectedProjectsIds =
+    externalSelectedProjectsIds ?? storeSelectedProjectsIds;
   const onSelectionChange = readonly ? undefined : setSelectedProjectsIds;
 
   useEffect(() => {
@@ -47,15 +52,15 @@ export const ProjectsTable = ({
       id: "current_work",
       label: "Current Work",
       sortable: true,
-      getValue: () => "not_mapped",
+      getValue: (row) => row.works?.at(-1)?.current_phase?.work_type_name,
     },
     {
       id: "phase",
       label: "Phase",
       sortable: true,
-      getValue: () => "not_mapped",
+      getValue: (row) => row.works?.at(-1)?.current_phase?.display_name,
     },
-  ]
+  ];
 
   return (
     <DataTable

--- a/submit-web/src/components/Shared/DataTable/DataTable.tsx
+++ b/submit-web/src/components/Shared/DataTable/DataTable.tsx
@@ -1,5 +1,10 @@
 import { OutlinedCheckbox } from "@/components/Shared/Icons/OutlinedCheckbox";
-import { PlainCheckboxTableCell, PlainTableCell, SubmitCheckboxTableHeadCell, SubmitTableHeadCell } from "@/components/Shared/Table/common";
+import {
+  PlainCheckboxTableCell,
+  PlainTableCell,
+  SubmitCheckboxTableHeadCell,
+  SubmitTableHeadCell,
+} from "@/components/Shared/Table/common";
 import {
   Box,
   LinearProgress,
@@ -109,7 +114,7 @@ export function DataTable<T>({
   // Pagination
   const paginatedData = useMemo(() => {
     if (sortedData.length === 0) return [];
-    if (!paginated) return sortedData
+    if (!paginated) return sortedData;
 
     const startIndex = page * rowsPerPage;
     const endIndex = startIndex + rowsPerPage;
@@ -188,22 +193,26 @@ export function DataTable<T>({
 
   const emptyRows = Math.max(0, rowsPerPage - paginatedData.length);
   const numSelected = selected.filter((id) => !isSuccessful(id)).length;
-  const selectableRowCount = sortedData.filter((row) => !isSuccessful(getRowId(row))).length;
+  const selectableRowCount = sortedData.filter(
+    (row) => !isSuccessful(getRowId(row)),
+  ).length;
 
   return (
     <Box>
       <TableContainer>
-        <Table
-          {...tableProps}
-          sx={{ tableLayout: "fixed", ...tableProps?.sx }}
-        >
+        <Table {...tableProps} sx={{ tableLayout: "fixed", ...tableProps?.sx }}>
           <TableHead>
             <TableRow>
               {selectable && (
                 <SubmitCheckboxTableHeadCell padding="checkbox">
                   <OutlinedCheckbox
-                    indeterminate={numSelected > 0 && numSelected < selectableRowCount}
-                    checked={selectableRowCount > 0 && numSelected === selectableRowCount}
+                    indeterminate={
+                      numSelected > 0 && numSelected < selectableRowCount
+                    }
+                    checked={
+                      selectableRowCount > 0 &&
+                      numSelected === selectableRowCount
+                    }
                     onChange={handleSelectAllClick}
                     inputProps={{
                       "aria-label": "select all",
@@ -235,7 +244,10 @@ export function DataTable<T>({
           <TableBody key={`table-body-${page}-${rowsPerPage}`}>
             {isError && (
               <TableRow>
-                <TableCell colSpan={columns.length + (selectable ? 1 : 0)} align="center">
+                <TableCell
+                  colSpan={columns.length + (selectable ? 1 : 0)}
+                  align="center"
+                >
                   {errorMessage}
                 </TableCell>
               </TableRow>
@@ -264,7 +276,10 @@ export function DataTable<T>({
 
             {!isLoading && !isError && paginatedData.length === 0 && (
               <TableRow>
-                <TableCell colSpan={columns.length + (selectable ? 1 : 0)} align="center">
+                <TableCell
+                  colSpan={columns.length + (selectable ? 1 : 0)}
+                  align="center"
+                >
                   {emptyMessage}
                 </TableCell>
               </TableRow>
@@ -285,13 +300,18 @@ export function DataTable<T>({
                     role={selectable ? "checkbox" : undefined}
                     aria-checked={selectable ? isItemSuccessful : undefined}
                     selected={isItemSuccessful}
-                    sx={{ 
-                      cursor: selectable && !isItemSuccessful ? "pointer" : "default",
+                    sx={{
+                      cursor:
+                        selectable && !isItemSuccessful ? "pointer" : "default",
                       "&.Mui-selected": {
-                        backgroundColor: isItemSuccessful ? BCDesignTokens.supportSurfaceColorSuccess : "transparent",
+                        backgroundColor: isItemSuccessful
+                          ? BCDesignTokens.supportSurfaceColorSuccess
+                          : "transparent",
                       },
                       "&.Mui-selected:hover": {
-                        backgroundColor: isItemSuccessful ? BCDesignTokens.supportSurfaceColorSuccess : "rgba(0, 0, 0, 0.04)",
+                        backgroundColor: isItemSuccessful
+                          ? BCDesignTokens.supportSurfaceColorSuccess
+                          : "rgba(0, 0, 0, 0.04)",
                       },
                     }}
                   >
@@ -308,10 +328,12 @@ export function DataTable<T>({
                     )}
                     {columns.map((column) => {
                       const cellContent =
-                        column.renderCell?.(row) ?? column.getValue?.(row) ?? null;
+                        column.renderCell?.(row) ??
+                        column.getValue?.(row) ??
+                        null;
                       return (
                         <PlainTableCell key={column.id}>
-                          {cellContent}
+                          {cellContent ?? "-"}
                         </PlainTableCell>
                       );
                     })}
@@ -321,7 +343,10 @@ export function DataTable<T>({
 
             {paginated && !isLoading && !isError && emptyRows > 0 && (
               <TableRow style={{ height: ROW_HEIGHT * emptyRows }}>
-                <TableCell colSpan={columns.length + (selectable ? 1 : 0)} sx={{ border: "none" }} />
+                <TableCell
+                  colSpan={columns.length + (selectable ? 1 : 0)}
+                  sx={{ border: "none" }}
+                />
               </TableRow>
             )}
           </TableBody>

--- a/submit-web/src/hooks/api/useAccounts.ts
+++ b/submit-web/src/hooks/api/useAccounts.ts
@@ -122,6 +122,7 @@ export const getAccount = async (
         accountId: user.account_user.account.id,
         userType: USER_TYPE.PROPONENT,
         userManagementRole: user.account_user.role,
+        userManagementRoles: user.account_user.roles,
         roles: user.account_user.role.permissions,
         hasAgreedToTerms: user.account_user.has_agreed_to_terms,
       };

--- a/submit-web/src/models/AccountUser.ts
+++ b/submit-web/src/models/AccountUser.ts
@@ -25,6 +25,7 @@ export type AccountUser = {
   company_name: string;
   account: Account;
   role: Role;
+  roles: Role[];
   has_agreed_to_terms: boolean;
 };
 

--- a/submit-web/src/models/Project.ts
+++ b/submit-web/src/models/Project.ts
@@ -7,6 +7,7 @@ export type Project = {
   name: string;
   proponent_id: number;
   proponent?: Proponent;
+  works?: TrackWork[];
   ea_certificate?: string;
   epic_guid: string;
 };

--- a/submit-web/src/models/TrackPhase.ts
+++ b/submit-web/src/models/TrackPhase.ts
@@ -1,6 +1,7 @@
 export type TrackPhase = {
   id: number;
   name: string;
+  display_name?: string;
   ea_act_id?: number;
   work_type_id: number;
   work_type_name?: string;

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout.tsx
@@ -26,8 +26,9 @@ export const Route = createFileRoute(
     }
 
     if (
-      String(account.userManagementRole?.account_project_id) !==
-      accountProjectId
+      !account.userManagementRoles?.some(
+        (role) => String(role.account_project_id) === accountProjectId,
+      )
     ) {
       return redirect({
         to: "/unauthorized",
@@ -69,11 +70,15 @@ function ProjectLayout() {
   const { data: accountProject } = useSuspenseQuery(
     getAccountProjectQueryOptions(accountProjectId),
   );
-  const { userManagementRole } = useAccount();
+  const { userManagementRoles } = useAccount();
 
   if (!accountProject) return <Navigate to="/error" />;
 
-  if (userManagementRole?.account_project_id !== accountProjectId) {
+  if (
+    !userManagementRoles?.some(
+      (role) => role.account_project_id === accountProjectId,
+    )
+  ) {
     return <Navigate to="/unauthorized" />;
   }
 

--- a/submit-web/src/store/proponentStore.ts
+++ b/submit-web/src/store/proponentStore.ts
@@ -8,12 +8,12 @@ interface ProponentState {
   selectedProjectsIds: (string | number)[];
   isLoading: boolean;
   isError: boolean;
-  
+
   // Computed/derived properties
   onboardedProjects: Project[];
   eligibleProjects: Project[];
   pendingInvitation: Invitation | undefined;
-  
+
   // Actions
   setProponent: (proponent: Proponent | null) => void;
   setSelectedProjectsIds: (ids: (string | number)[]) => void;
@@ -34,39 +34,46 @@ const initialState = {
 
 export const useProponentStore = create<ProponentState>((set) => ({
   ...initialState,
-  
+
   setProponent: (proponent) => {
     set({ proponent });
-    
+
     if (proponent) {
       // Ideally there is only 1 pending invitation per proponent, but just in case we grab the most recent pending invite.
-      const pendingInvitation = proponent.invitations
-        ?.filter((invitation) => invitation.status === InvitationStatus.PENDING)
-        .sort(
-          (a, b) =>
-            new Date(b.expiry_date).getTime() - new Date(a.expiry_date).getTime(),
-        )[0];  
+      const pendingInvitation =
+        proponent.status == "ONBOARDED"
+          ? undefined
+          : proponent.invitations
+              ?.filter(
+                (invitation) => invitation.status === InvitationStatus.PENDING,
+              )
+              .sort(
+                (a, b) =>
+                  new Date(b.expiry_date).getTime() -
+                  new Date(a.expiry_date).getTime(),
+              )[0];
 
       const accountProjectIds = new Set(
-        proponent.account_projects?.map(ap => ap.project_id) || []
+        proponent.account_projects?.map((ap) => ap.project_id) || [],
       );
 
       const onboardedProjects = (proponent.projects || [])
-        .filter(project => accountProjectIds.has(project.id))
+        .filter((project) => accountProjectIds.has(project.id))
         .sort((a, b) => a.name.localeCompare(b.name));
 
-      const eligibleProjects = proponent.status != "ONBOARDED" 
-      ? proponent.projects 
-      : (proponent.projects || [])
-        .filter(project => !accountProjectIds.has(project.id))
-        .sort((a, b) => a.name.localeCompare(b.name));
+      const eligibleProjects =
+        proponent.status != "ONBOARDED"
+          ? proponent.projects
+          : (proponent.projects || [])
+              .filter((project) => !accountProjectIds.has(project.id))
+              .sort((a, b) => a.name.localeCompare(b.name));
 
       set({ pendingInvitation, onboardedProjects, eligibleProjects });
     } else {
       set({ onboardedProjects: [], eligibleProjects: [] });
     }
   },
-  
+
   setSelectedProjectsIds: (selectedProjectsIds) => set({ selectedProjectsIds }),
   setIsLoading: (isLoading) => set({ isLoading }),
   setIsError: (isError) => set({ isError }),


### PR DESCRIPTION
Tickets: 
- [SUBMIT-700](https://eao-dst.atlassian.net/browse/SUBMIT-700) EAO - View and Manage Onboarded and Eligible Projects/Works
- [SUBMIT-752](https://eao-dst.atlassian.net/browse/SUBMIT-752) Entity - Display Assessment Early Engagement Card on Projects Page (partial PR)

**Description**
_Backend_
- Create `user_role` and `account_project_works` entries when a user has been onboarded, or a project is enabled for an existing user.
- Return project works and phase data from api.
- Allow a user to access multiple projects if they have the correct user roles. Previously we only allow a user to access a single project. Roles needed: `ACCOUNT_PRIMARY_ADMIN`, `PROJECT_ADMIN`.

_Frontend_
- Fix displaying "Assessment" project cards.
- Map project work and phase data in projects table (where the data exists).
- Check if user is authorized based on the roles list, not the singular role returned from the api.

_Screenshots_

The projects table now lists the work and phase data.
<img width="1195" height="287" alt="Screenshot 2026-03-10 at 3 22 23 PM" src="https://github.com/user-attachments/assets/8539997e-0d67-4725-b9f5-f407da5f4722" />

---

Multiple project access for an account primary admin user. Previously this user could only access a single project. This also applies to project admins.
<img width="1470" height="499" alt="Screenshot 2026-03-10 at 5 16 24 PM" src="https://github.com/user-attachments/assets/f0fce383-c3e3-4950-b2cd-42c892ca16b7" />



[SUBMIT-700]: https://eao-dst.atlassian.net/browse/SUBMIT-700?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUBMIT-752]: https://eao-dst.atlassian.net/browse/SUBMIT-752?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ