### PR TITLE
SUBMIT-791 | SUBMIT-849 EAO - Refuse IPD Submission

### DIFF
--- a/submit-api/migrations/versions/1585f55d0118_add_decision_date_to_package.py
+++ b/submit-api/migrations/versions/1585f55d0118_add_decision_date_to_package.py
@@ -1,0 +1,25 @@
+"""Add decision date to package
+
+Revision ID: 1585f55d0118
+Revises: 0a91b52dc3b1
+Create Date: 2026-05-15 10:37:00.732673
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '1585f55d0118'
+down_revision = '0a91b52dc3b1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table('packages', schema=None) as batch_op:
+        batch_op.add_column(sa.Column('decision_date',  sa.DateTime(), nullable=True))
+
+def downgrade():
+    with op.batch_alter_table('packages', schema=None) as batch_op:
+        batch_op.drop_column('decision_date')

--- a/submit-api/src/submit_api/models/package.py
+++ b/submit-api/src/submit_api/models/package.py
@@ -104,6 +104,7 @@ class Package(BaseModel):
     submitted_by_user = db.relationship(
         'User', foreign_keys=[submitted_by], lazy='joined')
     completed_on = Column(db.DateTime, nullable=True)
+    decision_date = Column(db.DateTime, nullable=True)
     meta = db.relationship(
         'PackageMetadata', backref='package', lazy='joined', uselist=False, cascade='all, delete', passive_deletes=True)
     items = db.relationship('Item', backref='package',

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -59,11 +59,15 @@ class PackageQueries:
             )
             .join(PackageModel, PackageModel.account_project_id == AccountProject.id)
             .join(PackageVersion,
-                  PackageModel.version_id == PackageVersion.id)  # Join with PackageVersion to filter by version_id
+                  PackageModel.version_id == PackageVersion.id, isouter=True)  # Join with PackageVersion to filter by version_id
             .join(latest_versions_subquery,
                   # Only fetch packages with the latest version_id
-                  PackageModel.version_id == latest_versions_subquery.c.latest_version_id)
-            .filter(AccountProject.account_id == account_id)
+                  PackageModel.version_id == latest_versions_subquery.c.latest_version_id, isouter=True)
+            .filter(AccountProject.account_id == account_id,
+                db.or_(
+                    PackageModel.version_id == latest_versions_subquery.c.latest_version_id,
+                    PackageModel.version_id == None
+                ))
         )
 
         if account_project_ids:

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -58,16 +58,18 @@ class PackageQueries:
                 ).label("packages")  # Aggregate packages as a JSON array
             )
             .join(PackageModel, PackageModel.account_project_id == AccountProject.id)
+            # Join with PackageVersion to filter by version_id
             .join(PackageVersion,
-                  PackageModel.version_id == PackageVersion.id, isouter=True)  # Join with PackageVersion to filter by version_id
+                  PackageModel.version_id == PackageVersion.id, isouter=True)
             .join(latest_versions_subquery,
                   # Only fetch packages with the latest version_id
                   PackageModel.version_id == latest_versions_subquery.c.latest_version_id, isouter=True)
             .filter(AccountProject.account_id == account_id,
-                db.or_(
-                    PackageModel.version_id == latest_versions_subquery.c.latest_version_id,
-                    PackageModel.version_id == None
-                ))
+                    db.or_(
+                        PackageModel.version_id == latest_versions_subquery.c.latest_version_id,
+                        PackageModel.version_id is None
+                    )
+                    )
         )
 
         if account_project_ids:

--- a/submit-api/src/submit_api/resources/package.py
+++ b/submit-api/src/submit_api/resources/package.py
@@ -23,7 +23,7 @@ from submit_api.enums.role import ProponentPermissionsEnum
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.package import (
     CreatePackageVersionSchema, CreateUpdateRequestNoteSchema, CreateUpdateRequestSchema, PackageSchema,
-    PackageUpdateRequestSchema, PackageVersionSchema, PostPackageRequestSchema, PostPackageState, StaffPackageSchema)
+    PackageUpdateRequestSchema, PackageVersionSchema, PostPackageRequestSchema, PostPackageState, StaffPackageSchema, RefusePackageSchema)
 from submit_api.services import authorization
 from submit_api.services.package_service import PackageService
 from submit_api.utils.roles import EpicSubmitRole
@@ -267,3 +267,24 @@ class PackageUpdateRequestNote(Resource):
         package_with_updated_note = PackageService.update_update_request_note(
             package_id, update_request_id, update_note_data)
         return PackageSchema().dump(package_with_updated_note), HTTPStatus.OK
+
+@cors_preflight("OPTIONS, POST")
+@API.route("/<int:package_id>/refuse", methods=["POST", "OPTIONS"])
+class RefusePackage(Resource):
+    """Resource for refusing a package."""
+
+    @staticmethod
+    @ApiHelper.swagger_decorators(
+        API, endpoint_description="Refuse package"
+    )
+    @API.response(
+        code=HTTPStatus.CREATED, model=package_model, description="Refused package"
+    )
+    @API.response(HTTPStatus.BAD_REQUEST, "Bad Request")
+    @cross_origin(origins=allowedorigins())
+    @auth.require
+    def post(package_id):
+        """Refuse package."""
+        request_body = RefusePackageSchema().load(API.payload)
+        new_package = PackageService.refuse_package(package_id, request_body.get("decision_date"))
+        return PackageSchema().dump(new_package), HTTPStatus.CREATED

--- a/submit-api/src/submit_api/resources/package.py
+++ b/submit-api/src/submit_api/resources/package.py
@@ -23,7 +23,8 @@ from submit_api.enums.role import ProponentPermissionsEnum
 from submit_api.resources.apihelper import Api as ApiHelper
 from submit_api.schemas.package import (
     CreatePackageVersionSchema, CreateUpdateRequestNoteSchema, CreateUpdateRequestSchema, PackageSchema,
-    PackageUpdateRequestSchema, PackageVersionSchema, PostPackageRequestSchema, PostPackageState, StaffPackageSchema, RefusePackageSchema)
+    PackageUpdateRequestSchema, PackageVersionSchema, PostPackageRequestSchema, PostPackageState, StaffPackageSchema,
+    RefusePackageSchema)
 from submit_api.services import authorization
 from submit_api.services.package_service import PackageService
 from submit_api.utils.roles import EpicSubmitRole
@@ -267,6 +268,7 @@ class PackageUpdateRequestNote(Resource):
         package_with_updated_note = PackageService.update_update_request_note(
             package_id, update_request_id, update_note_data)
         return PackageSchema().dump(package_with_updated_note), HTTPStatus.OK
+
 
 @cors_preflight("OPTIONS, POST")
 @API.route("/<int:package_id>/refuse", methods=["POST", "OPTIONS"])

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -75,6 +75,8 @@ class PostPackageState(Schema):
         unknown = EXCLUDE
 
     status = fields.Str(data_key="status")
+    decision_date = fields.DateTime(dataKey="decision_date")
+    reason = fields.Str(data_key="reason")
 
 
 class CreateUpdateRequestSchema(Schema):

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -75,6 +75,15 @@ class PostPackageState(Schema):
         unknown = EXCLUDE
 
     status = fields.Str(data_key="status")
+
+class RefusePackageSchema(Schema):
+    """refuse package schema."""
+
+    class Meta:  # pylint: disable=too-few-public-methods
+        """Exclude unknown fields in the deserialized output."""
+
+        unknown = EXCLUDE
+
     decision_date = fields.DateTime(dataKey="decision_date")
     reason = fields.Str(data_key="reason")
 

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -76,6 +76,7 @@ class PostPackageState(Schema):
 
     status = fields.Str(data_key="status")
 
+
 class RefusePackageSchema(Schema):
     """refuse package schema."""
 

--- a/submit-api/src/submit_api/services/package_service.py
+++ b/submit-api/src/submit_api/services/package_service.py
@@ -603,6 +603,30 @@ class PackageService:
             return package
 
     @classmethod
+    def not_approved_package(cls, package_id):
+        """Do not approve the package."""
+        with session_scope() as session:
+            package = cls.get_package_by_id(package_id)
+            if not package:
+                raise BadRequestError("Package not found")
+
+            # Remove all document statuses
+            for item in package.items:
+                for submission in item.submissions:
+                    if submission.type == SubmissionType.DOCUMENT:
+                        submission.status = None
+                        session.add(submission)
+
+            package.status = [PackageStatus.NOT_APPROVED.value]
+            session.add(package)
+
+            # Create new package version
+
+            # Save
+            session.flush()
+            return package
+
+    @classmethod
     def start_review(cls, package_id, _session=None):
         """Start the review process for the package."""
         package = cls._get_and_validate_package_for_starting_review(package_id)
@@ -735,6 +759,7 @@ class PackageService:
                 PackageStatus.UNDER_CONSULTATION_CHECK.value: cls.start_cr_check,
                 PackageStatus.ACKNOWLEDGED.value: cls.acknowledge_package,
                 PackageStatus.APPROVED.value: cls.approve_package,
+                PackageStatus.NOT_APPROVED.value: cls.not_approved_package
             }
         )
         return state_updaters[status]

--- a/submit-api/src/submit_api/services/package_service.py
+++ b/submit-api/src/submit_api/services/package_service.py
@@ -603,7 +603,7 @@ class PackageService:
             return package
 
     @classmethod
-    def not_approved_package(cls, package_id):
+    def refuse_package(cls, package_id, decision_date):
         """Do not approve the package."""
         with session_scope() as session:
             package = cls.get_package_by_id(package_id)
@@ -618,13 +618,24 @@ class PackageService:
                         session.add(submission)
 
             package.status = [PackageStatus.NOT_APPROVED.value]
+            package.decision_date = decision_date
             session.add(package)
 
-            # Create new package version
+            # Cancel all open update requests
+            for update_request in package.update_requests:
+                update_request.status = UpdateRequestStatus.CLOSED.value
+                update_request.active = False
+                session.add(update_request)
 
-            # Save
+            # Create new package version
+            new_package = cls.create_new_package_from_original(package_id, session)
+            if package.submitted_by:
+                user = User.get_by_guid(package.submitted_by)
+                if user:
+                    new_package.submitted_by = user.auth_guid
+
             session.flush()
-            return package
+            return new_package
 
     @classmethod
     def start_review(cls, package_id, _session=None):
@@ -759,7 +770,6 @@ class PackageService:
                 PackageStatus.UNDER_CONSULTATION_CHECK.value: cls.start_cr_check,
                 PackageStatus.ACKNOWLEDGED.value: cls.acknowledge_package,
                 PackageStatus.APPROVED.value: cls.approve_package,
-                PackageStatus.NOT_APPROVED.value: cls.not_approved_package
             }
         )
         return state_updaters[status]

--- a/submit-web/src/components/App/PackageStatusChip/index.tsx
+++ b/submit-web/src/components/App/PackageStatusChip/index.tsx
@@ -48,25 +48,22 @@ const themes = {
 type StyleProps = {
   label: string;
   theme: keyof typeof themes;
-  width?: string;
 };
 
 const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
   {
     APPROVED: { label: "Approved", theme: "success" },
-    ACCEPTED: { label: "Accepted", theme: "success", width: "83px" },
-    SATISFIED: { label: "Satisfied", theme: "success", width: "78px" },
+    ACCEPTED: { label: "Accepted", theme: "success" },
+    SATISFIED: { label: "Satisfied", theme: "success" },
     REVIEWED: { label: "Reviewed", theme: "success" },
     COMPLETED: { label: "Completed", theme: "success" },
     PASSED_CONSULTATION_CHECK: {
       label: "Passed Consultation Check",
       theme: "success",
-      width: "191px",
     },
     NO_REVISION_REQUIRED: {
       label: "No Revision Required",
       theme: "success",
-      width: "157px",
     },
     VERIFIED: { label: "Verified", theme: "success" },
     ACKNOWLEDGED: { label: "Acknowledged", theme: "success" },
@@ -78,13 +75,12 @@ const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
       label: "Under Consultation Check",
       theme: "info",
     },
-    SUBMITTED: { label: "Submitted", theme: "info", width: "104px" },
+    SUBMITTED: { label: "Submitted", theme: "info" },
     RESUBMITTED: { label: "Resubmitted", theme: "info" },
 
     REVIEW_REJECTED: {
       label: "Review Rejected",
       theme: "danger",
-      width: "125px",
     },
     FAILED_CONSULTATION_CHECK: {
       label: "Failed Consultation Check",
@@ -95,13 +91,11 @@ const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
     REVIEW_NOT_COMPLETED: {
       label: "Review Not Completed",
       theme: "warning",
-      width: "168px",
     },
     PARTIALLY_COMPLETED: { label: "Partially Completed", theme: "warning" },
     REQUESTED_BY_EAO: {
       label: "Requested by EAO",
       theme: "warning",
-      width: "139px",
     },
     INTERNAL_VERIFICATION: { label: "Internal Verification", theme: "warning" },
 
@@ -111,7 +105,6 @@ const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
     AWAITING_MANAGER_APPROVAL: {
       label: "Awaiting Manager Approval",
       theme: "orange",
-      width: "196px",
     },
     UPDATE_REQUESTED: {
       label: "Update Requested",
@@ -120,12 +113,10 @@ const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
     REVISION_REQUIRED: {
       label: "Revision Required",
       theme: "orange",
-      width: "140px",
     },
     REVISION_REQUESTED: {
       label: "Revision Requested",
       theme: "orange",
-      width: "150px",
     },
 
     UPDATED: { label: "Updated", theme: "purple" },
@@ -156,7 +147,6 @@ export default function PackageStatusChip({ status }: PackageStatusChipProps) {
   const sx: SxProps<Theme> = {
     ...baseSx,
     ...(config.theme ? themes[config.theme] : {}),
-    ...(config.width ? { width: config.width } : {}),
   };
 
   return <Chip sx={sx} label={config.label} />;

--- a/submit-web/src/components/App/PackageStatusChip/index.tsx
+++ b/submit-web/src/components/App/PackageStatusChip/index.tsx
@@ -7,6 +7,9 @@ const baseSx: SxProps<Theme> = {
   borderRadius: 1,
   height: "24px",
   px: 1,
+  "& .MuiChip-label": {
+    overflow: "visible",
+  },
 };
 
 const themes = {

--- a/submit-web/src/components/App/Projects/Project.tsx
+++ b/submit-web/src/components/App/Projects/Project.tsx
@@ -11,9 +11,10 @@ type ProjectParam = {
 
 export const Project = ({ accountProject }: ProjectParam) => {
   const navigate = useNavigate();
-  
+
   const { name, ea_certificate } = accountProject.project;
-  const hasAccountProjectWorks = (accountProject.account_project_works?.length ?? 0) > 0;
+  const hasAccountProjectWorks =
+    (accountProject.account_project_works?.length ?? 0) > 0;
 
   const handleNewSubmission = (workId?: number, isManagementPlan?: boolean) => {
     navigate({
@@ -29,31 +30,34 @@ export const Project = ({ accountProject }: ProjectParam) => {
       topLabel={accountProject.project.proponent?.name || ""}
       bottomLabel={ea_certificate ? `EAC # ${ea_certificate}` : ""}
     >
-      {hasAccountProjectWorks && accountProject.account_project_works && 
+      {hasAccountProjectWorks &&
+        accountProject.account_project_works &&
         accountProject.account_project_works.map((accountProjectWork) => {
           const workPackages = accountProject.packages.filter(
-            (pkg) => pkg.account_project_work?.id === accountProjectWork.id
+            (pkg) => pkg.account_project_work?.id === accountProjectWork.id,
           );
           return (
             <ProjectSubmissionsCard
               key={accountProjectWork.id}
               title={accountProjectWork.work.title || ""}
-              status={accountProjectWork.work.current_phase?.name || PROJECT_STATUS.POST_DECISION}
+              status={
+                accountProjectWork.work.current_phase?.name ||
+                PROJECT_STATUS.POST_DECISION
+              }
               isWorkRelated={true}
               workId={accountProjectWork.id}
               packages={workPackages}
               onNewSubmission={handleNewSubmission}
             />
           );
-        })
-      }
+        })}
       {accountProject.project.has_approved_condition && (
         <ProjectSubmissionsCard
           title="Management Plans & Related Documents"
           status={PROJECT_STATUS.POST_DECISION}
           isWorkRelated={false}
           packages={accountProject.packages.filter(
-            (pkg) => pkg.type.name === SubmissionPackageType.MANAGEMENT_PLAN
+            (pkg) => pkg.type.name === SubmissionPackageType.MANAGEMENT_PLAN,
           )}
           onNewSubmission={handleNewSubmission}
         />

--- a/submit-web/src/components/App/Submission/DocumentRow/index.tsx
+++ b/submit-web/src/components/App/Submission/DocumentRow/index.tsx
@@ -274,10 +274,7 @@ export default function DocumentRow({
             colSpan={6}
             style={{ paddingBottom: 0, paddingTop: 0, borderTop: "none" }}
           >
-            <DocumentsSubTable
-              submission={documentSubmission}
-              packageType={packageType}
-            />
+            <DocumentsSubTable submission={documentSubmission} />
           </SubmitTableCell>
         </TableRow>
       )}

--- a/submit-web/src/components/App/Submission/DocumentRow/index.tsx
+++ b/submit-web/src/components/App/Submission/DocumentRow/index.tsx
@@ -206,7 +206,7 @@ export default function DocumentRow({
             <span style={{ marginRight: "24px" }} />
           )}
         </SubmitTableCell>
-        <SubmitTableCell align="right" width={"15%"}>
+        <SubmitTableCell align="right" width={"18%"}>
           <Box mr={2}>
             <StatusCell
               submittedDocument={documentSubmission}
@@ -214,7 +214,7 @@ export default function DocumentRow({
             />
           </Box>
         </SubmitTableCell>
-        <SubmitTableCell align="right" width={"20%"}>
+        <SubmitTableCell align="right" width={"17%"}>
           <Box
             sx={{
               display: "flex",

--- a/submit-web/src/components/App/Submission/ItemsTable/DocumentsSubTable.tsx
+++ b/submit-web/src/components/App/Submission/ItemsTable/DocumentsSubTable.tsx
@@ -12,19 +12,16 @@ import { Submission } from "@/models/Submission";
 import { useGetSubmissionVersions } from "@/hooks/api/useSubmissions";
 import DocumentSubRow from "./DocumentSubRow";
 import { useMemo, useState } from "react";
-import { PackageType } from "@/models/Package";
 import ItemsTableHead from "./ItemsTableHead";
 import { useMounted } from "@/hooks/common";
 
 type DocumentsSubTableProps = Readonly<{
   submission?: Submission;
-  packageType?: PackageType;
   submissionId?: number;
   currentDocumentId?: number;
 }>;
 export default function DocumentsSubTable({
   submission,
-  packageType,
   submissionId,
   currentDocumentId,
 }: DocumentsSubTableProps) {

--- a/submit-web/src/components/App/Submission/ItemsTable/DocumentsSubTable.tsx
+++ b/submit-web/src/components/App/Submission/ItemsTable/DocumentsSubTable.tsx
@@ -89,7 +89,7 @@ export default function DocumentsSubTable({
           Previous Submitted Versions
         </Typography>
         <Table sx={{ tableLayout: "fixed" }}>
-          <ItemsTableHead packageType={packageType} />
+          <ItemsTableHead />
           <TableBody>
             {filteredSubmissions?.map((submission) => (
               <DocumentSubRow

--- a/submit-web/src/components/App/Submission/ItemsTable/ItemsTableHead.tsx
+++ b/submit-web/src/components/App/Submission/ItemsTable/ItemsTableHead.tsx
@@ -1,14 +1,8 @@
 import { TableHead, TableRow, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
 import { SubmitTableHeadCell } from "@/components/Shared/Table/common";
-import { PackageType, SubmissionPackageType } from "@/models/Package";
 
-export default function ItemsTableHead({
-  packageType,
-}: {
-  packageType?: PackageType;
-}) {
-  const isIPD = packageType?.name === SubmissionPackageType.IPD;
+export default function ItemsTableHead() {
   return (
     <TableHead
       sx={{
@@ -37,11 +31,11 @@ export default function ItemsTableHead({
         <SubmitTableHeadCell width={"10%"} align="right">
           Version
         </SubmitTableHeadCell>
-        <SubmitTableHeadCell width={"15%"} align="center">
+        <SubmitTableHeadCell width={"18%"} align="center">
           Status
         </SubmitTableHeadCell>
         <SubmitTableHeadCell
-          width={isIPD ? "30%" : "20%"}
+          width="17%"
           align="right"
           sx={{
             paddingRight: "2% !important",

--- a/submit-web/src/components/App/Submission/ItemsTable/index.tsx
+++ b/submit-web/src/components/App/Submission/ItemsTable/index.tsx
@@ -65,9 +65,12 @@ export default function ItemsTable({
     ));
 
   return (
-    <TableContainer component={Box} sx={{ height: "100%", overflow: "hidden", mt: 2.25,mb:1 }}>
+    <TableContainer
+      component={Box}
+      sx={{ height: "100%", overflow: "hidden", mt: 2.25, mb: 1 }}
+    >
       <Table sx={{ tableLayout: "fixed" }}>
-        <ItemsTableHead packageType={packageType} />
+        <ItemsTableHead />
         <TableBody>
           {renderItems(submissionItems)}
           <When

--- a/submit-web/src/components/App/Submission/Modals/NotApprovedSubmissionModal.tsx
+++ b/submit-web/src/components/App/Submission/Modals/NotApprovedSubmissionModal.tsx
@@ -1,0 +1,137 @@
+import { Box, Grid, Typography } from "@mui/material";
+import WarningBox from "@/components/Shared/Layouts/WarningBox";
+import { Warning } from "@mui/icons-material";
+import { BCDesignTokens } from "epic.theme";
+import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
+import ControlledTextField from "@/components/Shared/ControlledFormFields/ControlledTextField";
+import ControlledDatePicker from "@/components/Shared/ControlledFormFields/ControlledDatePicker";
+import { FormProvider, useForm } from "react-hook-form";
+import { yupResolver } from "@hookform/resolvers/yup";
+import * as yup from "yup";
+import dayjs from "dayjs";
+
+const NotApprovedSubmissionFormSchema = yup.object().shape({
+  decisionDate: yup
+    .date()
+    .transform((value, original) =>
+      dayjs.isDayjs(original) ? original.toDate() : value,
+    )
+    .required("Please enter the decision date"),
+  reason: yup.string().optional().nullable(),
+});
+
+type NotApprovedSubmissionForm = yup.InferType<
+  typeof NotApprovedSubmissionFormSchema
+>;
+
+type NotApprovedSubmissionModalProps = {
+  onConfirm: (data: NotApprovedSubmissionForm) => void;
+  onCancel: () => void;
+};
+
+const NotApprovedSubmissionModal = ({
+  onConfirm,
+  onCancel,
+}: NotApprovedSubmissionModalProps) => {
+  const methods = useForm<NotApprovedSubmissionForm>({
+    resolver: yupResolver(NotApprovedSubmissionFormSchema),
+    mode: "onSubmit",
+    defaultValues: {
+      decisionDate: new Date(),
+      reason: "",
+    },
+  });
+
+  return (
+    <ConfirmationModal
+      title="Submission package not approved"
+      onConfirm={methods.handleSubmit((data) => {
+        onConfirm(data);
+      })}
+      confirmButtonColor="error"
+      onSecondaryAction={onCancel}
+      confirmText="Confirm Package is NOT Accepted"
+      secondaryActionText="Cancel"
+      description={
+        <Box
+          sx={{
+            display: "flex",
+            flexDirection: "column",
+            gap: 2,
+            width: "520px",
+          }}
+        >
+          <WarningBox
+            sx={{
+              p: 1.5,
+              border: "0px",
+              borderLeft: `4px solid ${BCDesignTokens.supportBorderColorWarning}`,
+            }}
+          >
+            <Box sx={{ display: "flex", gap: 1.5 }}>
+              <Warning
+                sx={{ color: BCDesignTokens.supportBorderColorWarning }}
+              />
+              <Box>
+                <Typography variant="body2">
+                  Not approving this package will require the entity to submit a
+                  new package. Any open update requests will be cancelled.
+                </Typography>
+                <Typography
+                  variant="body2"
+                  sx={{ fontWeight: 700, mt: "10px" }}
+                >
+                  Please confirm this decision has been communicated to the
+                  proponent BEFORE clicking the "Confirm Package is NOT
+                  Accepted" button as an automated notification will be sent to
+                  the proponent when you confirm the decision.
+                </Typography>
+              </Box>
+            </Box>
+          </WarningBox>
+          <FormProvider {...methods}>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <Typography variant="body1" fontWeight={"bold"}>
+                  Decision Date
+                </Typography>
+              </Grid>
+              <Grid item xs={12} sx={{ pt: "0px !important" }}>
+                <ControlledDatePicker name="decisionDate" sx={{ mb: 0 }} />
+              </Grid>
+            </Grid>
+            <Grid container spacing={2}>
+              <Grid item xs={12}>
+                <Typography variant="body1" fontWeight={"bold"}>
+                  Reason for not approving this package
+                </Typography>
+              </Grid>
+              <Grid item xs={12} sx={{ pt: "0px !important" }}>
+                <ControlledTextField
+                  name="reason"
+                  fullWidth
+                  multiline
+                  rows={4}
+                  placeholder="Provide a reason for not approving this package (optional)..."
+                  helperText={
+                    <Typography
+                      variant="body2"
+                      component="span"
+                      sx={{ fontSize: "12px" }}
+                    >
+                      <strong>Internal note only.</strong> This reason will be
+                      recorded in the submission history.
+                    </Typography>
+                  }
+                  maxLength={500}
+                />
+              </Grid>
+            </Grid>
+          </FormProvider>
+        </Box>
+      }
+    />
+  );
+};
+
+export default NotApprovedSubmissionModal;

--- a/submit-web/src/components/App/Submission/Modals/RefuseSubmissionModal.tsx
+++ b/submit-web/src/components/App/Submission/Modals/RefuseSubmissionModal.tsx
@@ -10,7 +10,7 @@ import { yupResolver } from "@hookform/resolvers/yup";
 import * as yup from "yup";
 import dayjs from "dayjs";
 
-const NotApprovedSubmissionFormSchema = yup.object().shape({
+const RefuseSubmissionFormSchema = yup.object().shape({
   decisionDate: yup
     .date()
     .transform((value, original) =>
@@ -20,21 +20,19 @@ const NotApprovedSubmissionFormSchema = yup.object().shape({
   reason: yup.string().optional().nullable(),
 });
 
-type NotApprovedSubmissionForm = yup.InferType<
-  typeof NotApprovedSubmissionFormSchema
->;
+type RefuseSubmissionForm = yup.InferType<typeof RefuseSubmissionFormSchema>;
 
-type NotApprovedSubmissionModalProps = {
-  onConfirm: (data: NotApprovedSubmissionForm) => void;
+type RefuseSubmissionModalProps = {
+  onConfirm: (data: RefuseSubmissionForm) => void;
   onCancel: () => void;
 };
 
-const NotApprovedSubmissionModal = ({
+const RefuseSubmissionModal = ({
   onConfirm,
   onCancel,
-}: NotApprovedSubmissionModalProps) => {
-  const methods = useForm<NotApprovedSubmissionForm>({
-    resolver: yupResolver(NotApprovedSubmissionFormSchema),
+}: RefuseSubmissionModalProps) => {
+  const methods = useForm<RefuseSubmissionForm>({
+    resolver: yupResolver(RefuseSubmissionFormSchema),
     mode: "onSubmit",
     defaultValues: {
       decisionDate: new Date(),
@@ -134,4 +132,4 @@ const NotApprovedSubmissionModal = ({
   );
 };
 
-export default NotApprovedSubmissionModal;
+export default RefuseSubmissionModal;

--- a/submit-web/src/components/App/SubmissionStatusChip/index.tsx
+++ b/submit-web/src/components/App/SubmissionStatusChip/index.tsx
@@ -17,6 +17,9 @@ const baseSx: SxProps<Theme> = {
   borderRadius: 1,
   height: "24px",
   px: 1,
+  "& .MuiChip-label": {
+    overflow: "visible",
+  },
 };
 
 const themes = {

--- a/submit-web/src/components/App/SubmissionStatusChip/index.tsx
+++ b/submit-web/src/components/App/SubmissionStatusChip/index.tsx
@@ -58,7 +58,6 @@ const themes = {
 type StyleProps = {
   label: string;
   theme: keyof typeof themes;
-  width?: string;
   icon?: ReactNode;
 };
 
@@ -67,16 +66,14 @@ const statusMap: Record<string, StyleProps> = {
   PASSED_CONSULTATION_CHECK: {
     label: "Passed Consultation Check",
     theme: "success",
-    width: "191px",
   },
   APPROVED: { label: "Approved", theme: "success" },
-  REVIEWED: { label: "Reviewed", theme: "success", width: "85px" },
-  ACCEPTED: { label: "Accepted", theme: "success", width: "83px" },
-  SATISFIED: { label: "Satisfied", theme: "success", width: "85px" },
+  REVIEWED: { label: "Reviewed", theme: "success" },
+  ACCEPTED: { label: "Accepted", theme: "success" },
+  SATISFIED: { label: "Satisfied", theme: "success" },
   NO_REVISION_REQUIRED: {
     label: "No Revision Required",
     theme: "success",
-    width: "157px",
   },
   VERIFIED: {
     label: "Verified",
@@ -108,7 +105,7 @@ const statusMap: Record<string, StyleProps> = {
     label: "Under Consultation Check",
     theme: "info",
   },
-  SUBMITTED: { label: "Submitted", theme: "info", width: "90px" },
+  SUBMITTED: { label: "Submitted", theme: "info" },
   NEW_VERSION: {
     label: "New Version",
     theme: "info",
@@ -126,7 +123,6 @@ const statusMap: Record<string, StyleProps> = {
   REVIEW_REJECTED: {
     label: "Review Rejected",
     theme: "danger",
-    width: "125px",
   },
   FAILED_CONSULTATION_CHECK: {
     label: "Failed Consultation Check",
@@ -136,13 +132,11 @@ const statusMap: Record<string, StyleProps> = {
   PREVIOUSLY_FAILED: {
     label: "Previously Failed",
     theme: "danger",
-    width: "128px",
   },
 
   REVIEW_NOT_COMPLETED: {
     label: "Review Not Completed",
     theme: "warning",
-    width: "168px",
   },
   PARTIALLY_COMPLETED: { label: "Partially Completed", theme: "warning" },
 
@@ -152,25 +146,21 @@ const statusMap: Record<string, StyleProps> = {
   AWAITING_MANAGER_APPROVAL: {
     label: "Awaiting Manager Approval",
     theme: "orange",
-    width: "196px",
   },
   UPDATE_REQUESTED: {
     label: "Update Requested",
     theme: "orange",
-    width: "140px",
   },
   REVISION_REQUIRED: {
     label: "Revision Required",
     theme: "orange",
-    width: "140px",
   },
   REVISION_REQUESTED: {
     label: "Revision Requested",
     theme: "orange",
-    width: "150px",
   },
 
-  UPDATED: { label: "Updated", theme: "purple", width: "85px" },
+  UPDATED: { label: "Updated", theme: "purple" },
 };
 
 type SubmissionStatusChipProps = Readonly<{
@@ -188,7 +178,6 @@ export function SubmissionStatusChip({
   const sx: SxProps<Theme> = {
     ...baseSx,
     ...(config.theme ? themes[config.theme] : {}),
-    ...(config.width ? { width: config.width } : {}),
   };
 
   return (

--- a/submit-web/src/components/Shared/ControlledFormFields/ControlledDatePicker.tsx
+++ b/submit-web/src/components/Shared/ControlledFormFields/ControlledDatePicker.tsx
@@ -1,0 +1,60 @@
+import React from "react";
+import { FormControl, FormHelperText } from "@mui/material";
+import { DatePicker, DatePickerProps } from "@mui/x-date-pickers/DatePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { Controller, useFormContext } from "react-hook-form";
+import dayjs, { Dayjs } from "dayjs";
+import { get } from "lodash";
+import { DATE_FORMAT } from "@/utils/dateUtils";
+
+type IFormInputProps = {
+  name: string;
+  hideError?: boolean;
+} & DatePickerProps<Dayjs>;
+
+const ControlledDatePicker: React.FC<IFormInputProps> = ({
+  name,
+  hideError = false,
+  ...otherProps
+}) => {
+  const {
+    control,
+    formState: { defaultValues, errors },
+  } = useFormContext();
+
+  const error = get(errors, name);
+  return (
+    <LocalizationProvider dateAdapter={AdapterDayjs}>
+      <FormControl error={Boolean(error)}>
+        <Controller
+          control={control}
+          name={name}
+          defaultValue={defaultValues?.[name] ?? null}
+          render={({ field }) => {
+            const { value, onChange, ...restField } = field;
+
+            const dateValue = value ? dayjs(value) : null;
+
+            return (
+              <DatePicker
+                {...otherProps}
+                {...restField}
+                value={dateValue}
+                format={DATE_FORMAT}
+                onChange={(newValue) => {
+                  onChange(newValue ?? null);
+                }}
+              />
+            );
+          }}
+        />
+        {error && !hideError && (
+          <FormHelperText>{error.message?.toString()}</FormHelperText>
+        )}
+      </FormControl>
+    </LocalizationProvider>
+  );
+};
+
+export default ControlledDatePicker;

--- a/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
+++ b/submit-web/src/components/Shared/Modals/ConfirmationModal.tsx
@@ -13,11 +13,14 @@ import { modalStyle } from "./constants";
 import { LoadingButton } from "@/components/Shared/LoadingButton";
 import CloseIcon from "@mui/icons-material/Close";
 
+type ConfirmButtonColorType = "primary" | "error";
+
 type ConfirmationModalProps = {
   title: string;
   description: string | React.ReactNode;
   onConfirm: () => void;
   confirmText?: string;
+  confirmButtonColor?: ConfirmButtonColorType;
   hideSecondary?: boolean;
   // Either show cancel or secondary action, but not both
   cancelText?: string;
@@ -31,6 +34,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
   description,
   onConfirm,
   confirmText,
+  confirmButtonColor = "primary",
   hideSecondary,
   cancelText,
   onCancel,
@@ -94,7 +98,7 @@ const ConfirmationModal: React.FC<ConfirmationModalProps> = ({
           loading={isLoading}
           variant="contained"
           onClick={handleConfirm}
-          color="primary"
+          color={confirmButtonColor}
         >
           {confirmText ?? "Confirm"}
         </LoadingButton>

--- a/submit-web/src/hooks/api/usePackages.ts
+++ b/submit-web/src/hooks/api/usePackages.ts
@@ -279,6 +279,54 @@ export const useUpdateStateSubmissionPackage = (options?: Options) => {
   });
 };
 
+const refuseSubmissionPackage = ({
+  packageId,
+  data,
+}: {
+  packageId: number;
+  data: Record<string, unknown>;
+}) => {
+  return submitRequest<SubmissionPackage>({
+    url: `/packages/${packageId}/refuse`,
+    method: "post",
+    data,
+  });
+};
+
+export const useRefuseSubmissionPackage = (options?: Options) => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: refuseSubmissionPackage,
+    ...options,
+    onSuccess: (submissionPackage) => {
+      if (options?.onSuccess) {
+        options.onSuccess(submissionPackage);
+      }
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.SUBMISSION_PACKAGE, submissionPackage.id],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          QUERY_KEY.SUBMISSION_VERSIONS,
+          submissionPackage.account_project_id,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [
+          QUERY_KEY.ACCOUNT_PROJECT,
+          submissionPackage.account_project_id,
+        ],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QUERY_KEY.ACCOUNT_PROJECTS],
+      });
+      queryClient.refetchQueries({
+        queryKey: [QUERY_KEY.ACTIVITY_LOGS],
+      });
+    },
+  });
+};
+
 const createPackageUpdateRequest = ({
   packageId,
   data,

--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -82,7 +82,7 @@ export function useStaffSubmissionPage({
   );
 
   const canAcknowledge =
-    (approval_type === SubmissionPackageApprovalType.A)
+    approval_type === SubmissionPackageApprovalType.A
       ? isPackageVerified
       : isReadyForAcknowledgement;
 

--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -1,17 +1,22 @@
 import { useQueryClient } from "@tanstack/react-query";
-import { useMemo } from "react";
+import { useEffect, useMemo, useState } from "react";
 import {
   useGetPackageVersionsByOriginalPackageId,
   useGetStaffSubmissionPackage,
   useUpdateStateSubmissionPackage,
+  useRefuseSubmissionPackage,
+  getStaffSubmissionPackageById,
 } from "@/hooks/api/usePackages";
 import { getAccountProjectForStaffQueryOptions } from "@/hooks/api/useProjects";
 import { useModal } from "@/components/Shared/Modals/modalStore";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
 import {
   PACKAGE_STATUS,
+  SubmissionPackage,
   SubmissionPackageApprovalType,
 } from "@/models/Package";
+import { QUERY_KEY } from "./api/constants";
+import { useNavigate } from "@tanstack/react-router";
 
 interface UseStaffSubmissionPageOptions {
   submissionPackageId: number;
@@ -25,6 +30,8 @@ export function useStaffSubmissionPage({
   queryClient,
 }: UseStaffSubmissionPageOptions) {
   const { setOpen: setOpenModal, setClose: setCloseModal } = useModal();
+  const [isLoading, setIsLoading] = useState(false);
+  const navigate = useNavigate();
 
   const accountProject = queryClient.getQueryData(
     getAccountProjectForStaffQueryOptions(accountProjectId).queryKey,
@@ -41,6 +48,67 @@ export function useStaffSubmissionPage({
     originalPackageId: submissionPackage?.version?.original_package_id,
     enabled: Boolean(submissionPackage?.version?.original_package_id),
   });
+
+  const loadNewPackage = async (packageId: number) => {
+    try {
+      setIsLoading(true);
+      await queryClient.ensureQueryData<SubmissionPackage>({
+        queryKey: [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
+        queryFn: () => getStaffSubmissionPackageById({ packageId }),
+      });
+      console.log(
+        "navigate",
+        `/staff/projects/${accountProject?.id}/submission-packages/${packageId}`,
+      );
+      navigate({
+        to: `/staff/projects/${accountProject?.id}/submission-packages/${packageId}`,
+        replace: true,
+      });
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // ─── Mutations ────────────────────────────────────────────────────────────
+
+  const { mutate: updatePackageState, isPending: updatingPackageState } =
+    useUpdateStateSubmissionPackage({
+      onSuccess: () => {
+        setCloseModal();
+        notify.success("Submission acknowledged successfully");
+      },
+      onError: (error: any) => {
+        notify.error(
+          error?.response?.data?.message ?? "Failed to acknowledge submission",
+        );
+      },
+    });
+
+  const { mutate: refusePackage, isPending: refusingPackage } =
+    useRefuseSubmissionPackage({
+      onSuccess: (newPackage) => {
+        setCloseModal();
+        notify.success("Submission refused successfully");
+
+        // Invalidate the old package so it's refetched when revisited
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.SUBMISSION_PACKAGE, submissionPackageId],
+        });
+        queryClient.invalidateQueries({
+          queryKey: [
+            QUERY_KEY.PACKAGE_VERSIONS,
+            newPackage.version?.original_package_id,
+          ],
+        });
+
+        loadNewPackage(newPackage.id);
+      },
+      onError: (error: any) => {
+        notify.error(
+          error?.response?.data?.message ?? "Failed to refuse submission",
+        );
+      },
+    });
 
   // ─── Derived State ────────────────────────────────────────────────────────
 
@@ -97,27 +165,17 @@ export function useStaffSubmissionPage({
   const showApproveButtons =
     isPackageAcknowledged && approval_type == SubmissionPackageApprovalType.C;
 
-  // ─── Mutations ────────────────────────────────────────────────────────────
-
-  const { mutate: updatePackageState, isPending: updatingPackageState } =
-    useUpdateStateSubmissionPackage({
-      onSuccess: () => {
-        setCloseModal();
-        notify.success("Submission acknowledged successfully");
-      },
-      onError: (error: any) => {
-        notify.error(
-          error?.response?.data?.message ?? "Failed to acknowledge submission",
-        );
-      },
-    });
+  useEffect(() => {
+    setIsLoading(updatingPackageState || refusingPackage);
+  }, [updatingPackageState, refusingPackage]);
 
   return {
     accountProject,
     submissionPackage,
     isFetching,
     updatePackageState,
-    updatingPackageState,
+    refusePackage,
+    isLoading,
     isLatestApprovedPackageVersion,
     isNewerThanLastApprovedButNotApproved,
     canAcknowledge,

--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -56,10 +56,6 @@ export function useStaffSubmissionPage({
         queryKey: [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
         queryFn: () => getStaffSubmissionPackageById({ packageId }),
       });
-      console.log(
-        "navigate",
-        `/staff/projects/${accountProject?.id}/submission-packages/${packageId}`,
-      );
       navigate({
         to: `/staff/projects/${accountProject?.id}/submission-packages/${packageId}`,
         replace: true,

--- a/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -30,6 +30,7 @@ import AcknowledgeSubmissionModal from "@/components/App/Submission/Modals/Ackno
 import { useUpdateRequests } from "@/hooks/useUpdateRequests";
 import { useStaffSubmissionPage } from "@/hooks/useStaffSubmissionPage";
 import ApproveSubmissionModal from "@/components/App/Submission/Modals/ApproveSubmissionModal";
+import NotApprovedSubmissionModal from "@/components/App/Submission/Modals/NotApprovedSubmissionModal";
 
 export const Route = createFileRoute(
   "/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
@@ -135,18 +136,19 @@ export default function SubmissionPage() {
 
   const handleNotApprovedClick = () => {
     setOpenModal(
-      <AcknowledgeSubmissionModal
-        onConfirm={() => {
+      <NotApprovedSubmissionModal
+        onConfirm={(data) => {
           updatePackageState({
             packageId: submissionPackageId,
             data: {
-              status: PACKAGE_STATUS.ACKNOWLEDGED.value,
+              status: PACKAGE_STATUS.NOT_APPROVED.value,
+              decision_date: data.decisionDate,
+              reason: data.reason,
             },
           });
+          console.log(data);
         }}
         onCancel={() => setCloseModal()}
-        hasOpenUpdateRequests={sentUpdateRequests.length > 0}
-        openRequestSectionNames={openRequestSectionNames}
       />,
     );
   };

--- a/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -30,7 +30,7 @@ import AcknowledgeSubmissionModal from "@/components/App/Submission/Modals/Ackno
 import { useUpdateRequests } from "@/hooks/useUpdateRequests";
 import { useStaffSubmissionPage } from "@/hooks/useStaffSubmissionPage";
 import ApproveSubmissionModal from "@/components/App/Submission/Modals/ApproveSubmissionModal";
-import NotApprovedSubmissionModal from "@/components/App/Submission/Modals/NotApprovedSubmissionModal";
+import RefuseSubmissionModal from "@/components/App/Submission/Modals/RefuseSubmissionModal";
 
 export const Route = createFileRoute(
   "/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
@@ -136,7 +136,7 @@ export default function SubmissionPage() {
 
   const handleNotApprovedClick = () => {
     setOpenModal(
-      <NotApprovedSubmissionModal
+      <RefuseSubmissionModal
         onConfirm={(data) => {
           updatePackageState({
             packageId: submissionPackageId,
@@ -146,7 +146,6 @@ export default function SubmissionPage() {
               reason: data.reason,
             },
           });
-          console.log(data);
         }}
         onCancel={() => setCloseModal()}
       />,

--- a/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -58,7 +58,8 @@ export default function SubmissionPage() {
     submissionPackage,
     isFetching,
     updatePackageState,
-    updatingPackageState,
+    refusePackage,
+    isLoading,
     isLatestApprovedPackageVersion,
     isNewerThanLastApprovedButNotApproved,
     canAcknowledge,
@@ -138,10 +139,9 @@ export default function SubmissionPage() {
     setOpenModal(
       <RefuseSubmissionModal
         onConfirm={(data) => {
-          updatePackageState({
+          refusePackage({
             packageId: submissionPackageId,
             data: {
-              status: PACKAGE_STATUS.NOT_APPROVED.value,
               decision_date: data.decisionDate,
               reason: data.reason,
             },
@@ -338,8 +338,8 @@ export default function SubmissionPage() {
                     variant="outlined"
                     color="primary"
                     onClick={handleAcknowledgeClick}
-                    disabled={!canAcknowledge || updatingPackageState}
-                    loading={updatingPackageState}
+                    disabled={!canAcknowledge || isLoading}
+                    loading={isLoading}
                   >
                     {submissionPackage?.type.name ===
                     SubmissionPackageType.ADDITIONAL_INFORMATION ? (
@@ -357,8 +357,8 @@ export default function SubmissionPage() {
                       variant="outlined"
                       color="error"
                       onClick={handleNotApprovedClick}
-                      disabled={updatingPackageState}
-                      loading={updatingPackageState}
+                      disabled={isLoading}
+                      loading={isLoading}
                     >
                       Not Approved
                     </Button>
@@ -366,8 +366,8 @@ export default function SubmissionPage() {
                       variant="outlined"
                       color="primary"
                       onClick={handleApproveSubmissionClick}
-                      disabled={updatingPackageState}
-                      loading={updatingPackageState}
+                      disabled={isLoading}
+                      loading={isLoading}
                     >
                       Approve Submission
                     </Button>


### PR DESCRIPTION
Tickets:
- [SUBMIT-791](https://eao-dst.atlassian.net/browse/SUBMIT-791) EAO - Refuse IPD Submission
- [SUBMIT-849](https://eao-dst.atlassian.net/browse/SUBMIT-849) EAO/Entity - Status badges should never be truncated

**Description**

_Database_
- Added `decision_date` to the `packages` table. The decision date might **not** be the same as the current date. More info from MA:
> This is a pretty important decision and it might not be entered in .submit the moment it happens. The date would be the one we use for example in an automated email (TBC)

_Backend_
- Added a `/<int:package_id>/refuse` endpoint. The flow is different enough from existing endpoints I figured the best option was to create a new endpoint for it, rather than try to tweak existing endpoints.

_Frontend_
- Ensure that the package and submission status chips do not truncate.
- Added a `RefuseSubmissionModal` component.

_Screenshots_
<img width="606" height="673" alt="Screenshot 2026-05-15 at 11 36 46 AM" src="https://github.com/user-attachments/assets/0fc4deb9-023d-4aef-9183-7df4169847f9" />


[SUBMIT-791]: https://eao-dst.atlassian.net/browse/SUBMIT-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUBMIT-849]: https://eao-dst.atlassian.net/browse/SUBMIT-849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ