### PR TITLE
SUBMIT-830 Add silent signout when proponent does not have access

### DIFF
--- a/submit-web/src/routes/oidc-callback/index.tsx
+++ b/submit-web/src/routes/oidc-callback/index.tsx
@@ -17,7 +17,11 @@ function OidcCallback() {
   const baseProponentPath = "/proponent";
 
   const account = useAccount();
-  const { isAuthenticated, isLoading: isAuthLoading } = useAuth();
+  const {
+    isAuthenticated,
+    signoutSilent,
+    isLoading: isAuthLoading,
+  } = useAuth();
 
   if (account.isLoading || isAuthLoading) {
     return <PageLoader />;
@@ -39,6 +43,7 @@ function OidcCallback() {
   }
 
   if (account?.error?.status === HTTP_STATUS.NOT_FOUND) {
+    signoutSilent();
     return <Navigate to="/need-access" />;
   }
 


### PR DESCRIPTION
Ticket: [SUBMIT-830](https://eao-dst.atlassian.net/browse/SUBMIT-830) Session out when display no-access screen

**Description**
- Remove session details when proponent does not have access. This fixes an issue where a proponent/staff could not sign in (with a different account) when the No Access page was hit.

[SUBMIT-830]: https://eao-dst.atlassian.net/browse/SUBMIT-830?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ