### PR TITLE
SUBMIT-799 Skip adding PENDING_ACKNOWLEDGEMENT on type A submissions

### DIFF
--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -338,7 +338,7 @@ class PackageSubmissionQueries:
         # Type A staged workflow
         if approval_type == PackageApprovalType.A:
             cls._add_internal_verification_status(aggregated_statuses, statuses)
-            cls._add_verified_status(aggregated_statuses, statuses, approval_type=None)
+            cls._add_verified_status(aggregated_statuses, statuses, approval_type=approval_type)
 
         # Type B/C staged workflow
         elif approval_type in [PackageApprovalType.B, PackageApprovalType.C]:


### PR DESCRIPTION
**Description**
- Small change needed in order to handle AIS PENDING_ACKNOWLEDGEMENT status correctly.

**Screenshot**
_PENDING_ACKNOWLEDGEMENT no longer shows when all items verified on AIS submissions. The acknowledge button correctly displays_
<img width="1234" height="746" alt="Screenshot 2026-05-25 at 4 31 40 PM" src="https://github.com/user-attachments/assets/46b9abae-d263-4139-9eed-c720deafa55e" />
