### PR TITLE
SUBMIT-811 Update package versioning

### DIFF
--- a/submit-api/src/submit_api/services/package_service.py
+++ b/submit-api/src/submit_api/services/package_service.py
@@ -642,7 +642,7 @@ class PackageService:
                 if user:
                     new_package.submitted_by = user.auth_guid
             new_package.status = [PackageStatus.REVISION_REQUIRED]
-            
+
             # Add works
             new_package.account_project_work = package.account_project_work
 

--- a/submit-api/src/submit_api/services/package_service.py
+++ b/submit-api/src/submit_api/services/package_service.py
@@ -641,6 +641,10 @@ class PackageService:
                 user = User.get_by_guid(package.submitted_by)
                 if user:
                     new_package.submitted_by = user.auth_guid
+            new_package.status = [PackageStatus.REVISION_REQUIRED]
+            
+            # Add works
+            new_package.account_project_work = package.account_project_work
 
             session.flush()
             return new_package

--- a/submit-api/src/submit_api/services/package_version_service.py
+++ b/submit-api/src/submit_api/services/package_version_service.py
@@ -49,7 +49,7 @@ class PackageVersionService:
         new_package.version_id = new_version.id
         session.add(new_package)
 
-        if current_package.meta.json:
+        if current_package.meta and current_package.meta.json:
             new_metadata = {
                 PackageMetadataFields.MAIN_CONDITION.value: current_package.meta.json.get(
                     PackageMetadataFields.MAIN_CONDITION.value, None),

--- a/submit-web/src/components/App/Submission/Modals/AcknowledgeSubmissionModal.tsx
+++ b/submit-web/src/components/App/Submission/Modals/AcknowledgeSubmissionModal.tsx
@@ -33,35 +33,48 @@ const AcknowledgeSubmissionModal = ({
             width: "520px",
           }}
         >
-          {hasOpenUpdateRequests && (
-            <WarningBox sx={{ p: 1.5 }}>
-              <Box sx={{ display: "flex", gap: 1.5 }}>
-                <WarningAmberOutlinedIcon
-                  sx={{ color: BCDesignTokens.supportBorderColorWarning }}
-                />
-                <Box>
-                  <Typography variant="body1" sx={{ fontWeight: 700 }}>
-                    Open Update Requests
-                  </Typography>
-                  <Typography variant="body2">
-                    The following sections have open update requests:{" "}
-                    <b>{openRequestSectionNames.join(", ")}</b>
-                  </Typography>
+          {hasOpenUpdateRequests ? (
+            <>
+              <WarningBox sx={{ p: 1.5 }}>
+                <Box sx={{ display: "flex", gap: 1.5 }}>
+                  <WarningAmberOutlinedIcon
+                    sx={{ color: BCDesignTokens.supportBorderColorWarning }}
+                  />
+                  <Box>
+                    <Typography variant="body1" sx={{ fontWeight: 700 }}>
+                      Open Update Requests
+                    </Typography>
+                    <Typography variant="body2">
+                      The following sections have open update requests:{" "}
+                      <b>{openRequestSectionNames.join(", ")}</b>
+                    </Typography>
+                  </Box>
                 </Box>
-              </Box>
-            </WarningBox>
+              </WarningBox>
+              <Typography variant="body1">
+                The proponent will receive an email acknowledging receipt of the
+                submission, but the package will remain open until all open
+                update requests are either withdrawn or until documents are
+                resubmitted and acknowledged.
+              </Typography>
+            </>
+          ) : (
+            <>
+              <Typography variant="body1">
+                The proponent will receive an automated email confirming the EAO
+                has acknowledged receipt of the submission. Once acknowledged,
+                the proponent will no longer be able to submit additional
+                documents.
+              </Typography>
+              <Typography variant="body1">
+                If you need to allow the proponent to resubmit some documents,
+                you can send an Update Request before or after acknowledging the
+                submission. When an Update Request is open, the submission
+                package will remain open for the proponent to resubmit
+                documents.
+              </Typography>
+            </>
           )}
-          <Typography variant="body1">
-            The proponent will receive an automated email confirming the EAO has
-            acknowledged receipt of the submission. Once acknowledged, the
-            proponent will no longer be able to submit additional documents.
-          </Typography>
-          <Typography variant="body1">
-            If you need to allow the proponent to resubmit some documents, you
-            can send an Update Request before or after acknowledging the
-            submission. When an Update Request is open, the submission package
-            will remain open for the proponent to resubmit documents.
-          </Typography>
         </Box>
       }
     />

--- a/submit-web/src/components/App/Submission/VersionGroup.tsx
+++ b/submit-web/src/components/App/Submission/VersionGroup.tsx
@@ -4,8 +4,13 @@ import {
   getSubmissionPackageById,
   useGetPackageVersionsByOriginalPackageId,
   useCreateNewPackageVersion,
+  useGetStaffSubmissionPackage,
 } from "@/hooks/api/usePackages";
-import { PackageVersion, SubmissionPackage } from "@/models/Package";
+import {
+  PackageVersion,
+  SubmissionPackage,
+  SubmissionPackageApprovalType,
+} from "@/models/Package";
 import { USER_TYPE } from "@/models/User";
 import { useAccount } from "@/store/accountStore";
 import {
@@ -46,6 +51,10 @@ export default function VersionGroup({
   const { data: packageVersions, isPending: isVersionsLoading } =
     useGetPackageVersionsByOriginalPackageId({
       originalPackageId: currentPackageVersion.original_package_id,
+    });
+  const { data: submissionPackage, isFetching: isPackageLoading } =
+    useGetStaffSubmissionPackage({
+      packageId: submissionPackageId,
     });
 
   const queryClient = useQueryClient();
@@ -120,7 +129,18 @@ export default function VersionGroup({
     return currentPackageVersion.version === latestVersion;
   }, [packageVersions, currentPackageVersion.version]);
 
-  if (isVersionsLoading) {
+  const canCreateVersion =
+    submissionPackage?.type.approval_type !== SubmissionPackageApprovalType.C;
+
+  const showVersions =
+    packageVersions?.length !== 1 &&
+    submissionPackage?.type.approval_type === SubmissionPackageApprovalType.C;
+
+  console.log(showVersions);
+  console.log(packageVersions?.length);
+  console.log(submissionPackage?.type.approval_type);
+
+  if (isVersionsLoading || isPackageLoading) {
     return (
       <Stack direction="row" spacing={1}>
         <Skeleton variant="rectangular" width={35} height={35} />
@@ -137,7 +157,7 @@ export default function VersionGroup({
       >
         <CircularProgress color="inherit" />
       </Backdrop>
-      {!isProponent && isLatestVersion && (
+      {!isProponent && isLatestVersion && canCreateVersion && (
         <Button
           color="secondary"
           sx={{
@@ -149,25 +169,26 @@ export default function VersionGroup({
           New
         </Button>
       )}
-      {packageVersions?.map((packageVersion) => (
-        <Button
-          key={packageVersion.id}
-          color={
-            packageId === packageVersion.package_id ? "primary" : "secondary"
-          }
-          sx={{
-            width: "auto",
-          }}
-          onClick={() => handleUpdatePackageId(packageVersion.package_id)}
-          startIcon={
-            packageVersion.id === last_approved_package_version?.id ? (
-              <GppGoodOutlinedIcon />
-            ) : undefined
-          }
-        >
-          Package {packageVersion.version}
-        </Button>
-      ))}
+      {showVersions &&
+        packageVersions?.map((packageVersion) => (
+          <Button
+            key={packageVersion.id}
+            color={
+              packageId === packageVersion.package_id ? "primary" : "secondary"
+            }
+            sx={{
+              width: "auto",
+            }}
+            onClick={() => handleUpdatePackageId(packageVersion.package_id)}
+            startIcon={
+              packageVersion.id === last_approved_package_version?.id ? (
+                <GppGoodOutlinedIcon />
+              ) : undefined
+            }
+          >
+            Package {packageVersion.version}
+          </Button>
+        ))}
     </Stack>
   );
 }

--- a/submit-web/src/components/App/Submission/VersionGroup.tsx
+++ b/submit-web/src/components/App/Submission/VersionGroup.tsx
@@ -132,13 +132,9 @@ export default function VersionGroup({
   const canCreateVersion =
     submissionPackage?.type.approval_type !== SubmissionPackageApprovalType.C;
 
-  const showVersions =
-    packageVersions?.length !== 1 &&
+  const hideVersions =
+    packageVersions?.length === 1 &&
     submissionPackage?.type.approval_type === SubmissionPackageApprovalType.C;
-
-  console.log(showVersions);
-  console.log(packageVersions?.length);
-  console.log(submissionPackage?.type.approval_type);
 
   if (isVersionsLoading || isPackageLoading) {
     return (
@@ -169,7 +165,7 @@ export default function VersionGroup({
           New
         </Button>
       )}
-      {showVersions &&
+      {!hideVersions &&
         packageVersions?.map((packageVersion) => (
           <Button
             key={packageVersion.id}


### PR DESCRIPTION
Tickets:
- [SUBMIT-811](https://eao-dst.atlassian.net/browse/SUBMIT-811) EAO - Package versioning
- [SUBMIT-791](https://eao-dst.atlassian.net/browse/SUBMIT-791) [FIX] EAO - Refuse IPD Submission
- [SUBMIT-796](https://eao-dst.atlassian.net/browse/SUBMIT-796) [FIX] EAO - Acknowledge Submission Modal

**Description**
Several small fixes included in this PR:
- SUBMIT-811
  - Hide option to create new Type C versions.
  - If Type C version number is 1, hide the version button.
  - This logic should be the same _"for all type C (or at least for the Revised application, which is the only other type C package during the assessment"_ (via MA)
- SUBMIT-791 (feedback from @dinesh-aot )
  - Tagged the `account_project_work_id` to the new package version on refusal.
  - The new package status is now REVISION_REQUESTED (which was in the ticket but I missed it originally). We don't need to worry about the difference between NEW and CREATED because it will have the revision status.
- SUBMIT-796 (feedback from MA):
  - Update Acknowledge modal text when there are open update requests

_Screenshots_
_New empty IPD package after refusal with correct state. From the AC:_
> Once the "Not Approved" desision is confirmed. This will close the current package and create a new package version. The new package version will be empty and will have the status "Revision Required" (orange badge).
<img width="1216" height="721" alt="Screenshot 2026-05-25 at 5 22 20 PM" src="https://github.com/user-attachments/assets/7504f098-aaf9-425d-a470-b82524e171b1" />


[SUBMIT-811]: https://eao-dst.atlassian.net/browse/SUBMIT-811?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUBMIT-791]: https://eao-dst.atlassian.net/browse/SUBMIT-791?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SUBMIT-796]: https://eao-dst.atlassian.net/browse/SUBMIT-796?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ