### PR TITLE
SUBMIT-745 Update submission banner logic

### DIFF
--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -72,16 +72,15 @@ export default function SubmissionPage() {
   });
 
   const currentPackageVersion = packageVersions?.find(
-    (pv) => pv.package_id === submissionPackageId
+    (pv) => pv.package_id === submissionPackageId,
   );
 
-  const isLatestApprovedPackageVersion = 
-    currentPackageVersion?.is_latest && 
-    currentPackageVersion?.is_approved;
+  const hasAnyApprovedPackageVersion = packageVersions?.some(
+    (pv) => pv.is_approved,
+  );
 
-  const isNewerThanLastApprovedButNotApproved = 
-    currentPackageVersion?.is_latest && 
-    !currentPackageVersion?.is_approved;
+  const isLatestApprovedPackageVersion =
+    currentPackageVersion?.is_latest && currentPackageVersion?.is_approved;
 
   const {
     mutate: updateStateSubmissionPackage,
@@ -212,11 +211,9 @@ export default function SubmissionPage() {
                   alignItems: "center",
                   justifyContent: "space-between",
 
-                  mb:
-                    isLatestApprovedPackageVersion ||
-                    isNewerThanLastApprovedButNotApproved
-                      ? 0
-                      : BCDesignTokens.layoutMarginXlarge,
+                  mb: hasAnyApprovedPackageVersion
+                    ? 0
+                    : BCDesignTokens.layoutMarginXlarge,
                 }}
               >
                 <BarTitle title={managementPlanName} />
@@ -255,7 +252,12 @@ export default function SubmissionPage() {
                   </Typography>
                 </SuccessBox>
               </When>
-              <When condition={isNewerThanLastApprovedButNotApproved}>
+              <When
+                condition={
+                  !isLatestApprovedPackageVersion &&
+                  hasAnyApprovedPackageVersion
+                }
+              >
                 <WarningBox
                   sx={{
                     mb: BCDesignTokens.layoutMarginMedium,
@@ -266,8 +268,13 @@ export default function SubmissionPage() {
                     variant="body2"
                     color={BCDesignTokens.typographyColorPrimary}
                   >
-                    Please Note: This submission is still pending EAO review.
-                    Until finalized, it is not considered enforceable.
+                    Please Note: This submission is not considered enforceable.
+                    Please refer to the Submission Package with this icon
+                    <GppGoodOutlinedIcon
+                      fontSize="small"
+                      sx={{ verticalAlign: "middle" }}
+                    />
+                    for the enforceable version.
                   </Typography>
                 </WarningBox>
               </When>


### PR DESCRIPTION
Ticket: [SUBMIT-745](https://eao-dst.atlassian.net/browse/SUBMIT-745) Entity - Submission Banners

**Description**
Updated how the "Pending" submission banner displays. See comment from MA:

>The latest approved Plan ONLY has the green badge and “checkmark” on the package version button.
>
>All other packages (submitted before the latest approved package AND submitted after the latest approved package) will have the yellow badge. Edit the content to: “Please Note: This submission is not considered enforceable. Please refer to the Submission Package with this icon [insert shield with checkmark icon] for the enforceable version.

[SUBMIT-745]: https://eao-dst.atlassian.net/browse/SUBMIT-745?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ