### PR TITLE
SUBMIT-806 Hide scrollbars on document tables

### DIFF
--- a/submit-web/src/components/App/DocumentUpload/DocumentTable.tsx
+++ b/submit-web/src/components/App/DocumentUpload/DocumentTable.tsx
@@ -39,7 +39,7 @@ export default function DocumentTable({
     return null;
   }
   return (
-    <TableContainer component={Box} sx={{ height: "100%" }}>
+    <TableContainer component={Box} sx={{ height: "100%", overflow: "hidden" }}>
       <Table sx={{ tableLayout: "fixed" }}>
         <TableHead
           sx={{

--- a/submit-web/src/components/App/Submission/ItemsTable/index.tsx
+++ b/submit-web/src/components/App/Submission/ItemsTable/index.tsx
@@ -27,7 +27,7 @@ export default function ItemsTable({ submissionPackage }: ItemsTableProps) {
   }, [submissionPackage.internal_staff_documents, initializeFiles]);
 
   return (
-    <TableContainer component={Box} sx={{ height: "100%" }}>
+    <TableContainer component={Box} sx={{ height: "100%", overflow: "hidden" }}>
       <Table sx={{ tableLayout: "fixed" }}>
         <ItemsTableHead packageType={packageType} />
         <TableBody>

--- a/submit-web/src/components/App/SubmissionItem/InternalDocuments/Table.tsx
+++ b/submit-web/src/components/App/SubmissionItem/InternalDocuments/Table.tsx
@@ -15,7 +15,9 @@ type TableProps = Readonly<{
 }>;
 export default function Table({ hideManageDocuments = false }: TableProps) {
   return (
-    <TableContainer sx={{ height: "100%", cursor: "pointer" }}>
+    <TableContainer
+      sx={{ height: "100%", cursor: "pointer", overflow: "hidden" }}
+    >
       <MuiTable sx={{ tableLayout: "fixed" }}>
         <TableHead
           sx={{

--- a/submit-web/src/components/Shared/Table/common.tsx
+++ b/submit-web/src/components/Shared/Table/common.tsx
@@ -20,7 +20,7 @@ export const SubmitTableHeadCell = styled(TableCell)(() => ({
 }));
 
 export const SubmitCheckboxTableHeadCell = styled(SubmitTableHeadCell)(() => ({
-  textAlign: 'center'
+  textAlign: "center",
 }));
 
 export const SubmitTableCell = styled(TableCell)(() => ({
@@ -62,7 +62,7 @@ export const PlainTableCell = styled(TableCell)(() => ({
 export const PlainCheckboxTableCell = styled(PlainTableCell)(() => ({
   padding: 0,
   borderRight: `1px solid ${BCDesignTokens.themeGray40}`,
-  textAlign: 'center'
+  textAlign: "center",
 }));
 
 export const SubmitTableHead = styled(TableHead)(() => ({}));
@@ -70,6 +70,7 @@ export const SubmitTableHead = styled(TableHead)(() => ({}));
 export const SubmitTableContainer = styled(TableContainer)(() => ({
   height: "100%",
   cursor: "pointer",
+  overflow: "hidden",
 }));
 
 const StyledTableRow = styled(TableRow, {
@@ -105,31 +106,29 @@ export const SubmitTablePrimaryRow = ({
 
 export const SubmitPrimaryRowTableCell = styled(TableCell, {
   shouldForwardProp: (prop) => prop !== "error",
-})<{ error?: boolean }>(
-  ({ error }) => ({
-    borderTop: error
+})<{ error?: boolean }>(({ error }) => ({
+  borderTop: error
+    ? `1px solid ${BCDesignTokens.supportBorderColorDanger}`
+    : `1px solid ${BCDesignTokens.themeBlue20}`,
+  borderBottom: error
+    ? `1px solid ${BCDesignTokens.supportBorderColorDanger}`
+    : `1px solid ${BCDesignTokens.themeBlue20}`,
+  padding: `${BCDesignTokens.layoutPaddingXsmall} !important`,
+  "&:first-of-type": {
+    borderLeft: error
       ? `1px solid ${BCDesignTokens.supportBorderColorDanger}`
       : `1px solid ${BCDesignTokens.themeBlue20}`,
-    borderBottom: error
+    borderTopLeftRadius: 5,
+    borderBottomLeftRadius: 5,
+  },
+  "&:last-of-type": {
+    borderRight: error
       ? `1px solid ${BCDesignTokens.supportBorderColorDanger}`
       : `1px solid ${BCDesignTokens.themeBlue20}`,
-    padding: `${BCDesignTokens.layoutPaddingXsmall} !important`,
-    "&:first-of-type": {
-      borderLeft: error
-        ? `1px solid ${BCDesignTokens.supportBorderColorDanger}`
-        : `1px solid ${BCDesignTokens.themeBlue20}`,
-      borderTopLeftRadius: 5,
-      borderBottomLeftRadius: 5,
-    },
-    "&:last-of-type": {
-      borderRight: error
-        ? `1px solid ${BCDesignTokens.supportBorderColorDanger}`
-        : `1px solid ${BCDesignTokens.themeBlue20}`,
-      borderTopRightRadius: 5,
-      borderBottomRightRadius: 5,
-    },
-  }),
-);
+    borderTopRightRadius: 5,
+    borderBottomRightRadius: 5,
+  },
+}));
 
 export const SubmitSubTableCell = styled(TableCell)(() => ({
   borderTop: `none`,


### PR DESCRIPTION
Tickets: [SUBMIT-806](https://eao-dst.atlassian.net/browse/SUBMIT-806) Entity- Remove scroll bar at the bottom of the submission table on submission package page

**Description**
- Set `overflow: "hidden"` on documents tables to hide scroll bars.
- Verified this does not change existing viewing on smaller window sizes.

[SUBMIT-806]: https://eao-dst.atlassian.net/browse/SUBMIT-806?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ