### PR TITLE
SUBMIT-883-Refactoring on the account-projects filtering logic and permission related fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,5 @@ deployment/charts/submit-web/values.prod.yaml
 deployment/charts/submit-api/values.prod.yaml
 deployment/charts/submit-api/values.dev.yaml
 deployment/charts/submit-web/values.dev.yaml
+.windsurf/
 .kiro/

--- a/.gitignore
+++ b/.gitignore
@@ -168,4 +168,4 @@ deployment/charts/submit-web/values.prod.yaml
 deployment/charts/submit-api/values.prod.yaml
 deployment/charts/submit-api/values.dev.yaml
 deployment/charts/submit-web/values.dev.yaml
-.windsurf/
+.kiro/

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -11,7 +11,11 @@
             "request": "launch",
             "program": "${workspaceFolder}/submit-api/wsgi.py",
             "console": "integratedTerminal",
-            "justMyCode": true
+            "justMyCode": true,
+            "python": "${workspaceFolder}/submit-api/venv/Scripts/python.exe",
+            "env": {
+                "PYTHONPATH": "${workspaceFolder}/submit-api/src"
+            }
         },
         {
             "name": "Submit CRON - CENTRE",

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,9 +1,11 @@
 {
+    "python.defaultInterpreterPath": "${workspaceFolder}/submit-api/venv/Scripts/python.exe",
     "editor.defaultFormatter": "rvest.vs-code-prettier-eslint",
     "editor.formatOnType": false, // required
     "editor.formatOnPaste": true, // optional
     "editor.formatOnSave": true, // optional
     "editor.formatOnSaveMode": "file", // required to format on save
     "files.autoSave": "onFocusChange", // optional but recommended
-    "vs-code-prettier-eslint.prettierLast": false // set as "true" to run 'prettier' last not first
+    "vs-code-prettier-eslint.prettierLast": false // set as "true" to run 'prettier'
+    "python.defaultInterpreterPath": "${workspaceFolder}/submit-api/venv/Scripts/python.exe"
 }

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -30,6 +30,7 @@ from submit_api.schemas.project import AccountProjectSchema, StaffAccountProject
 from submit_api.utils.token_info import TokenInfo
 from submit_api.models.update_request import UpdateRequest, UpdateRequestType, UpdateRequestStatus
 from submit_api.services.package_service import PackageService
+from submit_api.utils.constants import MP_VIEW_PACKAGE_TYPES
 
 
 class ProjectQueries:
@@ -38,10 +39,10 @@ class ProjectQueries:
     @classmethod
     def get_accessible_account_project_ids_for_user(cls, user):
         """Return all account_project_ids accessible by the user based on their roles."""
-        if user.type == UserType.STAFF:
-            # Staff can access all projects
-            account_project_ids = db.session.query(AccountProject.id).all()
-            return [ap_id for (ap_id,) in account_project_ids]
+        # if user.type == UserType.STAFF:
+        #     # Staff can access all projects
+        #     account_project_ids = db.session.query(AccountProject.id).all()
+        #     return [ap_id for (ap_id,) in account_project_ids]
 
         if not user.account_user or not user.account_user.roles:
             return []
@@ -92,15 +93,17 @@ class ProjectQueries:
         schema_class = StaffAccountProjectSchema if is_staff else AccountProjectSchema
         account_project_dict = schema_class().dump(account_project)
 
-        package_query = db.session.query(Package).join(AccountProject).filter(AccountProject.id == account_project_id)
-        package_query = cls._filter_packages_by_user_access(package_query)
-        filtered_package_ids = [package.id for package in package_query.all()]
+        # package_query = db.session.query(Package).join(AccountProject).filter(AccountProject.id == account_project_id)
+        # passing the dict as list for the _filter_packages_by_user_access to work with the existing logic
+        account_project_dict = cls._filter_packages_by_user_access([account_project_dict])
+        account_project_dict = account_project_dict[0]
+        # filtered_package_ids = [package.id for package in package_query.all()]
 
-        if filtered_package_ids:
-            account_project_dict['packages'] = [
-                package for package in account_project_dict['packages']
-                if package['id'] in filtered_package_ids
-            ]
+        # if filtered_package_ids:
+        #     account_project_dict['packages'] = [
+        #         package for package in account_project_dict['packages']
+        #         if package['id'] in filtered_package_ids
+        #     ]
 
         # Filter account_project_works for staff users without full_access role
         if is_staff and user and user.type == UserType.STAFF:
@@ -114,91 +117,89 @@ class ProjectQueries:
 
         return account_project_dict
 
+    # @classmethod
+    # def get_filtered_package_ids(cls, search_options: AccountProjectSearchOptions, user: User = None) -> list:
+    #     """Retrieve package IDs based on search filters."""
+    #     package_query = cls._filter_by_search_criteria(search_options)
+    #     # package_query = cls._filter_packages_by_user_access(package_query, user)
+
+    #     result = [row[0] for row in package_query.with_entities(
+    #         Package.id).all()] if package_query else None
+    #     return result
+
+    # @classmethod
+    # def _filter_account_projects_by_user_access(cls, query=None, user: User = None):
+    #     """Filter AccountProjects by all accessible projects of the user."""
+    #     if user is None:
+    #         user = User.get_by_guid(TokenInfo.get_username())
+
+    #     if not user:
+    #         raise ValueError("User not found.")
+
+    #     if user.type == UserType.STAFF:
+    #         return query
+
+    #     if not user.account_user or not user.account_user.role:
+    #         # No access if no role
+    #         return query.filter(False)
+
+    #     accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
+
+    #     if query is None:
+    #         query = db.session.query(AccountProject)
+
+    #     # Filter projects by accessible project ids
+    #     query = query.filter(AccountProject.id.in_(accessible_project_ids))
+
+    #     return query
+
+    # @classmethod
+    # def get_paginated_account_project_ids(cls, page: int, page_size: int,
+    #                                       filtered_package_ids: list = None, user: User = None) -> tuple:
+    #     """Retrieve paginated AccountProject IDs based on filtering."""
+    #     query = db.session.query(AccountProject).join(Project)
+
+    #     # if user is not None:
+    #     #     query = cls._filter_account_projects_by_user_access(query, user)
+
+    #     if filtered_package_ids is None or len(filtered_package_ids) == 0:
+    #         account_project_ids_subquery = query.with_entities(AccountProject.id).distinct()
+    #     else:
+    #         account_project_ids_subquery = (query.join(Package).filter(Package.id.in_(filtered_package_ids))
+    #                                         .with_entities(AccountProject.id).distinct())
+
+    #     account_project_ids_query = (
+    #         db.session.query(AccountProject.id)
+    #         .join(Project)
+    #         .filter(AccountProject.id.in_(account_project_ids_subquery))
+    #         .order_by(Project.name)
+    #     )
+
+    #     if page and page_size:
+    #         paginated_result = account_project_ids_query.paginate(page=page, per_page=page_size)
+    #         return [row[0] for row in paginated_result.items], paginated_result.total
+
+    #     return ([row[0] for row in account_project_ids_query.all()],
+    #             account_project_ids_query.count())
+
     @classmethod
-    def get_filtered_package_ids(cls, search_options: AccountProjectSearchOptions, user: User = None) -> list:
-        """Retrieve package IDs based on search filters."""
-        package_query = cls._filter_by_search_criteria(search_options)
-        package_query = cls._filter_packages_by_user_access(package_query, user)
-
-        result = [row[0] for row in package_query.with_entities(
-            Package.id).all()] if package_query else None
-        return result
-
-    @classmethod
-    def _filter_account_projects_by_user_access(cls, query=None, user: User = None):
-        """Filter AccountProjects by all accessible projects of the user."""
-        if user is None:
-            user = User.get_by_guid(TokenInfo.get_username())
-
-        if not user:
-            raise ValueError("User not found.")
-
-        if user.type == UserType.STAFF:
-            return query
-
-        if not user.account_user or not user.account_user.role:
-            # No access if no role
-            return query.filter(False)
-
-        accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
-
-        if query is None:
-            query = db.session.query(AccountProject)
-
-        # Filter projects by accessible project ids
-        query = query.filter(AccountProject.id.in_(accessible_project_ids))
-
-        return query
-
-    @classmethod
-    def get_paginated_account_project_ids(cls, page: int, page_size: int,
-                                          filtered_package_ids: list = None, user: User = None) -> tuple:
-        """Retrieve paginated AccountProject IDs based on filtering."""
-        query = db.session.query(AccountProject).join(Project)
-
-        if user is not None:
-            query = cls._filter_account_projects_by_user_access(query, user)
-
-        if filtered_package_ids is None or len(filtered_package_ids) == 0:
-            account_project_ids_subquery = query.with_entities(AccountProject.id).distinct()
-        else:
-            account_project_ids_subquery = (query.join(Package).filter(Package.id.in_(filtered_package_ids))
-                                            .with_entities(AccountProject.id).distinct())
-
-        account_project_ids_query = (
-            db.session.query(AccountProject.id)
-            .join(Project)
-            .filter(AccountProject.id.in_(account_project_ids_subquery))
-            .order_by(Project.name)
-        )
-
-        if page and page_size:
-            paginated_result = account_project_ids_query.paginate(page=page, per_page=page_size)
-            return [row[0] for row in paginated_result.items], paginated_result.total
-
-        return ([row[0] for row in account_project_ids_query.all()],
-                account_project_ids_query.count())
-
-    @classmethod
-    def get_full_account_projects(cls, account_project_ids: list,
-                                  is_proponent: bool, filtered_package_ids: list) -> list:
+    def get_full_account_projects(cls, is_proponent: bool, account_projects: list) -> list:
         """Retrieve full AccountProject objects, apply schema, and filter packages."""
         # Get user type for status calculation
         user = User.get_by_guid(TokenInfo.get_username())
         user_type = user.type if user else None
-
-        # Load account projects with packages, items, and submissions for status calculation
-        account_projects = (
-            db.session.query(AccountProject)
-            .join(Project, AccountProject.project_id == Project.id)
-            .filter(AccountProject.id.in_(account_project_ids))
-            .options(
-                joinedload(AccountProject.packages)
-                .joinedload(Package.items)
-                .joinedload(Item.submissions)
-            )
-            .order_by(Project.name)
-        ).all()
+        # # Load account projects with packages, items, and submissions for status calculation
+        # account_projects = (
+        #     db.session.query(AccountProject)
+        #     .join(Project, AccountProject.project_id == Project.id)
+        #     .filter(AccountProject.id.in_(account_project_ids))
+        #     .options(
+        #         joinedload(AccountProject.packages)
+        #         .joinedload(Package.items)
+        #         .joinedload(Item.submissions)
+        #     )
+        #     .order_by(Project.name)
+        # ).all()
 
         # Pre-calculate statuses for all packages
         package_statuses = {}
@@ -219,48 +220,48 @@ class ProjectQueries:
         account_projects_list = schema_class(many=True).dump(account_projects)
 
         # Apply package access filtering for staff users only
-        if not is_proponent and user and user.type == UserType.STAFF:
-            package_query = db.session.query(Package).filter(
-                Package.account_project_id.in_(account_project_ids)
-            )
-            package_query = cls._filter_packages_by_user_access(package_query, user)
-            accessible_package_ids = {pkg.id for pkg in package_query.all()}
+        # if not is_proponent and user and user.type == UserType.STAFF:
+        #     package_query = db.session.query(Package).filter(
+        #         Package.account_project_id.in_(account_project_ids)
+        #     )
+        #     package_query = cls._filter_packages_by_user_access(package_query, user)
+        #     accessible_package_ids = {pkg.id for pkg in package_query.all()}
 
-            # Combine with search filtering if provided
-            if filtered_package_ids:
-                # Intersection: packages matching BOTH access control AND search criteria
-                final_package_ids = accessible_package_ids & set(filtered_package_ids)
-            else:
-                # No search criteria: use only access control filtering
-                final_package_ids = accessible_package_ids
+        #     # Combine with search filtering if provided
+        #     if filtered_package_ids:
+        #         # Intersection: packages matching BOTH access control AND search criteria
+        #         final_package_ids = accessible_package_ids & set(filtered_package_ids)
+        #     else:
+        #         # No search criteria: use only access control filtering
+        #         final_package_ids = accessible_package_ids
 
-            # Filter packages in serialized output
-            for account_project in account_projects_list:
-                account_project['packages'] = [
-                    package for package in account_project['packages']
-                    if package['id'] in final_package_ids
-                ]
-        elif filtered_package_ids:
-            # For proponent users, only apply search filtering (no access control filtering)
-            for account_project in account_projects_list:
-                account_project['packages'] = [
-                    package for package in account_project['packages']
-                    if package['id'] in filtered_package_ids
-                ]
+        #     # Filter packages in serialized output
+        #     for account_project in account_projects_list:
+        #         account_project['packages'] = [
+        #             package for package in account_project['packages']
+        #             if package['id'] in final_package_ids
+        #         ]
+        # elif filtered_package_ids:
+        #     # For proponent users, only apply search filtering (no access control filtering)
+        #     for account_project in account_projects_list:
+        #         account_project['packages'] = [
+        #             package for package in account_project['packages']
+        #             if package['id'] in filtered_package_ids
+        #         ]
 
-        # Filter account_project_works for staff users without full_access role
-        if not is_proponent and user and user.type == UserType.STAFF:
-            if not jwt.contains_role([EpicSubmitRole.FULL_ACCESS.value]):
-                # Get accessible work IDs for this staff user
-                accessible_work_ids = cls._get_accessible_work_ids_for_staff_user(user)
+        # # Filter account_project_works for staff users without full_access role
+        # if not is_proponent and user and user.type == UserType.STAFF:
+        #     if not jwt.contains_role([EpicSubmitRole.FULL_ACCESS.value]):
+        #         # Get accessible work IDs for this staff user
+        #         accessible_work_ids = cls._get_accessible_work_ids_for_staff_user(user)
 
-                # Filter account_project_works to only include accessible works
-                for account_project in account_projects_list:
-                    if 'account_project_works' in account_project:
-                        account_project['account_project_works'] = [
-                            work for work in account_project['account_project_works']
-                            if work.get('work_id') in accessible_work_ids
-                        ]
+        #         # Filter account_project_works to only include accessible works
+        #         for account_project in account_projects_list:
+        #             if 'account_project_works' in account_project:
+        #                 account_project['account_project_works'] = [
+        #                     work for work in account_project['account_project_works']
+        #                     if work.get('work_id') in accessible_work_ids
+        #                 ]
 
         return account_projects_list
 
@@ -277,26 +278,26 @@ class ProjectQueries:
         if user is None:
             user = User.get_by_guid(TokenInfo.get_username())
 
-        filtered_package_ids = cls.get_filtered_package_ids(search_options, user)
+        # filtered_package_ids = cls.get_filtered_package_ids(search_options, user)
+        account_project_query = cls._filter_by_search_criteria(search_options)
+        paginated_result = account_project_query.add_columns(Project.name).order_by(Project.name).distinct().paginate(page=page, per_page=page_size)
+        # account_project_ids, total = cls.get_paginated_account_project_ids(page, page_size,
+        #                                                                    filtered_package_ids, user)
 
-        account_project_ids, total = cls.get_paginated_account_project_ids(page, page_size,
-                                                                           filtered_package_ids, user)
+        # if not account_project_ids:
+        #     return [], 0
+        account_projects = [account_project for account_project, project_name in paginated_result.items]
+        account_projects_list = cls.get_full_account_projects(is_proponent, account_projects)
+        account_projects_list = cls._filter_packages_by_user_access(account_projects_list, user)
 
-        if not account_project_ids:
-            return [], 0
-
-        account_projects_list = cls.get_full_account_projects(
-            account_project_ids, is_proponent, filtered_package_ids)
-
-        return account_projects_list, total
+        return account_projects_list, paginated_result.total
 
     @classmethod
     def _filter_by_search_criteria(cls, search_options: AccountProjectSearchOptions):
         """Apply various filters based on search options."""
+        query = db.session.query(AccountProject).join(Package).join(Project)
         if not search_options or not any(bool(search_option) for search_option in search_options.__dict__.values()):
-            return None
-
-        query = db.session.query(Package).join(AccountProject).join(Project)
+            return query
 
         if search_options.search_text:
             query = cls._filter_by_search_text(
@@ -320,6 +321,8 @@ class ProjectQueries:
         staff_user = user.staff_user
         if not staff_user:
             return []
+        if not jwt.contains_role([EpicSubmitRole.W_VIEW.value]):
+            return []
 
         # Get all active work IDs for this staff user
         work_ids = db.session.query(StaffUserWork.work_id).filter(
@@ -330,87 +333,137 @@ class ProjectQueries:
         return [work_id for (work_id,) in work_ids]
 
     @classmethod
-    def _filter_packages_by_user_access(cls, package_query=None, user: User = None):
+    def _filter_packages_by_user_access(cls, account_project_list=None, user: User = None):
         """Filter packages by all accessible packages of the user."""
         if user is None:
             user = User.get_by_guid(TokenInfo.get_username())
 
         if not user:
             raise ValueError("User not found.")
-        if not package_query:
-            package_query = db.session.query(Package)
         if user.type == UserType.STAFF:
             # Users with full_access role have access to all packages
             if jwt.contains_role([EpicSubmitRole.FULL_ACCESS.value]):
-                return package_query
+                return account_project_list
 
             # Filter packages based on staff user's work assignments and permissions
             staff_user = user.staff_user
             if not staff_user:
-                return package_query.filter(False)
-
+                return []
+            accessible_work_ids = cls._get_accessible_work_ids_for_staff_user(user)
             # Check if user has w_view permission for works
             has_w_view = jwt.contains_role([EpicSubmitRole.W_VIEW.value])
+
+            # Check if user has gis_extended_edit permission
+            has_gis_extended_edit = jwt.contains_role([EpicSubmitRole.GIS_EXTENDED_EDIT.value])
 
             # Check if user has mp_view permission for management plans
             has_mp_view = jwt.contains_role([EpicSubmitRole.MP_VIEW.value])
 
             # Build filter conditions based on permissions
-            filter_conditions = []
+            for account_project in account_project_list:
+                allowed_packages = []
+                packages = account_project["packages"]
+                work_related_packages = [package for package in packages if package.get("account_project_work_id") is not None]
+                management_plan_related_packages = [package for package in packages if package.get("type").get("name") in MP_VIEW_PACKAGE_TYPES]
+                # GIS_EXTENDED_EDIT users can access all work related packages
+                if has_gis_extended_edit:
+                    allowed_packages.extend(work_related_packages)
+                # W_VIEW users can access work related packages for works they are assigned to
+                if has_w_view and not has_gis_extended_edit:
+                    staff_user_works = StaffUserWork.find_by_staff_user_id(staff_user.id)
+                    work_ids = [staff_user_work.work_id for staff_user_work in staff_user_works]
+                    allowed_packages.extend([package for package in work_related_packages if package.get("account_project_work").get("work_id") in work_ids])
+                # MP_VIEW users can access management plan related packages
+                if has_mp_view:
+                    allowed_packages.extend(management_plan_related_packages)
+                account_project["packages"] = allowed_packages
+                # Set the correct account_project_works
+                if 'account_project_works' in account_project:
+                    account_project['account_project_works'] = [
+                        work for work in account_project['account_project_works']
+                        if work.get('work_id') in accessible_work_ids
+                    ]
+        if user.type == UserType.PROPONENT:
+            if not user.account_user or not user.account_user.role:
+                return []
+            user_role = user.account_user.role
 
-            # If user has w_view permission, check work assignments
-            if has_w_view:
-                # Get all active work IDs for this staff user
-                active_work_ids = db.session.query(StaffUserWork.work_id).filter(
-                    StaffUserWork.staff_user_id == staff_user.id,
-                    StaffUserWork.is_active == True  # noqa: E712
-                ).subquery()
+            if not user_role.active:
+                return []
+            accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
+            if len(accessible_project_ids) == 0:
+                return []
+            account_project_list = [account_project for account_project in account_project_list if account_project.get("id") in accessible_project_ids]
+            if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value, RoleEnum.ACCOUNT_PRIMARY_ADMIN.value]:
+                return account_project_list
+            if user_role.original_package_ids:
+                for account_project in account_project_list:
+                    allowed_packages = []
+                    original_packages = [package for package in account_project.get("packages") if package.get("version").get("orignial_package_id") in user_role.original_package_ids]
+                    allowed_packages.extend(original_packages)
+                    account_project["packages"] = allowed_packages
+            else:
+                account_project_list = []
+            # # If user has gis_extended_edit permission, they can see all packages with account_project_work
+            # if has_gis_extended_edit:
+            #     filter_conditions.append(Package.account_project_work_id.isnot(None))
+            # # If user has w_view permission, check work assignments (unless they have gis_extended_edit)
+            # if has_w_view and not has_gis_extended_edit:
+            #     # Get all active work IDs for this staff user
+            #     active_work_ids = db.session.query(StaffUserWork.work_id).filter(
+            #         StaffUserWork.staff_user_id == staff_user.id,
+            #         StaffUserWork.is_active == True  # noqa: E712
+            #     ).subquery()
 
-                # Join with AccountProjectWork to filter work packages
-                package_query = package_query.outerjoin(
-                    AccountProjectWork,
-                    Package.account_project_work_id == AccountProjectWork.id
-                )
+            #     # Join with AccountProjectWork to filter work packages
+            #     account_project_query = account_project_query.outerjoin(
+            #         AccountProjectWork,
+            #         Package.account_project_work_id == AccountProjectWork.id
+            #     )
 
-                # Add condition for work packages staff has access to
-                filter_conditions.append(AccountProjectWork.work_id.in_(active_work_ids))
+            #     # Add condition for work packages staff has access to
+            #     filter_conditions.append(AccountProjectWork.work_id.in_(active_work_ids))
 
-            # If user has mp_view permission, include management plan packages
-            if has_mp_view:
-                from submit_api.models.package_type import PackageType
-                from submit_api.utils.constants import MP_VIEW_PACKAGE_TYPES
-                # Add condition for all package types accessible via MP_VIEW role
-                filter_conditions.append(
-                    Package.type.has(PackageType.name.in_(MP_VIEW_PACKAGE_TYPES))
-                )
+            # # If user has mp_view permission, include management plan packages
+            # if has_mp_view:
+            #     from submit_api.models.package_type import PackageType
+            #     from submit_api.utils.constants import MP_VIEW_PACKAGE_TYPES
+            #     # Add condition for all package types accessible via MP_VIEW role
+            #     filter_conditions.append(
+            #         Package.type.has(PackageType.name.in_(MP_VIEW_PACKAGE_TYPES))
+            #     )
 
-            # If no permissions, deny all access
-            if not filter_conditions:
-                return package_query.filter(False)
+            # # If no permissions, deny all access
+            # if not filter_conditions:
+            #     return account_project_query.filter(False)
 
-            # Apply the filter conditions
-            package_query = package_query.filter(or_(*filter_conditions))
+            # # Apply the filter conditions
+            # account_project_query = account_project_query.filter(or_(*filter_conditions))
 
-            return package_query
+            # return account_project_query
+        # accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
+        # if len(accessible_project_ids) == 0:
+        #     return account_project_query.filter(False)
+        # account_project_query = account_project_query.filter(AccountProject.id.in_(accessible_project_ids))
+        # if not user.account_user or not user.account_user.role:
+        #     return account_project_query.filter(False)
 
-        if not user.account_user or not user.account_user.role:
-            return package_query.filter(False)
+        # user_role = user.account_user.role
 
-        user_role = user.account_user.role
+        # if not user_role.active:
+        #     return account_project_query.filter(False)
 
-        if not user_role.active:
-            return package_query.filter(False)
+        # if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value, RoleEnum.ACCOUNT_PRIMARY_ADMIN.value]:
+        #     return account_project_query
 
-        if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value]:
-            return package_query
+        # if user_role.original_package_ids:
+        #     account_project_query = account_project_query.join(PackageVersion).filter(
+        #         PackageVersion.original_package_id.in_(user_role.original_package_ids))
+        # else:
+        #     account_project_query = account_project_query.filter(False)
 
-        if user_role.original_package_ids:
-            package_query = package_query.join(PackageVersion).filter(
-                PackageVersion.original_package_id.in_(user_role.original_package_ids))
-        else:
-            package_query = package_query.filter(False)
-
-        return package_query
+        # return account_project_query
+        return account_project_list
 
     @classmethod
     def _filter_by_search_text(cls, query, search_text):

--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -19,9 +19,8 @@ from submit_api.auth import jwt
 from submit_api.enums.role import RoleEnum
 from submit_api.utils.roles import EpicSubmitRole
 from submit_api.models.package import PackageStatus, NonCanonicalPackageStatus
-from submit_api.models import AccountProject, Project, db, User, PackageVersion
+from submit_api.models import AccountProject, Project, db, User
 from submit_api.models.account_project_search_options import AccountProjectSearchOptions
-from submit_api.models.account_project_work import AccountProjectWork
 from submit_api.models.package import Package
 from submit_api.models.item import Item
 from submit_api.models.staff_user_work import StaffUserWork
@@ -39,11 +38,6 @@ class ProjectQueries:
     @classmethod
     def get_accessible_account_project_ids_for_user(cls, user):
         """Return all account_project_ids accessible by the user based on their roles."""
-        # if user.type == UserType.STAFF:
-        #     # Staff can access all projects
-        #     account_project_ids = db.session.query(AccountProject.id).all()
-        #     return [ap_id for (ap_id,) in account_project_ids]
-
         if not user.account_user or not user.account_user.roles:
             return []
 
@@ -93,94 +87,21 @@ class ProjectQueries:
         schema_class = StaffAccountProjectSchema if is_staff else AccountProjectSchema
         account_project_dict = schema_class().dump(account_project)
 
-        # package_query = db.session.query(Package).join(AccountProject).filter(AccountProject.id == account_project_id)
-        # passing the dict as list for the _filter_packages_by_user_access to work with the existing logic
         account_project_dict = cls._filter_packages_by_user_access([account_project_dict])
         account_project_dict = account_project_dict[0]
-        # filtered_package_ids = [package.id for package in package_query.all()]
-
-        # if filtered_package_ids:
-        #     account_project_dict['packages'] = [
-        #         package for package in account_project_dict['packages']
-        #         if package['id'] in filtered_package_ids
-        #     ]
 
         # Filter account_project_works for staff users without full_access role
         if is_staff and user and user.type == UserType.STAFF:
             if not jwt.contains_role([EpicSubmitRole.FULL_ACCESS.value]):
+                has_gis_extended_edit = jwt.contains_role([EpicSubmitRole.GIS_EXTENDED_EDIT.value])
                 accessible_work_ids = cls._get_accessible_work_ids_for_staff_user(user)
                 if 'account_project_works' in account_project_dict:
                     account_project_dict['account_project_works'] = [
                         work for work in account_project_dict['account_project_works']
-                        if work.get('work_id') in accessible_work_ids
+                        if work.get('work_id') in accessible_work_ids or has_gis_extended_edit
                     ]
 
         return account_project_dict
-
-    # @classmethod
-    # def get_filtered_package_ids(cls, search_options: AccountProjectSearchOptions, user: User = None) -> list:
-    #     """Retrieve package IDs based on search filters."""
-    #     package_query = cls._filter_by_search_criteria(search_options)
-    #     # package_query = cls._filter_packages_by_user_access(package_query, user)
-
-    #     result = [row[0] for row in package_query.with_entities(
-    #         Package.id).all()] if package_query else None
-    #     return result
-
-    # @classmethod
-    # def _filter_account_projects_by_user_access(cls, query=None, user: User = None):
-    #     """Filter AccountProjects by all accessible projects of the user."""
-    #     if user is None:
-    #         user = User.get_by_guid(TokenInfo.get_username())
-
-    #     if not user:
-    #         raise ValueError("User not found.")
-
-    #     if user.type == UserType.STAFF:
-    #         return query
-
-    #     if not user.account_user or not user.account_user.role:
-    #         # No access if no role
-    #         return query.filter(False)
-
-    #     accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
-
-    #     if query is None:
-    #         query = db.session.query(AccountProject)
-
-    #     # Filter projects by accessible project ids
-    #     query = query.filter(AccountProject.id.in_(accessible_project_ids))
-
-    #     return query
-
-    # @classmethod
-    # def get_paginated_account_project_ids(cls, page: int, page_size: int,
-    #                                       filtered_package_ids: list = None, user: User = None) -> tuple:
-    #     """Retrieve paginated AccountProject IDs based on filtering."""
-    #     query = db.session.query(AccountProject).join(Project)
-
-    #     # if user is not None:
-    #     #     query = cls._filter_account_projects_by_user_access(query, user)
-
-    #     if filtered_package_ids is None or len(filtered_package_ids) == 0:
-    #         account_project_ids_subquery = query.with_entities(AccountProject.id).distinct()
-    #     else:
-    #         account_project_ids_subquery = (query.join(Package).filter(Package.id.in_(filtered_package_ids))
-    #                                         .with_entities(AccountProject.id).distinct())
-
-    #     account_project_ids_query = (
-    #         db.session.query(AccountProject.id)
-    #         .join(Project)
-    #         .filter(AccountProject.id.in_(account_project_ids_subquery))
-    #         .order_by(Project.name)
-    #     )
-
-    #     if page and page_size:
-    #         paginated_result = account_project_ids_query.paginate(page=page, per_page=page_size)
-    #         return [row[0] for row in paginated_result.items], paginated_result.total
-
-    #     return ([row[0] for row in account_project_ids_query.all()],
-    #             account_project_ids_query.count())
 
     @classmethod
     def get_full_account_projects(cls, is_proponent: bool, account_projects: list) -> list:
@@ -188,18 +109,6 @@ class ProjectQueries:
         # Get user type for status calculation
         user = User.get_by_guid(TokenInfo.get_username())
         user_type = user.type if user else None
-        # # Load account projects with packages, items, and submissions for status calculation
-        # account_projects = (
-        #     db.session.query(AccountProject)
-        #     .join(Project, AccountProject.project_id == Project.id)
-        #     .filter(AccountProject.id.in_(account_project_ids))
-        #     .options(
-        #         joinedload(AccountProject.packages)
-        #         .joinedload(Package.items)
-        #         .joinedload(Item.submissions)
-        #     )
-        #     .order_by(Project.name)
-        # ).all()
 
         # Pre-calculate statuses for all packages
         package_statuses = {}
@@ -219,50 +128,6 @@ class ProjectQueries:
         schema_class = AccountProjectSchema if is_proponent else StaffAccountProjectSchema
         account_projects_list = schema_class(many=True).dump(account_projects)
 
-        # Apply package access filtering for staff users only
-        # if not is_proponent and user and user.type == UserType.STAFF:
-        #     package_query = db.session.query(Package).filter(
-        #         Package.account_project_id.in_(account_project_ids)
-        #     )
-        #     package_query = cls._filter_packages_by_user_access(package_query, user)
-        #     accessible_package_ids = {pkg.id for pkg in package_query.all()}
-
-        #     # Combine with search filtering if provided
-        #     if filtered_package_ids:
-        #         # Intersection: packages matching BOTH access control AND search criteria
-        #         final_package_ids = accessible_package_ids & set(filtered_package_ids)
-        #     else:
-        #         # No search criteria: use only access control filtering
-        #         final_package_ids = accessible_package_ids
-
-        #     # Filter packages in serialized output
-        #     for account_project in account_projects_list:
-        #         account_project['packages'] = [
-        #             package for package in account_project['packages']
-        #             if package['id'] in final_package_ids
-        #         ]
-        # elif filtered_package_ids:
-        #     # For proponent users, only apply search filtering (no access control filtering)
-        #     for account_project in account_projects_list:
-        #         account_project['packages'] = [
-        #             package for package in account_project['packages']
-        #             if package['id'] in filtered_package_ids
-        #         ]
-
-        # # Filter account_project_works for staff users without full_access role
-        # if not is_proponent and user and user.type == UserType.STAFF:
-        #     if not jwt.contains_role([EpicSubmitRole.FULL_ACCESS.value]):
-        #         # Get accessible work IDs for this staff user
-        #         accessible_work_ids = cls._get_accessible_work_ids_for_staff_user(user)
-
-        #         # Filter account_project_works to only include accessible works
-        #         for account_project in account_projects_list:
-        #             if 'account_project_works' in account_project:
-        #                 account_project['account_project_works'] = [
-        #                     work for work in account_project['account_project_works']
-        #                     if work.get('work_id') in accessible_work_ids
-        #                 ]
-
         return account_projects_list
 
     @classmethod
@@ -280,22 +145,31 @@ class ProjectQueries:
 
         # filtered_package_ids = cls.get_filtered_package_ids(search_options, user)
         account_project_query = cls._filter_by_search_criteria(search_options)
-        paginated_result = account_project_query.add_columns(Project.name).order_by(Project.name).distinct().paginate(page=page, per_page=page_size)
-        # account_project_ids, total = cls.get_paginated_account_project_ids(page, page_size,
-        #                                                                    filtered_package_ids, user)
+        ordered_query = (
+            account_project_query
+            .add_columns(Project.name)
+            .order_by(Project.name)
+            .distinct()
+        )
 
-        # if not account_project_ids:
-        #     return [], 0
-        account_projects = [account_project for account_project, project_name in paginated_result.items]
+        if page and page_size:
+            paginated_result = ordered_query.paginate(page=page, per_page=page_size)
+            account_projects = [ap for ap, _ in paginated_result.items]
+            total = paginated_result.total
+        else:
+            results = ordered_query.all()
+            account_projects = [ap for ap, _ in results]
+            total = len(account_projects)
+
         account_projects_list = cls.get_full_account_projects(is_proponent, account_projects)
         account_projects_list = cls._filter_packages_by_user_access(account_projects_list, user)
 
-        return account_projects_list, paginated_result.total
+        return account_projects_list, total
 
     @classmethod
     def _filter_by_search_criteria(cls, search_options: AccountProjectSearchOptions):
         """Apply various filters based on search options."""
-        query = db.session.query(AccountProject).join(Package).join(Project)
+        query = db.session.query(AccountProject).outerjoin(Package).join(Project)
         if not search_options or not any(bool(search_option) for search_option in search_options.__dict__.values()):
             return query
 
@@ -363,25 +237,37 @@ class ProjectQueries:
             for account_project in account_project_list:
                 allowed_packages = []
                 packages = account_project["packages"]
-                work_related_packages = [package for package in packages if package.get("account_project_work_id") is not None]
-                management_plan_related_packages = [package for package in packages if package.get("type").get("name") in MP_VIEW_PACKAGE_TYPES]
+                work_related_packages = [
+                    package for package in packages
+                    if package.get("account_project_work_id") is not None
+                ]
+                management_plan_related_packages = [
+                    package for package in packages
+                    if package.get("type").get("name") in MP_VIEW_PACKAGE_TYPES
+                ]
                 # GIS_EXTENDED_EDIT users can access all work related packages
                 if has_gis_extended_edit:
                     allowed_packages.extend(work_related_packages)
                 # W_VIEW users can access work related packages for works they are assigned to
                 if has_w_view and not has_gis_extended_edit:
                     staff_user_works = StaffUserWork.find_by_staff_user_id(staff_user.id)
-                    work_ids = [staff_user_work.work_id for staff_user_work in staff_user_works]
-                    allowed_packages.extend([package for package in work_related_packages if package.get("account_project_work").get("work_id") in work_ids])
+                    work_ids = [
+                        staff_user_work.work_id for staff_user_work in staff_user_works
+                    ]
+                    allowed_packages.extend([
+                        package for package in work_related_packages
+                        if package.get("account_project_work").get("work_id") in work_ids
+                    ])
                 # MP_VIEW users can access management plan related packages
                 if has_mp_view:
                     allowed_packages.extend(management_plan_related_packages)
                 account_project["packages"] = allowed_packages
                 # Set the correct account_project_works
+                # Skip the accesible work ids check if there is gis permission
                 if 'account_project_works' in account_project:
                     account_project['account_project_works'] = [
                         work for work in account_project['account_project_works']
-                        if work.get('work_id') in accessible_work_ids
+                        if work.get('work_id') in accessible_work_ids or has_gis_extended_edit
                     ]
         if user.type == UserType.PROPONENT:
             if not user.account_user or not user.account_user.role:
@@ -393,75 +279,28 @@ class ProjectQueries:
             accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
             if len(accessible_project_ids) == 0:
                 return []
-            account_project_list = [account_project for account_project in account_project_list if account_project.get("id") in accessible_project_ids]
-            if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value, RoleEnum.ACCOUNT_PRIMARY_ADMIN.value]:
+            account_project_list = [
+                account_project for account_project in account_project_list
+                if account_project.get("id") in accessible_project_ids
+            ]
+            if user_role.role.role_name in [
+                RoleEnum.SUBMISSION_ADMIN.value,
+                RoleEnum.PROJECT_ADMIN.value,
+                RoleEnum.ACCOUNT_PRIMARY_ADMIN.value
+            ]:
                 return account_project_list
             if user_role.original_package_ids:
                 for account_project in account_project_list:
                     allowed_packages = []
-                    original_packages = [package for package in account_project.get("packages") if package.get("version").get("orignial_package_id") in user_role.original_package_ids]
+                    original_packages = [
+                        package for package in account_project.get("packages")
+                        if package.get("version").get("orignial_package_id")
+                        in user_role.original_package_ids
+                    ]
                     allowed_packages.extend(original_packages)
                     account_project["packages"] = allowed_packages
             else:
                 account_project_list = []
-            # # If user has gis_extended_edit permission, they can see all packages with account_project_work
-            # if has_gis_extended_edit:
-            #     filter_conditions.append(Package.account_project_work_id.isnot(None))
-            # # If user has w_view permission, check work assignments (unless they have gis_extended_edit)
-            # if has_w_view and not has_gis_extended_edit:
-            #     # Get all active work IDs for this staff user
-            #     active_work_ids = db.session.query(StaffUserWork.work_id).filter(
-            #         StaffUserWork.staff_user_id == staff_user.id,
-            #         StaffUserWork.is_active == True  # noqa: E712
-            #     ).subquery()
-
-            #     # Join with AccountProjectWork to filter work packages
-            #     account_project_query = account_project_query.outerjoin(
-            #         AccountProjectWork,
-            #         Package.account_project_work_id == AccountProjectWork.id
-            #     )
-
-            #     # Add condition for work packages staff has access to
-            #     filter_conditions.append(AccountProjectWork.work_id.in_(active_work_ids))
-
-            # # If user has mp_view permission, include management plan packages
-            # if has_mp_view:
-            #     from submit_api.models.package_type import PackageType
-            #     from submit_api.utils.constants import MP_VIEW_PACKAGE_TYPES
-            #     # Add condition for all package types accessible via MP_VIEW role
-            #     filter_conditions.append(
-            #         Package.type.has(PackageType.name.in_(MP_VIEW_PACKAGE_TYPES))
-            #     )
-
-            # # If no permissions, deny all access
-            # if not filter_conditions:
-            #     return account_project_query.filter(False)
-
-            # # Apply the filter conditions
-            # account_project_query = account_project_query.filter(or_(*filter_conditions))
-
-            # return account_project_query
-        # accessible_project_ids = cls.get_accessible_account_project_ids_for_user(user)
-        # if len(accessible_project_ids) == 0:
-        #     return account_project_query.filter(False)
-        # account_project_query = account_project_query.filter(AccountProject.id.in_(accessible_project_ids))
-        # if not user.account_user or not user.account_user.role:
-        #     return account_project_query.filter(False)
-
-        # user_role = user.account_user.role
-
-        # if not user_role.active:
-        #     return account_project_query.filter(False)
-
-        # if user_role.role.role_name in [RoleEnum.SUBMISSION_ADMIN.value, RoleEnum.PROJECT_ADMIN.value, RoleEnum.ACCOUNT_PRIMARY_ADMIN.value]:
-        #     return account_project_query
-
-        # if user_role.original_package_ids:
-        #     account_project_query = account_project_query.join(PackageVersion).filter(
-        #         PackageVersion.original_package_id.in_(user_role.original_package_ids))
-        # else:
-        #     account_project_query = account_project_query.filter(False)
-
         # return account_project_query
         return account_project_list
 

--- a/submit-api/src/submit_api/schemas/package.py
+++ b/submit-api/src/submit_api/schemas/package.py
@@ -175,6 +175,7 @@ class PackageSchema(Schema):
                             data_key="version", exclude=["package_id"])
     account_project_work = fields.Nested(
         AccountProjectWorkSchema, data_key="account_project_work", allow_none=True)
+    account_project_work_id = fields.Int(data_key="account_project_work_id")
     internal_staff_documents = fields.Nested(InternalStaffDocumentSchema,
                                              data_key="internal_staff_documents",
                                              many=True)

--- a/submit-api/tests/unit/resources/test_project.py
+++ b/submit-api/tests/unit/resources/test_project.py
@@ -89,7 +89,7 @@ def test_get_project_by_id_invalid_jwt(client):
 def test_get_projects_by_account(client, session, jwt):
     """Returns projects for the given account."""
     headers, account_project = setup_authenticated_proponent(session, jwt)
-
+    print(account_project.id)
     response = client.get(
         f"{PROJECTS_URL}/accounts/{account_project.account_id}",
         headers=headers,
@@ -98,6 +98,8 @@ def test_get_projects_by_account(client, session, jwt):
     assert response.status_code == HTTPStatus.OK
     data = response.get_json()
     assert isinstance(data, list)
+    print(account_project.id)
+    print(response.get_json())
     assert any(p["id"] == account_project.id for p in data)
 
 

--- a/submit-web/src/components/App/Map/MapPreviewModal.tsx
+++ b/submit-web/src/components/App/Map/MapPreviewModal.tsx
@@ -30,6 +30,8 @@ import MapIcon from "@mui/icons-material/Map";
 import type { GeoJSON } from "geojson";
 import { Submission } from "@/models/Submission";
 import { BCDesignTokens } from "epic.theme";
+import { useHasRole } from "@/hooks/common";
+import { EPIC_SUBMIT_ROLE } from "@/models/Role";
 
 interface MapPreviewModalProps {
   open: boolean;
@@ -64,6 +66,7 @@ export const MapPreviewModal: React.FC<MapPreviewModalProps> = ({
   const [mapStyleUri, setMapStyleUri] = useState<string>(
     "https://tiles.openfreemap.org/styles/liberty",
   );
+  const isStaff = useHasRole(EPIC_SUBMIT_ROLE.eao_view);
 
   const SATELLITE_STYLE: any = {
     version: 8,
@@ -323,13 +326,15 @@ export const MapPreviewModal: React.FC<MapPreviewModalProps> = ({
               </Box>
 
               {/* Alert Banner */}
-              <Box sx={{ px: 2, pb: 2 }}>
-                <Alert severity="warning" sx={{ borderRadius: "8px", backgroundColor: BCDesignTokens.supportSurfaceColorWarning }} icon={false} variant="outlined">
-                  <Typography variant="body1" fontWeight={700}>Please verify this geospatial file</Typography>
-                  Review the map preview and file information to ensure this is the correct data (correct location, using the BC Albers Projection).
-                  You must manually approve or reject each file before proceeding.
-                </Alert>
-              </Box>
+              {!isStaff && (
+                <Box sx={{ px: 2, pb: 2 }}>
+                  <Alert severity="warning" sx={{ borderRadius: "8px", backgroundColor: BCDesignTokens.supportSurfaceColorWarning }} icon={false} variant="outlined">
+                    <Typography variant="body1" fontWeight={700}>Please verify this geospatial file</Typography>
+                    Review the map preview and file information to ensure this is the correct data (correct location, using the BC Albers Projection).
+                    You must manually approve or reject each file before proceeding.
+                  </Alert>
+                </Box>
+              )}
 
               {/* Dynamic Map Container */}
               <Box

--- a/submit-web/src/components/App/Projects/Project.tsx
+++ b/submit-web/src/components/App/Projects/Project.tsx
@@ -51,7 +51,10 @@ export const Project = ({ accountProject }: ProjectParam) => {
             />
           );
         })}
-      {accountProject.project.has_approved_condition && (
+      {accountProject.project.has_approved_condition &&
+        accountProject.packages.some(
+          (pkg) => pkg.type.name === SubmissionPackageType.MANAGEMENT_PLAN,
+        ) && (
           <ProjectSubmissionsCard
             title="Management Plans & Related Documents"
             status={PROJECT_STATUS.POST_DECISION}

--- a/submit-web/src/components/App/registration/addProjects/ProjectsList.tsx
+++ b/submit-web/src/components/App/registration/addProjects/ProjectsList.tsx
@@ -1,11 +1,5 @@
 import { Stack } from "@mui/material";
 import { Skeleton } from "./ProjectCard/Skeleton";
-// import { ProjectCard } from "./ProjectCard";
-// import { Project } from "@/models/Project";
-
-// type ProjectsListProps = {
-//   projects?: Project[];
-// };
 
 export const ProjectListSkeleton = () => {
   return (
@@ -16,15 +10,3 @@ export const ProjectListSkeleton = () => {
     </Stack>
   );
 };
-// export const ProjectsList = ({ projects }: ProjectsListProps) => {
-//   if (!projects?.length) {
-//     return <p>No projects found</p>;
-//   }
-//   return (
-//     <Stack spacing={2} direction="row">
-//       {projects?.map((project) => (
-//         <ProjectCard key={project.id} project={project} />
-//       ))}
-//     </Stack>
-//   );
-// };

--- a/submit-web/src/components/App/registration/addProjects/ProjectsList.tsx
+++ b/submit-web/src/components/App/registration/addProjects/ProjectsList.tsx
@@ -1,11 +1,11 @@
 import { Stack } from "@mui/material";
 import { Skeleton } from "./ProjectCard/Skeleton";
-import { ProjectCard } from "./ProjectCard";
-import { Project } from "@/models/Project";
+// import { ProjectCard } from "./ProjectCard";
+// import { Project } from "@/models/Project";
 
-type ProjectsListProps = {
-  projects?: Project[];
-};
+// type ProjectsListProps = {
+//   projects?: Project[];
+// };
 
 export const ProjectListSkeleton = () => {
   return (
@@ -16,15 +16,15 @@ export const ProjectListSkeleton = () => {
     </Stack>
   );
 };
-export const ProjectsList = ({ projects }: ProjectsListProps) => {
-  if (!projects?.length) {
-    return <p>No projects found</p>;
-  }
-  return (
-    <Stack spacing={2} direction="row">
-      {projects?.map((project) => (
-        <ProjectCard key={project.id} project={project} />
-      ))}
-    </Stack>
-  );
-};
+// export const ProjectsList = ({ projects }: ProjectsListProps) => {
+//   if (!projects?.length) {
+//     return <p>No projects found</p>;
+//   }
+//   return (
+//     <Stack spacing={2} direction="row">
+//       {projects?.map((project) => (
+//         <ProjectCard key={project.id} project={project} />
+//       ))}
+//     </Stack>
+//   );
+// };

--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -152,10 +152,23 @@ export function useStaffSubmissionPage({
     [submissionPackage],
   );
 
+  // Only users with w_extended_edit permission can approve/acknowledge packages
+  // GIS-only users (without full_access) should not be able to approve/acknowledge packages
+  const hasExtendedEdit = hasPermission({
+    permissions: account.roles || [],
+    scopes: [EPIC_SUBMIT_ROLE.w_extended_edit],
+  });
+  const hasGISRole = useHasRole(EPIC_SUBMIT_ROLE.gis_extended_edit);
+  const hasFullAccess = useHasRole(EPIC_SUBMIT_ROLE.full_access);
+
+  // Exclude GIS-only users (those with GIS role but not full_access)
+  const hasAcknowledgeOrApproveRole =
+    hasExtendedEdit && !(hasGISRole && !hasFullAccess);
+
   const canAcknowledge =
-    approval_type === SubmissionPackageApprovalType.A
+    (approval_type === SubmissionPackageApprovalType.A
       ? isPackageVerified
-      : isReadyForAcknowledgement;
+      : isReadyForAcknowledgement) && hasAcknowledgeOrApproveRole;
 
   const isPackagePastApproval = useMemo(
     () =>
@@ -174,19 +187,9 @@ export function useStaffSubmissionPage({
       SubmissionPackageApprovalType.C,
     ].includes(approval_type as SubmissionPackageApprovalType);
 
-  // Only users with w_extended_edit permission can approve packages
-  // GIS-only users (without full_access) should not be able to approve packages
-  const hasExtendedEdit = hasPermission({
-    permissions: account.roles || [],
-    scopes: [EPIC_SUBMIT_ROLE.w_extended_edit],
-  });
-  const hasGISRole = useHasRole(EPIC_SUBMIT_ROLE.gis_extended_edit);
-  const hasFullAccess = useHasRole(EPIC_SUBMIT_ROLE.full_access);
-  
-  // Exclude GIS-only users (those with GIS role but not full_access)
-  const canApprove = hasExtendedEdit && !(hasGISRole && !hasFullAccess);
+  const canApprove = hasAcknowledgeOrApproveRole;
   const showApproveButtons =
-    isPackageAcknowledged && 
+    isPackageAcknowledged &&
     approval_type == SubmissionPackageApprovalType.C &&
     canApprove;
 

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -731,7 +731,7 @@ export default function SubmissionPage() {
                   >
                     <Unless condition={submissionPackage.completed_on}>
                       <When
-                        condition={submissionPackage.type.versioning_enabled}
+                        condition={!!submissionPackage.account_project_work}
                       >
                         <Button
                           color="error"


### PR DESCRIPTION
Please check the account_project.py query file primarily as there were a lot of code I commented to make it simpler. Previously we were querying package_ids and project_ids separately and then query the projects and there were a lot redundant code was there. I just cleaned it up and tested it with all the roles we have except the CONTRIBUTOR role of the proponent.