### PR TITLE
SUBMIT-796 Fix logic for displaying acknowledge button

### DIFF
--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -150,14 +150,16 @@ export function useStaffSubmissionPage({
       ? isPackageVerified
       : isReadyForAcknowledgement;
 
-  const isPackageApproved = useMemo(
-    () => submissionPackage?.status.includes(PACKAGE_STATUS.APPROVED.value),
+  const isPackagePastApproval = useMemo(
+    () =>
+      submissionPackage?.status.includes(PACKAGE_STATUS.APPROVED.value) ||
+      submissionPackage?.status.includes(PACKAGE_STATUS.NOT_APPROVED.value),
     [submissionPackage],
   );
 
   const showAcknowledgeButton =
     !isPackageAcknowledged &&
-    !isPackageApproved &&
+    !isPackagePastApproval &&
     Boolean(approval_type) &&
     [
       SubmissionPackageApprovalType.A,

--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -150,7 +150,14 @@ export function useStaffSubmissionPage({
       ? isPackageVerified
       : isReadyForAcknowledgement;
 
+  const isPackageApproved = useMemo(
+    () => submissionPackage?.status.includes(PACKAGE_STATUS.APPROVED.value),
+    [submissionPackage],
+  );
+
   const showAcknowledgeButton =
+    !isPackageAcknowledged &&
+    !isPackageApproved &&
     Boolean(approval_type) &&
     [
       SubmissionPackageApprovalType.A,


### PR DESCRIPTION
**Description**
- Bugfix for acknowledge button display bug reported by Dinesh. See comment: https://eao-dst.atlassian.net/browse/SUBMIT-796?focusedCommentId=20944

**Verified**
- IPD:
  - Displays as disabled for NEW_SUBMISSION, INTERNAL_VERIFICATION, VERIFIED, and PENDING_ACKNOWLEDGEMENT.
  - Displays as clickable for READY_FOR_ACKNOWLEDGEMENT
  - Does not display for READY_FOR_APPROVAL, APPROVED, or NOT_APPROVED
- AIS:
  - Displays as disabled for NEW_SUBMISSION and INTERNAL_VERIFICATION
  - Displays as clickable for VERIFIED and PENDING_ACKNOWLEDGEMENT
  - Does not display once ACKNOWLEDGED
- MPT: Does not display