### PR TITLE
SUBMIT-782 Use isWorkRelated flag rather than explicit submission type checks

### DIFF
--- a/submit-api/src/submit_api/models/account_project.py
+++ b/submit-api/src/submit_api/models/account_project.py
@@ -37,6 +37,11 @@ class AccountProject(BaseModel):
         back_populates='account_project')
 
     @property
+    def is_work_related(self):
+        """Determines if the account_project is tied to an eligible work."""
+        return self.project.is_current_phase_enabled
+    
+    @property
     def latest_packages(self):
         """Get the latest packages by versions for the account project."""
         version_by_package = {}

--- a/submit-api/src/submit_api/models/account_project.py
+++ b/submit-api/src/submit_api/models/account_project.py
@@ -40,7 +40,7 @@ class AccountProject(BaseModel):
     def is_work_related(self):
         """Determines if the account_project is tied to an eligible work."""
         return self.project.is_current_phase_enabled
-    
+
     @property
     def latest_packages(self):
         """Get the latest packages by versions for the account project."""

--- a/submit-api/src/submit_api/models/project.py
+++ b/submit-api/src/submit_api/models/project.py
@@ -30,13 +30,22 @@ class Project(db.Model):
     )
 
     @property
+    def current_work(self):
+        """Returns the active in-progress work, preferring the one with the highest id if multiple exist."""
+        matching = [w for w in self.works if w.is_active and not w.is_deleted and w.work_state == 'IN_PROGRESS']
+        return max(matching, key=lambda w: w.id, default=None)
+
+    @property
+    def is_current_phase_enabled(self):
+        """Determines if the current active phase is enabled in submit"""
+        if not self.current_work or not self.current_work.current_phase:
+            return False
+        return self.current_work.current_phase.enable_submit    
+
+    @property
     def is_eligible(self):
         """Determines if the current project is eligible in submit."""
-        try:
-            phase_is_enabled = self.works.current_phase.enable_submit
-        except AttributeError:
-            phase_is_enabled = None
-        return bool(phase_is_enabled or self.has_approved_condition)
+        return bool(self.is_current_phase_enabled or self.has_approved_condition)
 
     def to_dict(self):
         """Convert object to dictionary."""

--- a/submit-api/src/submit_api/models/project.py
+++ b/submit-api/src/submit_api/models/project.py
@@ -40,7 +40,7 @@ class Project(db.Model):
         """Determines if the current active phase is enabled in submit"""
         if not self.current_work or not self.current_work.current_phase:
             return False
-        return self.current_work.current_phase.enable_submit    
+        return self.current_work.current_phase.enable_submit
 
     @property
     def is_eligible(self):

--- a/submit-api/src/submit_api/resources/package.py
+++ b/submit-api/src/submit_api/resources/package.py
@@ -153,7 +153,7 @@ class PackageVersions(Resource):
     @API.response(HTTPStatus.NOT_FOUND, "Not Found")
     @cross_origin(origins=allowedorigins())
     @auth.has_one_of_staff_roles([EpicSubmitRole.EAO_CREATE.value])
-    def post(original_package_id):
+    def post(original_package_id):  # pylint: disable=unused-argument
         """Create a new package version."""
         package_version_data = CreatePackageVersionSchema().load(API.payload)
         package_with_created_package_version = PackageService.create_new_package_version_with_contacts(

--- a/submit-api/src/submit_api/schemas/project.py
+++ b/submit-api/src/submit_api/schemas/project.py
@@ -26,7 +26,9 @@ class ProjectSchema(Schema):
     proponent = fields.Nested(ProponentSchema, data_key="proponent", allow_none=True)
     ea_certificate = fields.Str(data_key="ea_certificate")
     epic_guid = fields.Str(data_key="epic_guid")
+    has_approved_condition = fields.Boolean(data_key="has_approved_condition")
     works = fields.List(fields.Nested(TrackWorkSchema, data_key="works"))
+    current_work = fields.Nested(TrackWorkSchema, data_key="current_work")
 
 
 class AddProjectSchema(Schema):
@@ -65,6 +67,7 @@ class AccountProjectSchema(Schema):
     project = fields.Nested(ProjectSchema, data_key="project")
     latest_packages = fields.List(fields.Nested(AccountProjectPackageSchema), data_key="packages")
     account_project_works = fields.List(fields.Nested(AccountProjectWorkSchema, data_key="account_project_works"))
+    is_work_related = fields.Boolean(data_key="is_work_related")
 
 
 class StaffAccountProjectPackageSchema(StaffPackageSchema):

--- a/submit-web/src/components/App/Projects/Project.tsx
+++ b/submit-web/src/components/App/Projects/Project.tsx
@@ -10,10 +10,10 @@ type ProjectParam = {
 
 export const Project = ({ accountProject }: ProjectParam) => {
   const navigate = useNavigate();
-  const { name, ea_certificate } = accountProject.project;
-  const currentWork =
-    accountProject.account_project_works?.at(-1)?.work ?? null;
-  const currentPhase = currentWork?.current_phase ?? null;
+  const { name, ea_certificate, current_work } = accountProject.project;
+  const status =
+    current_work?.current_phase?.name || PROJECT_STATUS.POST_DECISION;
+  const title = current_work?.title || "Management Plans & Related Documents";
 
   const handleNewSubmission = () => {
     navigate({
@@ -28,21 +28,13 @@ export const Project = ({ accountProject }: ProjectParam) => {
       topLabel={accountProject.project.proponent?.name || ""}
       bottomLabel={ea_certificate ? `EAC # ${ea_certificate}` : ""}
     >
-      {currentPhase?.work_type_name?.toUpperCase() == "ASSESSMENT" ? (
-        <ProjectSubmissionsCard
-          title={`${currentWork?.title}`}
-          status={currentPhase.name}
-          packages={accountProject.packages}
-          onNewSubmission={handleNewSubmission}
-        />
-      ) : (
-        <ProjectSubmissionsCard
-          title="Management Plans & Related Documents"
-          status={PROJECT_STATUS.POST_DECISION}
-          packages={accountProject.packages}
-          onNewSubmission={handleNewSubmission}
-        />
-      )}
+      <ProjectSubmissionsCard
+        title={title}
+        status={status}
+        isWorkRelated={accountProject.is_work_related}
+        packages={accountProject.packages}
+        onNewSubmission={handleNewSubmission}
+      />
     </ContentBox>
   );
 };

--- a/submit-web/src/components/App/Projects/ProjectSubmissionsCard.tsx
+++ b/submit-web/src/components/App/Projects/ProjectSubmissionsCard.tsx
@@ -8,7 +8,6 @@ import AddIcon from "@mui/icons-material/Add";
 import { Box, Button, Divider, styled, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { When } from "react-if";
-import { PROJECT_STATUS } from "@/components/App/registration/addProjects/ProjectCard/constants";
 import { SubmissionTitle } from "@/components/App/Submission/SubmissionTitle";
 
 export const CardInnerBox = styled(Box)({
@@ -24,6 +23,7 @@ type ProjectSubmissionsCardProps = {
   title: string;
   status: string;
   packages: SubmissionPackage[];
+  isWorkRelated?: boolean;
   onNewSubmission: () => void;
 };
 
@@ -31,6 +31,7 @@ export const ProjectSubmissionsCard = ({
   title,
   status,
   packages,
+  isWorkRelated = false,
   onNewSubmission,
 }: ProjectSubmissionsCardProps) => {
   const { userType } = useAccount();
@@ -55,6 +56,7 @@ export const ProjectSubmissionsCard = ({
         justifyContent={"space-between"}
         sx={{
           pt: BCDesignTokens.layoutPaddingMedium,
+          pl: "0.75rem",
           pb: BCDesignTokens.layoutPaddingXlarge,
         }}
       >
@@ -71,7 +73,7 @@ export const ProjectSubmissionsCard = ({
         </When>
       </Box>
       <Box height={"100%"} px={BCDesignTokens.layoutPaddingXsmall}>
-        <When condition={status != PROJECT_STATUS.EARLY_ENGAGEMENT}>
+        <When condition={!isWorkRelated}>
           <Divider
             sx={{
               ml: BCDesignTokens.layoutPaddingSmall,
@@ -94,7 +96,7 @@ export const ProjectSubmissionsCard = ({
         >
           <ProjectTable submissionPackages={activeSubmissionPackages} />
         </CardInnerBox>
-        <When condition={status != PROJECT_STATUS.EARLY_ENGAGEMENT}>
+        <When condition={!isWorkRelated}>
           <Divider
             sx={{
               mb: BCDesignTokens.layoutPaddingXsmall,

--- a/submit-web/src/models/Project.ts
+++ b/submit-web/src/models/Project.ts
@@ -8,8 +8,10 @@ export type Project = {
   proponent_id: number;
   proponent?: Proponent;
   works?: TrackWork[];
+  current_work?: TrackWork;
   ea_certificate?: string;
   epic_guid: string;
+  has_approved_condition?: boolean;
   is_eligible?: boolean;
 };
 
@@ -30,6 +32,7 @@ export type AccountProject = {
   project: Project;
   packages: SubmissionPackage[];
   account_project_works?: AccountProjectWork[];
+  is_work_related?: boolean;
 };
 
 export const createDefaultAccountProject = (): AccountProject => ({

--- a/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -200,17 +200,20 @@ export default function SubmissionPage() {
                 </WarningBox>
               </When>
               <InfoBox submissionPackage={submissionPackage} />
+              <When condition={!accountProject.is_work_related}>
+                <Box
+                  sx={{
+                    pt: BCDesignTokens.layoutMarginXlarge,
+                    mb: BCDesignTokens.layoutMarginLarge,
+                    width: "100%",
+                  }}
+                >
+                  <UpdateRequestWidget submissionPackage={submissionPackage} />
+                </Box>
+              </When>
               <Box
                 sx={{
-                  pt: BCDesignTokens.layoutMarginXlarge,
-                  mb: BCDesignTokens.layoutMarginLarge,
-                  width: "100%",
-                }}
-              >
-                <UpdateRequestWidget submissionPackage={submissionPackage} />
-              </Box>
-              <Box
-                sx={{
+                  mt: accountProject.is_work_related ? "36px" : "0px",
                   mb: BCDesignTokens.layoutMarginXlarge,
                   pt: BCDesignTokens.layoutPaddingXsmall,
                 }}


### PR DESCRIPTION
Description
- This was part of my upcoming PR for SUBMIT-788, but it fixes a bug in how eligible work related projects are displayed in the Proponents/Holders table.
- Pulled it out of the bigger PR in order to get merged quicker and unblock MA.