### PR TITLE
SUBMIT-783 Update ProjectCard to get work and phase data from api

### DIFF
--- a/submit-api/src/submit_api/schemas/project.py
+++ b/submit-api/src/submit_api/schemas/project.py
@@ -25,6 +25,7 @@ class ProjectSchema(Schema):
     proponent = fields.Nested(ProponentSchema, data_key="proponent", allow_none=True)
     ea_certificate = fields.Str(data_key="ea_certificate")
     epic_guid = fields.Str(data_key="epic_guid")
+    works = fields.List(fields.Nested(TrackWorkSchema, data_key="works"))
 
 
 class AddProjectSchema(Schema):

--- a/submit-web/src/components/App/AccountRegistration/ProjectCard.tsx
+++ b/submit-web/src/components/App/AccountRegistration/ProjectCard.tsx
@@ -1,5 +1,6 @@
-import { FiberManualRecordTwoTone } from "@mui/icons-material";
-import { Box, Typography, Stack, Divider } from "@mui/material";
+import { Box, Typography, Divider } from "@mui/material";
+import { ProjectStatus } from "@/components/App/registration/addProjects/ProjectStatus";
+import { getProjectStatus } from "@/components/App/registration/addProjects/ProjectCard/constants";
 import { BCDesignTokens } from "epic.theme";
 import { Project } from "@/models/Project";
 
@@ -8,6 +9,10 @@ type ProjectCardProps = {
 };
 
 export const ProjectCard = ({ project }: ProjectCardProps) => {
+  const work = project.works?.at(-1)?.current_phase?.work_type_name;
+  const phase = project.works?.at(-1)?.current_phase?.name;
+  const status = phase ? getProjectStatus(phase) : undefined;
+
   return (
     <Box
       sx={{
@@ -47,20 +52,9 @@ export const ProjectCard = ({ project }: ProjectCardProps) => {
           }}
         >
           <Typography variant="h4" fontWeight={400} px={1.5} py={1}>
-            EAC Assessment
+            {work}
           </Typography>
-          <Stack
-            direction="row"
-            alignItems="center"
-            spacing={0.5}
-            px={1.5}
-            mb={1.5}
-          >
-            <FiberManualRecordTwoTone fontSize="small" />
-            <Typography variant="body2" color={BCDesignTokens.themeGray110}>
-              Early Engagement
-            </Typography>
-          </Stack>
+          {status && <ProjectStatus status={status} />}
           <Divider sx={{ borderColor: BCDesignTokens.themeGray40 }} />
           <Typography variant="body1" px={1.5} py={1.5}>
             Submit your Initial Project Description &amp; Engagement Plan, and

--- a/submit-web/src/components/App/AccountRegistration/ProjectCard.tsx
+++ b/submit-web/src/components/App/AccountRegistration/ProjectCard.tsx
@@ -51,10 +51,14 @@ export const ProjectCard = ({ project }: ProjectCardProps) => {
             boxShadow: "0 0px 6px 1px rgba(0, 0, 0, 0.10)",
           }}
         >
-          <Typography variant="h4" fontWeight={400} px={1.5} py={1}>
+          <Typography variant="h4" fontWeight={400} px={1.5} pt={1}>
             {work}
           </Typography>
-          {status && <ProjectStatus status={status} />}
+          {status && (
+            <Box px={1} pb={1}>
+              <ProjectStatus status={status} />
+            </Box>
+          )}
           <Divider sx={{ borderColor: BCDesignTokens.themeGray40 }} />
           <Typography variant="body1" px={1.5} py={1.5}>
             Submit your Initial Project Description &amp; Engagement Plan, and

--- a/submit-web/src/components/App/registration/addProjects/ProjectCard/constants.ts
+++ b/submit-web/src/components/App/registration/addProjects/ProjectCard/constants.ts
@@ -2,3 +2,16 @@ export const PROJECT_STATUS = {
   EARLY_ENGAGEMENT: "EARLY_ENGAGEMENT",
   POST_DECISION: "POST_DECISION",
 };
+
+export type ProjectStatusKey = keyof typeof PROJECT_STATUS;
+
+// Maps API display strings to PROJECT_STATUS keys
+const DISPLAY_NAME_TO_STATUS: Record<string, ProjectStatusKey> = {
+  "Post Decision": "POST_DECISION",
+  "Early Engagement": "EARLY_ENGAGEMENT",
+};
+
+export const getProjectStatus = (
+  displayName: string,
+): ProjectStatusKey | string =>
+  DISPLAY_NAME_TO_STATUS[displayName] ?? displayName;

--- a/submit-web/src/components/App/registration/addProjects/ProjectStatus.tsx
+++ b/submit-web/src/components/App/registration/addProjects/ProjectStatus.tsx
@@ -8,6 +8,11 @@ type StyleProps = {
   label: string;
 };
 
+const DEFAULT_STYLE: StyleProps = {
+  color: EAOColors.ProponentDark,
+  label: "Unknown Status",
+};
+
 const statusStyles: Record<string, StyleProps> = {
   POST_DECISION: {
     color: EAOColors.DecisionDark,
@@ -23,7 +28,7 @@ type ProjectStatusProps = {
   status: string;
 };
 export const ProjectStatus = ({ status }: ProjectStatusProps) => {
-  const style = statusStyles[status];
+  const style = statusStyles[status] ?? { ...DEFAULT_STYLE, label: status };
 
   if (!style) {
     return null;


### PR DESCRIPTION
Tickets: [SUBMIT-783](https://eao-dst.atlassian.net/browse/SUBMIT-783) EAO/Entity - Work/Phase mismatch between Proponent Info (EAO) and Account Creation (Entity)

**Description**
- Update ProjectCard to get work and phase data from api
- Use common project status component

**Screenshot**
_Notice that the work and phase match up now with the EAO project invitations table. The project phase status ("Early Engagement" in this case) design is updated to match the rest of the application._
<img width="882" height="547" alt="Screenshot 2026-04-15 at 7 55 58 AM" src="https://github.com/user-attachments/assets/19923be6-93c6-4cf5-9e7f-a84e72d74210" />

<img width="1186" height="265" alt="Screenshot 2026-04-15 at 7 57 05 AM" src="https://github.com/user-attachments/assets/bad544e2-3ad7-4ea4-93e2-1c49d9fcfdd2" />


[SUBMIT-783]: https://eao-dst.atlassian.net/browse/SUBMIT-783?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ