### PR TITLE
SUBMIT-719 Fix API error on packages and projects endpoints

### DIFF
--- a/submit-api/requirements.txt
+++ b/submit-api/requirements.txt
@@ -11,14 +11,14 @@ cryptography==46.0.6
 flake8_import_order==0.19.2
 Flask-Caching==2.3.1
 flask-cors==6.0.2
-flask-jwt-oidc==0.8.0
+flask-jwt-oidc==0.9.0
 Flask-Mail==0.10.0
 flask-marshmallow==1.2.1
 Flask-Migrate==4.1.0
 Flask-Moment==1.0.6
 flask-restx==1.3.2
 Flask-SQLAlchemy==3.1.1
-Flask==3.1.2
+Flask==3.1.3
 gunicorn==23.0.0
 idna==3.11
 importlib_resources==6.5.2
@@ -37,7 +37,7 @@ pycodestyle==2.14.0
 pycparser==2.23
 pyflakes==3.4.0
 pyhumps==3.8.0
-PyJWT==2.10.1
+PyJWT==2.12.1
 python-dotenv==1.2.1
 referencing==0.37.0
 requests==2.32.5


### PR DESCRIPTION
Tickets: [SUBMIT-719](https://eao-dst.atlassian.net/browse/SUBMIT-719) Refactor - Remove public and private endpoints and combine into one endpoint

**Description**
- There is a bug relating to the refactor where the `/projects` and `/packages` endpoints return an `HTTP 500` error, causing an error screen when trying to access a project.

<img width="1470" height="809" alt="Screenshot 2026-04-15 at 9 38 47 AM" src="https://github.com/user-attachments/assets/2982a0b6-5d32-4f8f-9b2c-ed2dc446611a" />

---

**Analysis**
- What was weird about the bug is it was not replicable in the local environment.

```bash
# in dev
2026-04-14 23:15:44 +0000] [8] [ERROR] Error handling request /api/projects/159
Traceback (most recent call last):

  (stack trace...) 

  File "/usr/local/lib/python3.12/site-packages/flask_jwt_oidc/jwt_manager.py", line 272, in decorated
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/src/submit_api/auth.py", line 44, in decorated
    return f(*args, **kwargs)
           ^^^^^^^^^^^^^^^^^^
  File "/opt/app-root/src/submit_api/resources/project.py", line 196, in get
    is_staff = jwt.contains_role([EpicSubmitRole.EAO_VIEW.value])
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
TypeError: JwtManager.contains_role() missing 1 required positional argument: 'roles'
```

```bash
# in local
INFO:werkzeug:127.0.0.1 - - [15/Apr/2026 08:27:33] "GET /api/projects/159 HTTP/1.1" 200 -
```

- After some digging I discovered that my local setup was using `flask-jwt-oidc==0.9.0` while dev is using `flask-jwt-oidc==0.8.0`. The `contains_role` function is different between the two versions (see [here](https://github.com/thorwolpert/flask-jwt-oidc/commit/c819074c00f0dd4e770fe63f5585303d6c981e0e#diff-e7f3670265ea902074ad877484228e3c3a9e77aa3877cfbcfed11bc62717a90dL200-R200)).

---

**Solution**
- There are 2 possible solutions. We either update `flask-jwt-oidc` in dev to the latest version. Or we update the usage of `contains_role` to match the old version (if for some reason we want to stay on 0.8.0). I suggest we just update `flask-jwt-oidc`.

[SUBMIT-719]: https://eao-dst.atlassian.net/browse/SUBMIT-719?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ