### PR TITLE
SUBMIT-782 Add is_eligible calculated property to projects

### DIFF
--- a/submit-api/src/submit_api/models/project.py
+++ b/submit-api/src/submit_api/models/project.py
@@ -29,6 +29,15 @@ class Project(db.Model):
         db.UniqueConstraint('name', 'proponent_id', name='uq_projects_name_proponent'),
     )
 
+    @property
+    def is_eligible(self):
+        """Determines if the current project is eligible in submit."""
+        try:
+            phase_is_enabled = self.works.current_phase.enable_submit
+        except AttributeError:
+            phase_is_enabled = None
+        return bool(phase_is_enabled or self.has_approved_condition)
+
     def to_dict(self):
         """Convert object to dictionary."""
         return {
@@ -39,6 +48,7 @@ class Project(db.Model):
             "works": [work.to_dict() for work in self.works],
             "ea_certificate": self.ea_certificate,
             "epic_guid": self.epic_guid,
+            "is_eligible": self.is_eligible
         }
 
     @classmethod

--- a/submit-web/src/models/Project.ts
+++ b/submit-web/src/models/Project.ts
@@ -10,6 +10,7 @@ export type Project = {
   works?: TrackWork[];
   ea_certificate?: string;
   epic_guid: string;
+  is_eligible?: boolean;
 };
 
 export const getProjectProponentId = (project: Project): number => {

--- a/submit-web/src/store/proponentStore.ts
+++ b/submit-web/src/store/proponentStore.ts
@@ -63,9 +63,10 @@ export const useProponentStore = create<ProponentState>((set) => ({
 
       const eligibleProjects =
         proponent.status != "ONBOARDED"
-          ? proponent.projects
+          ? (proponent.projects || []).filter((project) => project.is_eligible)
           : (proponent.projects || [])
               .filter((project) => !accountProjectIds.has(project.id))
+              .filter((project) => project.is_eligible)
               .sort((a, b) => a.name.localeCompare(b.name));
 
       set({ pendingInvitation, onboardedProjects, eligibleProjects });


### PR DESCRIPTION
Tickets: [SUBMIT-782](https://eao-dst.atlassian.net/browse/SUBMIT-782) Entity- Remove scroll bar at the bottom of the submission table on submission package page

**Description**
- Created an `is_eligible` calculated property on `Project` model. A project is eligible if either:
  1. It's current phase is enabled in submit
  2. It has approved conditions
- Only display eligible projects. Any illegible projects will be hidden on 

**Screenshots**
_Before: Multiple projects that are technically not eligible are still displayed_
<img width="1194" height="741" alt="Screenshot 2026-04-20 at 8 48 42 AM" src="https://github.com/user-attachments/assets/d54cfb83-9476-419d-a0fc-0a6b31c02c30" />

_After: Only the 3 projects that have approved conditions are displayed_
<img width="1200" height="613" alt="Screenshot 2026-04-20 at 8 46 13 AM" src="https://github.com/user-attachments/assets/0ad05ecf-fb4e-4fa9-a9c5-ee2e75eecf3a" />


[SUBMIT-782]: https://eao-dst.atlassian.net/browse/SUBMIT-782?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ