### PR TITLE
SUBMIT-921 - Gis compression

### DIFF
--- a/submit-api/Dockerfile
+++ b/submit-api/Dockerfile
@@ -11,7 +11,9 @@ RUN apt-get update && apt-get install -y \
     libldap2-dev \
     libssl-dev \
     gcc \
+    g++ \
     gdal-bin \
+    libgdal-dev \
     git \
  && rm -rf /var/lib/apt/lists/*
 

--- a/submit-api/Dockerfile
+++ b/submit-api/Dockerfile
@@ -32,4 +32,7 @@ USER 1001
 # Set Python path
 ENV PYTHONPATH=/opt/app-root/src
 
+# Set HOME to /tmp for OpenShift arbitrary UID support (prevents /.gunicorn permission denied errors)
+ENV HOME=/tmp
+
 ENTRYPOINT ["bash", "docker-entrypoint.sh"]

--- a/submit-api/Dockerfile
+++ b/submit-api/Dockerfile
@@ -11,6 +11,7 @@ RUN apt-get update && apt-get install -y \
     libldap2-dev \
     libssl-dev \
     gcc \
+    gdal-bin \
     git \
  && rm -rf /var/lib/apt/lists/*
 

--- a/submit-api/src/submit_api/services/document_service_client.py
+++ b/submit-api/src/submit_api/services/document_service_client.py
@@ -100,7 +100,7 @@ class DocumentServiceClient:
     def upload_file_via_presigned_url(
         presigned_url: str,
         file_path: str,
-        content_type: str = "application/geo+json",
+        content_type: str = "application/octet-stream",
     ):
         """Stream a local file directly to S3 via a presigned URL."""
         current_app.logger.info(f"Uploading file via presigned URL from {file_path}")

--- a/submit-api/src/submit_api/services/document_service_client.py
+++ b/submit-api/src/submit_api/services/document_service_client.py
@@ -97,6 +97,24 @@ class DocumentServiceClient:
         current_app.logger.info("Successfully uploaded file data")
 
     @staticmethod
+    def upload_file_via_presigned_url(
+        presigned_url: str,
+        file_path: str,
+        content_type: str = "application/geo+json",
+    ):
+        """Stream a local file directly to S3 via a presigned URL."""
+        current_app.logger.info(f"Uploading file via presigned URL from {file_path}")
+        with open(file_path, "rb") as file_data:
+            response = requests.put(
+                presigned_url,
+                data=file_data,
+                headers={"Content-Type": content_type},
+                timeout=300
+            )
+        response.raise_for_status()
+        current_app.logger.info("Successfully uploaded file")
+
+    @staticmethod
     def download_via_presigned_url(presigned_url: str, local_path: str) -> str:
         """Download file content directly from S3 via a presigned URL to a local path."""
         current_app.logger.info(f"Downloading file data via presigned URL to {local_path}")

--- a/submit-api/src/submit_api/services/document_service_client.py
+++ b/submit-api/src/submit_api/services/document_service_client.py
@@ -103,7 +103,6 @@ class DocumentServiceClient:
         content_type: str = "application/octet-stream",
     ):
         """Stream a local file directly to S3 via a presigned URL."""
-        current_app.logger.info(f"Uploading file via presigned URL from {file_path}")
         with open(file_path, "rb") as file_data:
             response = requests.put(
                 presigned_url,
@@ -111,8 +110,13 @@ class DocumentServiceClient:
                 headers={"Content-Type": content_type},
                 timeout=300
             )
-        response.raise_for_status()
-        current_app.logger.info("Successfully uploaded file")
+        try:
+            response.raise_for_status()
+        except requests.HTTPError as exc:
+            status_code = exc.response.status_code if exc.response is not None else "unknown"
+            raise requests.HTTPError(
+                f"Presigned file upload failed with HTTP status {status_code}"
+            ) from None
 
     @staticmethod
     def download_via_presigned_url(presigned_url: str, local_path: str) -> str:

--- a/submit-api/src/submit_api/services/geo/__init__.py
+++ b/submit-api/src/submit_api/services/geo/__init__.py
@@ -18,7 +18,8 @@ Public surface:
   process_geo_file    — converts a .shp/.zip into tiered GeoJSON
   validate_geo_file   — validates shapefile attributes before conversion
 """
-from submit_api.services.geo.processor import GeoService, process_geo_file
+from submit_api.services.geo.ogr_converter import process_geo_file
+from submit_api.services.geo.processor import GeoService
 from submit_api.services.geo.validator import validate_geo_file
 
 __all__ = ["GeoService", "process_geo_file", "validate_geo_file"]

--- a/submit-api/src/submit_api/services/geo/archive.py
+++ b/submit-api/src/submit_api/services/geo/archive.py
@@ -20,8 +20,26 @@ import zipfile
 from pathlib import Path
 
 
+# Zip uploads are expanded on disk before GDAL reads them. These limits protect
+# the API worker from archives that are small on upload but huge after
+# extraction, or from archives with enough entries/layers to create excessive
+# filesystem and conversion work. They are environment-configurable so ops can
+# raise them for legitimate large datasets without changing code.
+#
+# Maximum total uncompressed bytes across all files in a zip. This is not the
+# uploaded zip size; it is the sum of each member's declared extracted size and
+# is primarily a guard against zip-bomb style payloads and temp-disk exhaustion.
 DEFAULT_MAX_EXTRACTED_BYTES = int(os.environ.get("GEO_MAX_EXTRACTED_BYTES", 500 * 1024 * 1024))
+
+# Maximum number of non-directory files allowed in one zip. Shapefiles commonly
+# include several sidecar files per layer (.dbf, .shx, .prj, .cpg, etc.), so this
+# is intentionally higher than the shapefile count limit but still rejects
+# pathological archives with thousands of tiny files.
 DEFAULT_MAX_ZIP_MEMBERS = int(os.environ.get("GEO_MAX_ZIP_MEMBERS", 500))
+
+# Maximum number of .shp layers accepted from one upload. Each layer is converted
+# independently, then merged into preview and standard GeoJSON outputs, so this
+# caps CPU time, output size growth, and frontend layer/color complexity.
 DEFAULT_MAX_SHAPEFILES = int(os.environ.get("GEO_MAX_SHAPEFILES", 20))
 
 
@@ -53,6 +71,8 @@ def safe_extract_zip(
 ) -> None:
     """Extract a zip file after checking path traversal and expanded size limits."""
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        # Directories do not consume converted GIS input or meaningful disk
+        # capacity, so limits are applied only to actual file members.
         members = [member for member in zip_ref.infolist() if not member.is_dir()]
         if len(members) > max_members:
             raise ValueError(f"Zip archive contains too many files ({len(members)} > {max_members}).")

--- a/submit-api/src/submit_api/services/geo/archive.py
+++ b/submit-api/src/submit_api/services/geo/archive.py
@@ -43,17 +43,22 @@ DEFAULT_MAX_ZIP_MEMBERS = int(os.environ.get("GEO_MAX_ZIP_MEMBERS", 500))
 DEFAULT_MAX_SHAPEFILES = int(os.environ.get("GEO_MAX_SHAPEFILES", 20))
 
 
+def _is_unsafe_member_name(normalized_name: str, parts: tuple[str, ...]) -> bool:
+    """Return True when a zip member name can escape the extraction directory."""
+    if not normalized_name:
+        return True
+    if normalized_name.startswith(("/", "\\")):
+        return True
+    if parts and ":" in parts[0]:
+        return True
+    return ".." in parts
+
+
 def _safe_member_path(target_dir: str, member_name: str) -> Path:
     """Return a safe extraction path for one zip member."""
     normalized_name = member_name.replace("\\", "/")
     parts = Path(normalized_name).parts
-    if (
-        not normalized_name
-        or normalized_name.startswith("/")
-        or normalized_name.startswith("\\")
-        or (parts and ":" in parts[0])
-        or ".." in parts
-    ):
+    if _is_unsafe_member_name(normalized_name, parts):
         raise ValueError(f"Unsafe path in zip archive: {member_name}")
 
     base_path = Path(target_dir).resolve()

--- a/submit-api/src/submit_api/services/geo/archive.py
+++ b/submit-api/src/submit_api/services/geo/archive.py
@@ -1,0 +1,79 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Archive helpers for geospatial uploads."""
+from __future__ import annotations
+
+import os
+import shutil
+import zipfile
+from pathlib import Path
+
+
+DEFAULT_MAX_EXTRACTED_BYTES = int(os.environ.get("GEO_MAX_EXTRACTED_BYTES", 500 * 1024 * 1024))
+DEFAULT_MAX_ZIP_MEMBERS = int(os.environ.get("GEO_MAX_ZIP_MEMBERS", 500))
+DEFAULT_MAX_SHAPEFILES = int(os.environ.get("GEO_MAX_SHAPEFILES", 20))
+
+
+def _safe_member_path(target_dir: str, member_name: str) -> Path:
+    """Return a safe extraction path for one zip member."""
+    normalized_name = member_name.replace("\\", "/")
+    parts = Path(normalized_name).parts
+    if (
+        not normalized_name
+        or normalized_name.startswith("/")
+        or normalized_name.startswith("\\")
+        or (parts and ":" in parts[0])
+        or ".." in parts
+    ):
+        raise ValueError(f"Unsafe path in zip archive: {member_name}")
+
+    base_path = Path(target_dir).resolve()
+    target_path = (base_path / normalized_name).resolve()
+    if target_path != base_path and base_path not in target_path.parents:
+        raise ValueError(f"Unsafe path in zip archive: {member_name}")
+    return target_path
+
+
+def safe_extract_zip(
+    zip_path: str,
+    target_dir: str,
+    max_total_size: int = DEFAULT_MAX_EXTRACTED_BYTES,
+    max_members: int = DEFAULT_MAX_ZIP_MEMBERS,
+) -> None:
+    """Extract a zip file after checking path traversal and expanded size limits."""
+    with zipfile.ZipFile(zip_path, "r") as zip_ref:
+        members = [member for member in zip_ref.infolist() if not member.is_dir()]
+        if len(members) > max_members:
+            raise ValueError(f"Zip archive contains too many files ({len(members)} > {max_members}).")
+
+        total_size = sum(member.file_size for member in members)
+        if total_size > max_total_size:
+            raise ValueError(
+                "Zip archive is too large after extraction "
+                f"({total_size} bytes > {max_total_size} bytes)."
+            )
+
+        for member in members:
+            target_path = _safe_member_path(target_dir, member.filename)
+            target_path.parent.mkdir(parents=True, exist_ok=True)
+            with zip_ref.open(member) as source, open(target_path, "wb") as target:
+                shutil.copyfileobj(source, target)
+
+
+def find_shapefiles(root_dir: str, max_shapefiles: int = DEFAULT_MAX_SHAPEFILES) -> list[str]:
+    """Return sorted shapefile paths under ``root_dir`` and enforce a count limit."""
+    shapefiles = sorted(str(path) for path in Path(root_dir).rglob("*.shp") if path.is_file())
+    if len(shapefiles) > max_shapefiles:
+        raise ValueError(f"Zip archive contains too many shapefiles ({len(shapefiles)} > {max_shapefiles}).")
+    return shapefiles

--- a/submit-api/src/submit_api/services/geo/ogr_converter.py
+++ b/submit-api/src/submit_api/services/geo/ogr_converter.py
@@ -230,6 +230,21 @@ def _clamp_bbox(bounds: tuple[float, float, float, float] | None) -> list[float]
     return bbox
 
 
+def _merge_bounds(
+    current_bounds: list[float] | None,
+    geom_bounds: tuple[float, float, float, float],
+) -> list[float]:
+    """Return cumulative bounds after adding one geometry bounds tuple."""
+    if current_bounds is None:
+        return [geom_bounds[0], geom_bounds[1], geom_bounds[2], geom_bounds[3]]
+    return [
+        min(current_bounds[0], geom_bounds[0]),
+        min(current_bounds[1], geom_bounds[1]),
+        max(current_bounds[2], geom_bounds[2]),
+        max(current_bounds[3], geom_bounds[3]),
+    ]
+
+
 def _get_geojson_metadata(standard_path: str, crs_original: str) -> Dict[str, Any]:
     """Read final GeoJSON metadata one feature at a time."""
     geometry_counts: Counter[str] = Counter()
@@ -244,13 +259,7 @@ def _get_geojson_metadata(standard_path: str, crs_original: str) -> Dict[str, An
                 continue
             geometry_counts[geometry.get("type", "Unknown")] += 1
             geom_bounds = shape(geometry).bounds
-            if bounds is None:
-                bounds = [geom_bounds[0], geom_bounds[1], geom_bounds[2], geom_bounds[3]]
-            else:
-                bounds[0] = min(bounds[0], geom_bounds[0])
-                bounds[1] = min(bounds[1], geom_bounds[1])
-                bounds[2] = max(bounds[2], geom_bounds[2])
-                bounds[3] = max(bounds[3], geom_bounds[3])
+            bounds = _merge_bounds(bounds, geom_bounds)
 
     geometry_type = geometry_counts.most_common(1)[0][0] if geometry_counts else "Unknown"
     return {
@@ -288,15 +297,8 @@ def _summarize_crs(crs_values: list[str]) -> str:
     return "Mixed: " + ", ".join(unique_values)
 
 
-def process_geo_file(local_path: str, output_dir: str | None = None) -> Dict[str, Any]:
-    """Process a .shp or .zip into preview/standard GeoJSON files plus metadata."""
-    output_root = output_dir or tempfile.mkdtemp(prefix="geo-processed-")
-    os.makedirs(output_root, exist_ok=True)
-
-    shapefiles = _resolve_shapefiles(local_path, output_root)
-    layer_dir = os.path.join(output_root, "layers")
-    os.makedirs(layer_dir, exist_ok=True)
-
+def _convert_layers(shapefiles: list[str], layer_dir: str) -> tuple[list[str], list[str], list[str]]:
+    """Convert source shapefiles into per-layer standard and preview outputs."""
     standard_parts: list[str] = []
     preview_parts: list[str] = []
     crs_values: list[str] = []
@@ -313,6 +315,19 @@ def process_geo_file(local_path: str, output_dir: str | None = None) -> Dict[str
             preview_parts.append(preview_part)
             with fiona.open(preview_part) as preview_source:
                 remaining_preview_features -= len(preview_source)
+
+    return standard_parts, preview_parts, crs_values
+
+
+def process_geo_file(local_path: str, output_dir: str | None = None) -> Dict[str, Any]:
+    """Process a .shp or .zip into preview/standard GeoJSON files plus metadata."""
+    output_root = output_dir or tempfile.mkdtemp(prefix="geo-processed-")
+    os.makedirs(output_root, exist_ok=True)
+
+    shapefiles = _resolve_shapefiles(local_path, output_root)
+    layer_dir = os.path.join(output_root, "layers")
+    os.makedirs(layer_dir, exist_ok=True)
+    standard_parts, preview_parts, crs_values = _convert_layers(shapefiles, layer_dir)
 
     standard_output = os.path.join(output_root, "standard.geojson")
     preview_output = os.path.join(output_root, "preview.geojson")

--- a/submit-api/src/submit_api/services/geo/ogr_converter.py
+++ b/submit-api/src/submit_api/services/geo/ogr_converter.py
@@ -19,7 +19,9 @@ import logging
 import math
 import multiprocessing
 import os
+import resource
 import subprocess
+import sys
 import tempfile
 from collections import Counter
 from pathlib import Path
@@ -344,6 +346,23 @@ def process_geo_file(local_path: str, output_dir: str | None = None) -> Dict[str
     }
 
 
+def _max_rss_to_mb(max_rss: int) -> float:
+    """Convert ru_maxrss to MB; Linux reports KB, macOS reports bytes."""
+    divisor = 1024 * 1024 if sys.platform == "darwin" else 1024
+    return round(max_rss / divisor, 2)
+
+
+def _get_resource_usage() -> Dict[str, Any]:
+    """Return best-effort CPU and memory use for this worker and its GDAL subprocesses."""
+    self_usage = resource.getrusage(resource.RUSAGE_SELF)
+    child_usage = resource.getrusage(resource.RUSAGE_CHILDREN)
+    return {
+        "user_cpu_seconds": round(self_usage.ru_utime + child_usage.ru_utime, 3),
+        "system_cpu_seconds": round(self_usage.ru_stime + child_usage.ru_stime, 3),
+        "max_rss_mb": _max_rss_to_mb(max(self_usage.ru_maxrss, child_usage.ru_maxrss)),
+    }
+
+
 def _process_geo_file_worker(
     local_path: str,
     output_dir: str,
@@ -351,7 +370,9 @@ def _process_geo_file_worker(
 ) -> None:
     """Child-process entry point for timeout-controlled conversion."""
     try:
-        result_queue.put(("ok", process_geo_file(local_path, output_dir)))
+        result = process_geo_file(local_path, output_dir)
+        result["resource_usage"] = _get_resource_usage()
+        result_queue.put(("ok", result))
     except Exception as exc:  # pylint: disable=broad-except # noqa: B902
         result_queue.put(("error", str(exc)))
 

--- a/submit-api/src/submit_api/services/geo/ogr_converter.py
+++ b/submit-api/src/submit_api/services/geo/ogr_converter.py
@@ -49,9 +49,25 @@ COLOR_PALETTE = [
 ]
 
 OUTPUT_LAYER_NAME = "features"
+
+# Preview files are meant for quick browser rendering, not authoritative GIS
+# analysis. Simplification is done after the standard layer has already been
+# converted to WGS84, so the tolerance is in degrees and intentionally small.
 PREVIEW_SIMPLIFICATION = float(os.environ.get("GEO_PREVIEW_SIMPLIFICATION", "0.000001"))
+
+# Cap the number of features copied into preview output. The standard tier still
+# contains all features; this only keeps map previews responsive for large
+# uploads.
 PREVIEW_MAX_FEATURES = int(os.environ.get("GEO_PREVIEW_MAX_FEATURES", 10_000))
+
+# Maximum size for each generated GeoJSON tier. This catches unexpectedly large
+# outputs before they are uploaded to object storage and before the frontend is
+# asked to fetch/render them.
 GEO_MAX_OUTPUT_BYTES = int(os.environ.get("GEO_MAX_OUTPUT_BYTES", 500 * 1024 * 1024))
+
+# Hard wall-clock limit for a GIS conversion job. The subprocess-level timeout
+# limits each GDAL command; process_geo_file_with_timeout also enforces this at
+# the worker-process level so a stuck conversion can be terminated.
 GEO_PROCESSING_TIMEOUT_SECONDS = int(os.environ.get("GEO_PROCESSING_TIMEOUT_SECONDS", 60))
 
 
@@ -72,6 +88,9 @@ def _run_command(cmd: list[str], timeout_seconds: int = GEO_PROCESSING_TIMEOUT_S
             cmd,
             check=False,
             capture_output=True,
+            # Some shapefile uploads omit or damage the .shx index. GDAL can
+            # rebuild it when this flag is set, which makes the converter more
+            # tolerant without changing the uploaded source archive.
             env={**os.environ, "SHAPE_RESTORE_SHX": "YES"},
             text=True,
             timeout=timeout_seconds,
@@ -104,6 +123,10 @@ def _convert_source_to_standard(shp_path: str, output_path: str, layer_index: in
     """Convert one shapefile to a WGS84 GeoJSON layer and add map styling fields."""
     source_layer_name, crs_original = _get_source_info(shp_path)
     fill_color, stroke_color = COLOR_PALETTE[layer_index % len(COLOR_PALETTE)]
+
+    # Add frontend styling fields inside OGR's SQL projection so feature
+    # properties are preserved and Python never has to load the layer into a
+    # GeoDataFrame just to decorate each feature.
     sql = (
         "SELECT *, "
         f"{_quote_literal(fill_color)} AS layer_color, "
@@ -126,6 +149,9 @@ def _convert_source_to_standard(shp_path: str, output_path: str, layer_index: in
         sql,
     ]
     if crs_original == "Unknown":
+        # Without a .prj file GDAL cannot safely reproject coordinates. The old
+        # path treated missing CRS as WGS84, so keep that compatibility by
+        # assigning EPSG:4326 rather than transforming unknown coordinates.
         logger.warning("No CRS found in file %s (missing .prj?). Assuming EPSG:4326.", shp_path)
         cmd.extend(["-a_srs", "EPSG:4326"])
     else:
@@ -178,6 +204,8 @@ def _merge_geojson_files(source_paths: list[str], output_path: str) -> None:
                 for feature in source:
                     if not first_feature:
                         target.write(",")
+                    # Write one feature at a time so multi-layer uploads do not
+                    # accumulate full GeoJSON payloads in process memory.
                     json.dump(to_dict(feature), target, allow_nan=False, separators=(",", ":"))
                     first_feature = False
         target.write("]}")
@@ -321,6 +349,10 @@ def process_geo_file_with_timeout(
     """Run process_geo_file in a child process, enforcing a hard wall-clock timeout."""
     ctx = multiprocessing.get_context()
     result_queue: "multiprocessing.Queue" = ctx.Queue()
+
+    # Run conversion in a separate process instead of the request/background
+    # thread so a timeout can terminate GDAL/Fiona work cleanly and release the
+    # worker process resources.
     proc = ctx.Process(
         target=_process_geo_file_worker,
         args=(local_path, output_dir, result_queue),

--- a/submit-api/src/submit_api/services/geo/ogr_converter.py
+++ b/submit-api/src/submit_api/services/geo/ogr_converter.py
@@ -1,0 +1,352 @@
+# Copyright © 2024 Province of British Columbia
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Disk-based GDAL/OGR converter for geospatial uploads."""
+from __future__ import annotations
+
+import json
+import logging
+import math
+import multiprocessing
+import os
+import subprocess
+import tempfile
+from collections import Counter
+from pathlib import Path
+from queue import Empty
+from typing import Any, Dict
+
+import fiona
+from fiona.model import to_dict
+from shapely.geometry import shape
+
+from submit_api.services.geo.archive import find_shapefiles, safe_extract_zip
+
+
+logger = logging.getLogger(__name__)
+
+COLOR_PALETTE = [
+    ("#FF00FF", "#8B008B"),  # Neon Magenta
+    ("#00FFFF", "#008B8B"),  # Neon Cyan
+    ("#FF1493", "#C71585"),  # Deep Pink
+    ("#39FF14", "#008000"),  # Neon Green
+    ("#FF4500", "#B22222"),  # Orange Red
+    ("#9400D3", "#4B0082"),  # Dark Violet
+    ("#FFFF00", "#B8860B"),  # Bright Yellow
+    ("#FF007F", "#80003F"),  # Rose
+    ("#00FF00", "#006400"),  # Lime
+    ("#8A2BE2", "#483D8B"),  # Blue Violet
+]
+
+OUTPUT_LAYER_NAME = "features"
+PREVIEW_SIMPLIFICATION = float(os.environ.get("GEO_PREVIEW_SIMPLIFICATION", "0.000001"))
+PREVIEW_MAX_FEATURES = int(os.environ.get("GEO_PREVIEW_MAX_FEATURES", 10_000))
+GEO_MAX_OUTPUT_BYTES = int(os.environ.get("GEO_MAX_OUTPUT_BYTES", 500 * 1024 * 1024))
+GEO_PROCESSING_TIMEOUT_SECONDS = int(os.environ.get("GEO_PROCESSING_TIMEOUT_SECONDS", 60))
+
+
+def _quote_identifier(value: str) -> str:
+    """Quote an OGR SQL identifier."""
+    return '"' + value.replace('"', '""') + '"'
+
+
+def _quote_literal(value: str) -> str:
+    """Quote an OGR SQL string literal."""
+    return "'" + value.replace("'", "''") + "'"
+
+
+def _run_command(cmd: list[str], timeout_seconds: int = GEO_PROCESSING_TIMEOUT_SECONDS) -> None:
+    """Run a GDAL command and raise a concise error on failure."""
+    try:
+        result = subprocess.run(
+            cmd,
+            check=False,
+            capture_output=True,
+            env={**os.environ, "SHAPE_RESTORE_SHX": "YES"},
+            text=True,
+            timeout=timeout_seconds,
+        )
+    except FileNotFoundError as exc:
+        raise RuntimeError("GDAL command not found. Install gdal-bin so ogr2ogr is available.") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise TimeoutError(f"GDAL conversion timed out after {timeout_seconds} seconds.") from exc
+
+    if result.returncode != 0:
+        details = (result.stderr or result.stdout or "").strip()
+        raise RuntimeError(f"GDAL conversion failed: {details}")
+
+
+def _format_crs(src: fiona.Collection) -> str:
+    """Return a compact CRS name for metadata."""
+    if src.crs:
+        to_string = getattr(src.crs, "to_string", None)
+        return to_string() if callable(to_string) else str(src.crs)
+    return "Unknown"
+
+
+def _get_source_info(shp_path: str) -> tuple[str, str]:
+    """Return the OGR layer name and original CRS for a shapefile."""
+    with fiona.open(shp_path) as src:
+        return src.name or Path(shp_path).stem, _format_crs(src)
+
+
+def _convert_source_to_standard(shp_path: str, output_path: str, layer_index: int) -> str:
+    """Convert one shapefile to a WGS84 GeoJSON layer and add map styling fields."""
+    source_layer_name, crs_original = _get_source_info(shp_path)
+    fill_color, stroke_color = COLOR_PALETTE[layer_index % len(COLOR_PALETTE)]
+    sql = (
+        "SELECT *, "
+        f"{_quote_literal(fill_color)} AS layer_color, "
+        f"{_quote_literal(stroke_color)} AS stroke_color, "
+        f"{_quote_literal(Path(shp_path).name)} AS layer_name "
+        f"FROM {_quote_identifier(source_layer_name)}"
+    )
+
+    cmd = [
+        "ogr2ogr",
+        "-f",
+        "GeoJSON",
+        "-lco",
+        "RFC7946=YES",
+        "-nln",
+        OUTPUT_LAYER_NAME,
+        "-dialect",
+        "SQLite",
+        "-sql",
+        sql,
+    ]
+    if crs_original == "Unknown":
+        logger.warning("No CRS found in file %s (missing .prj?). Assuming EPSG:4326.", shp_path)
+        cmd.extend(["-a_srs", "EPSG:4326"])
+    else:
+        cmd.extend(["-t_srs", "EPSG:4326"])
+
+    cmd.extend([output_path, shp_path])
+    _run_command(cmd)
+    _check_output_size(output_path)
+    return crs_original
+
+
+def _convert_standard_to_preview(standard_path: str, output_path: str, feature_limit: int) -> None:
+    """Create one simplified preview layer from an already-WGS84 GeoJSON layer."""
+    sql = f"SELECT * FROM {_quote_identifier(OUTPUT_LAYER_NAME)} LIMIT {feature_limit}"
+    cmd = [
+        "ogr2ogr",
+        "-f",
+        "GeoJSON",
+        "-lco",
+        "RFC7946=YES",
+        "-nln",
+        OUTPUT_LAYER_NAME,
+        "-simplify",
+        str(PREVIEW_SIMPLIFICATION),
+        "-dialect",
+        "SQLite",
+        "-sql",
+        sql,
+        output_path,
+        standard_path,
+    ]
+    _run_command(cmd)
+    _check_output_size(output_path)
+
+
+def _check_output_size(path: str) -> None:
+    """Reject generated GeoJSON files that exceed the configured output limit."""
+    size = os.path.getsize(path)
+    if size > GEO_MAX_OUTPUT_BYTES:
+        raise ValueError(f"Generated GeoJSON is too large ({size} bytes > {GEO_MAX_OUTPUT_BYTES} bytes).")
+
+
+def _merge_geojson_files(source_paths: list[str], output_path: str) -> None:
+    """Merge GeoJSON FeatureCollections into one output file without byte buffering."""
+    with open(output_path, "w", encoding="utf-8") as target:
+        target.write('{"type":"FeatureCollection","features":[')
+        first_feature = True
+        for source_path in source_paths:
+            with fiona.open(source_path) as source:
+                for feature in source:
+                    if not first_feature:
+                        target.write(",")
+                    json.dump(to_dict(feature), target, allow_nan=False, separators=(",", ":"))
+                    first_feature = False
+        target.write("]}")
+    _check_output_size(output_path)
+
+
+def _clamp_bbox(bounds: tuple[float, float, float, float] | None) -> list[float]:
+    """Clamp a WGS84 bounds tuple to a frontend-safe bbox."""
+    if not bounds:
+        return [0.0, 0.0, 0.0, 0.0]
+
+    bbox: list[float] = []
+    for index, value in enumerate(bounds):
+        if not math.isfinite(value):
+            logger.warning("Invalid coordinate detected in bounds: %s. Using default bbox.", value)
+            return [-180.0, -90.0, 180.0, 90.0]
+
+        if index % 2 == 0:
+            bbox.append(float(max(-180, min(180, value))))
+        else:
+            bbox.append(float(max(-90, min(90, value))))
+    return bbox
+
+
+def _get_geojson_metadata(standard_path: str, crs_original: str) -> Dict[str, Any]:
+    """Read final GeoJSON metadata one feature at a time."""
+    geometry_counts: Counter[str] = Counter()
+    bounds: list[float] | None = None
+    feature_count = 0
+
+    with fiona.open(standard_path) as source:
+        for feature in source:
+            feature_count += 1
+            geometry = to_dict(feature).get("geometry")
+            if not geometry:
+                continue
+            geometry_counts[geometry.get("type", "Unknown")] += 1
+            geom_bounds = shape(geometry).bounds
+            if bounds is None:
+                bounds = [geom_bounds[0], geom_bounds[1], geom_bounds[2], geom_bounds[3]]
+            else:
+                bounds[0] = min(bounds[0], geom_bounds[0])
+                bounds[1] = min(bounds[1], geom_bounds[1])
+                bounds[2] = max(bounds[2], geom_bounds[2])
+                bounds[3] = max(bounds[3], geom_bounds[3])
+
+    geometry_type = geometry_counts.most_common(1)[0][0] if geometry_counts else "Unknown"
+    return {
+        "feature_count": feature_count,
+        "geometry_type": geometry_type,
+        "crs_original": crs_original,
+        "bbox": _clamp_bbox(tuple(bounds) if bounds else None),
+    }
+
+
+def _resolve_shapefiles(local_path: str, output_dir: str) -> list[str]:
+    """Return shapefiles to convert, extracting zip uploads when needed."""
+    if local_path.lower().endswith(".shp"):
+        return [local_path]
+
+    if local_path.lower().endswith(".zip"):
+        extract_dir = os.path.join(output_dir, "extracted")
+        os.makedirs(extract_dir, exist_ok=True)
+        safe_extract_zip(local_path, extract_dir)
+        shapefiles = find_shapefiles(extract_dir)
+        if not shapefiles:
+            raise ValueError("No .shp files found inside the zip archive.")
+        return shapefiles
+
+    raise ValueError(f"Unsupported file extension for conversion: {os.path.basename(local_path)}")
+
+
+def _summarize_crs(crs_values: list[str]) -> str:
+    """Return a stable CRS summary for one or more input layers."""
+    unique_values = [value for index, value in enumerate(crs_values) if value not in crs_values[:index]]
+    if not unique_values:
+        return "Unknown"
+    if len(unique_values) == 1:
+        return unique_values[0]
+    return "Mixed: " + ", ".join(unique_values)
+
+
+def process_geo_file(local_path: str, output_dir: str | None = None) -> Dict[str, Any]:
+    """Process a .shp or .zip into preview/standard GeoJSON files plus metadata."""
+    output_root = output_dir or tempfile.mkdtemp(prefix="geo-processed-")
+    os.makedirs(output_root, exist_ok=True)
+
+    shapefiles = _resolve_shapefiles(local_path, output_root)
+    layer_dir = os.path.join(output_root, "layers")
+    os.makedirs(layer_dir, exist_ok=True)
+
+    standard_parts: list[str] = []
+    preview_parts: list[str] = []
+    crs_values: list[str] = []
+    remaining_preview_features = PREVIEW_MAX_FEATURES
+
+    for index, shapefile in enumerate(shapefiles):
+        standard_part = os.path.join(layer_dir, f"standard-{index}.geojson")
+        crs_values.append(_convert_source_to_standard(shapefile, standard_part, index))
+        standard_parts.append(standard_part)
+
+        if remaining_preview_features > 0:
+            preview_part = os.path.join(layer_dir, f"preview-{index}.geojson")
+            _convert_standard_to_preview(standard_part, preview_part, remaining_preview_features)
+            preview_parts.append(preview_part)
+            with fiona.open(preview_part) as preview_source:
+                remaining_preview_features -= len(preview_source)
+
+    standard_output = os.path.join(output_root, "standard.geojson")
+    preview_output = os.path.join(output_root, "preview.geojson")
+    _merge_geojson_files(standard_parts, standard_output)
+    _merge_geojson_files(preview_parts, preview_output)
+
+    crs_original = _summarize_crs(crs_values)
+    return {
+        "tiers": {
+            "preview": preview_output,
+            "standard": standard_output,
+        },
+        "metadata": _get_geojson_metadata(standard_output, crs_original),
+    }
+
+
+def _process_geo_file_worker(
+    local_path: str,
+    output_dir: str,
+    result_queue: "multiprocessing.Queue",
+) -> None:
+    """Child-process entry point for timeout-controlled conversion."""
+    try:
+        result_queue.put(("ok", process_geo_file(local_path, output_dir)))
+    except Exception as exc:  # pylint: disable=broad-except # noqa: B902
+        result_queue.put(("error", str(exc)))
+
+
+def process_geo_file_with_timeout(
+    local_path: str,
+    output_dir: str,
+    timeout_seconds: int = GEO_PROCESSING_TIMEOUT_SECONDS,
+) -> Dict[str, Any]:
+    """Run process_geo_file in a child process, enforcing a hard wall-clock timeout."""
+    ctx = multiprocessing.get_context()
+    result_queue: "multiprocessing.Queue" = ctx.Queue()
+    proc = ctx.Process(
+        target=_process_geo_file_worker,
+        args=(local_path, output_dir, result_queue),
+        daemon=True,
+    )
+    proc.start()
+
+    try:
+        status, payload = result_queue.get(timeout=timeout_seconds)
+    except Empty as exc:
+        logger.warning(
+            "Geospatial processing exceeded %ss for %s; terminating worker process.",
+            timeout_seconds, local_path,
+        )
+        proc.terminate()
+        proc.join(timeout=5)
+        if proc.is_alive():
+            proc.kill()
+        raise TimeoutError(
+            f"Processing timed out after {timeout_seconds} seconds and was stopped."
+        ) from exc
+    finally:
+        result_queue.close()
+
+    proc.join(timeout=5)
+
+    if status == "error":
+        raise RuntimeError(payload)
+    return payload

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -179,6 +179,9 @@ class GeoService:
                         if not cls._validate_or_fail(upload, local_path):
                             return
 
+                        # Keep generated tier files under the same temporary
+                        # directory so they stay available until the presigned
+                        # uploads finish, then are removed with the source file.
                         result = process_geo_file_with_timeout(local_path, tmpdir)
                         cls._upload_processed_tiers(upload, result)
 

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -25,7 +25,10 @@ import os
 import tempfile
 import threading
 from datetime import datetime, timedelta, timezone
+from time import perf_counter
 from typing import Any, Dict
+
+from flask import current_app
 
 from submit_api.models import GeoDataUpload, Item as ItemModel, Submission as SubmissionModel, db
 from submit_api.models.submission import SubmissionType
@@ -46,6 +49,21 @@ GEO_MAX_CONCURRENT_JOBS = int(os.environ.get("GEO_MAX_CONCURRENT_JOBS", 3))
 _GEO_SEMAPHORE = threading.Semaphore(GEO_MAX_CONCURRENT_JOBS)
 
 
+def _elapsed_ms(started_at: float) -> int:
+    """Return elapsed milliseconds for compact operational logs."""
+    return round((perf_counter() - started_at) * 1000)
+
+
+def _file_size_bytes(file_path: str) -> int:
+    """Return a file size for logging without exposing temporary file paths."""
+    return os.path.getsize(file_path)
+
+
+def _tier_size_bytes(result: Dict[str, Any], tier: str) -> int:
+    """Return generated tier size for logging."""
+    return _file_size_bytes(result["tiers"][tier])
+
+
 class GeoService:
     """Service class for geospatial upload management."""
 
@@ -59,13 +77,21 @@ class GeoService:
         False if it failed and the upload was marked ``validation_failed``.
         """
         if os.environ.get("SKIP_GEO_FILE_ATTR_VALIDATION", "false").lower() == "true":
+            current_app.logger.info("GeoDataUpload %s validation skipped by configuration.", upload.id)
             return True
 
+        started_at = perf_counter()
+        current_app.logger.info("GeoDataUpload %s validation started.", upload.id)
         is_valid, errors, summary = validate_geo_file(local_path)
         if is_valid:
+            current_app.logger.info(
+                "GeoDataUpload %s validation passed in %sms.",
+                upload.id,
+                _elapsed_ms(started_at),
+            )
             return True
 
-        logger.warning(
+        current_app.logger.warning(
             "Attribute validation failed for GeoDataUpload %s: %d error(s) in field(s): %s",
             upload.id,
             summary["total_errors"],
@@ -124,12 +150,27 @@ class GeoService:
         """Upload processed tiers to S3 and record their keys on the upload."""
         for tier in ("preview", "standard"):
             s3_key = f"geo/processed/{upload.id}/{tier}.geojson"
+            started_at = perf_counter()
+            current_app.logger.info(
+                "GeoDataUpload %s uploading %s tier to %s (%s bytes).",
+                upload.id,
+                tier,
+                s3_key,
+                _tier_size_bytes(result, tier),
+            )
             write_url, actual_s3_key = DocumentServiceClient.get_presigned_write_url(s3_key)
             DocumentServiceClient.upload_file_via_presigned_url(write_url, result["tiers"][tier])
             if tier == "preview":
                 upload.preview_s3_key = actual_s3_key
             else:
                 upload.standard_s3_key = actual_s3_key
+            current_app.logger.info(
+                "GeoDataUpload %s uploaded %s tier to %s in %sms.",
+                upload.id,
+                tier,
+                actual_s3_key,
+                _elapsed_ms(started_at),
+            )
 
     @staticmethod
     def _mark_upload_failed(upload_id: int, exc: Exception) -> None:
@@ -144,11 +185,11 @@ class GeoService:
                 upload.status = "failed"
                 upload.error_message = str(exc)
                 db.session.commit()
-                logger.info("Successfully marked GeoDataUpload %s as failed.", upload_id)
+                current_app.logger.info("Successfully marked GeoDataUpload %s as failed.", upload_id)
             else:
-                logger.error("Could not re-fetch GeoDataUpload %s after rollback.", upload_id)
+                current_app.logger.error("Could not re-fetch GeoDataUpload %s after rollback.", upload_id)
         except Exception as fallback_exc:  # pylint: disable=broad-except # noqa: B902
-            logger.error(
+            current_app.logger.error(
                 "CRITICAL: Failed to save the error state for upload %s. "
                 "The database might be unreachable: %s",
                 upload_id, fallback_exc
@@ -159,17 +200,39 @@ class GeoService:
         """Download, convert, and re-upload a single GeoDataUpload (runs in daemon thread)."""
         with _GEO_SEMAPHORE:
             with app.app_context():
+                job_started_at = perf_counter()
                 upload = db.session.get(GeoDataUpload, upload_id)
                 if not upload:
-                    logger.error("GeoDataUpload %s not found.", upload_id)
+                    current_app.logger.error("GeoDataUpload %s not found.", upload_id)
                     return
 
                 try:
+                    current_app.logger.info(
+                        "GeoDataUpload %s processing started (filename=%s, file_type=%s, "
+                        "raw_s3_key=%s, configured_concurrency=%s).",
+                        upload.id,
+                        upload.filename,
+                        upload.file_type,
+                        upload.raw_s3_key,
+                        GEO_MAX_CONCURRENT_JOBS,
+                    )
                     read_url = DocumentServiceClient.get_presigned_read_url(upload.raw_s3_key)
 
                     with tempfile.TemporaryDirectory() as tmpdir:
                         local_path = os.path.join(tmpdir, os.path.basename(upload.raw_s3_key))
+                        step_started_at = perf_counter()
+                        current_app.logger.info(
+                            "GeoDataUpload %s downloading raw GIS file from %s.",
+                            upload.id,
+                            upload.raw_s3_key,
+                        )
                         DocumentServiceClient.download_via_presigned_url(read_url, local_path)
+                        current_app.logger.info(
+                            "GeoDataUpload %s downloaded raw GIS file in %sms (%s bytes).",
+                            upload.id,
+                            _elapsed_ms(step_started_at),
+                            _file_size_bytes(local_path),
+                        )
 
                         # Update file size in KB if it's currently 0.0 (or unknown)
                         if not upload.file_size_kb or upload.file_size_kb == 0.0:
@@ -182,7 +245,18 @@ class GeoService:
                         # Keep generated tier files under the same temporary
                         # directory so they stay available until the presigned
                         # uploads finish, then are removed with the source file.
+                        step_started_at = perf_counter()
+                        current_app.logger.info("GeoDataUpload %s conversion started.", upload.id)
                         result = process_geo_file_with_timeout(local_path, tmpdir)
+                        current_app.logger.info(
+                            "GeoDataUpload %s conversion completed in %sms "
+                            "(preview_bytes=%s, standard_bytes=%s, resource_usage=%s).",
+                            upload.id,
+                            _elapsed_ms(step_started_at),
+                            _tier_size_bytes(result, "preview"),
+                            _tier_size_bytes(result, "standard"),
+                            result.get("resource_usage", {}),
+                        )
                         cls._upload_processed_tiers(upload, result)
 
                     metadata = result["metadata"]
@@ -192,21 +266,32 @@ class GeoService:
                     upload.bbox = metadata["bbox"]
                     upload.status = "ready"
                     db.session.commit()
-                    logger.info("Successfully processed GeoDataUpload %s", upload_id)
+                    current_app.logger.info(
+                        "GeoDataUpload %s processing completed in %sms "
+                        "(feature_count=%s, geometry_type=%s, crs_original=%s, bbox=%s).",
+                        upload_id,
+                        _elapsed_ms(job_started_at),
+                        metadata["feature_count"],
+                        metadata["geometry_type"],
+                        metadata["crs_original"],
+                        metadata["bbox"],
+                    )
 
                 except Exception as exc:  # pylint: disable=broad-except # noqa: B902
-                    logger.exception("Error processing GeoDataUpload %s: %s", upload_id, exc)
+                    current_app.logger.exception("Error processing GeoDataUpload %s: %s", upload_id, exc)
                     cls._mark_upload_failed(upload_id, exc)
 
     @classmethod
     def _spawn_processing_thread(cls, app, upload_id: int) -> None:
         """Spawn a daemon thread to process the given upload."""
+        current_app.logger.info("GeoDataUpload %s background processing thread starting.", upload_id)
         thread = threading.Thread(
             target=cls._process_upload_in_background,
             args=(app, upload_id),
         )
         thread.daemon = True
         thread.start()
+        current_app.logger.info("GeoDataUpload %s background processing thread started.", upload_id)
 
     # -- CRUD ----------------------------------------------------------------
 
@@ -227,6 +312,14 @@ class GeoService:
         db.session.add(upload)
         db.session.commit()
 
+        current_app.logger.info(
+            "GeoDataUpload %s created (filename=%s, file_type=%s, file_size_kb=%s, raw_s3_key=%s).",
+            upload.id,
+            filename,
+            file_type,
+            file_size_kb,
+            s3_key,
+        )
         cls._spawn_processing_thread(app, upload.id)
         return upload
 

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -23,7 +23,7 @@ from __future__ import annotations
 import logging
 import os
 import tempfile
-import threading
+from concurrent.futures import ThreadPoolExecutor
 from datetime import datetime, timedelta, timezone
 from time import perf_counter
 from typing import Any, Dict
@@ -46,7 +46,18 @@ logger = logging.getLogger(__name__)
 
 # Max number of concurrent geospatial processing jobs to prevent resource exhaustion (RAM/CPU/DB)
 GEO_MAX_CONCURRENT_JOBS = int(os.environ.get("GEO_MAX_CONCURRENT_JOBS", 3))
-_GEO_SEMAPHORE = threading.Semaphore(GEO_MAX_CONCURRENT_JOBS)
+_GEO_EXECUTOR = ThreadPoolExecutor(
+    max_workers=GEO_MAX_CONCURRENT_JOBS,
+    thread_name_prefix="geo-processing",
+)
+
+
+def _log_processing_job_failure(future) -> None:
+    """Log unexpected worker-pool failures that escaped normal upload handling."""
+    try:
+        future.result()
+    except Exception:  # pylint: disable=broad-except
+        logger.exception("Unhandled GeoDataUpload processing worker error.")
 
 
 def _elapsed_ms(started_at: float) -> int:
@@ -164,73 +175,68 @@ class GeoService:
 
     @classmethod
     def _process_upload_in_background(cls, app, upload_id: int) -> None:
-        """Download, convert, and re-upload a single GeoDataUpload (runs in daemon thread)."""
-        with _GEO_SEMAPHORE:
-            with app.app_context():
-                job_started_at = perf_counter()
-                upload = db.session.get(GeoDataUpload, upload_id)
-                if not upload:
-                    current_app.logger.error("GeoDataUpload %s not found.", upload_id)
-                    return
+        """Download, convert, and re-upload a single GeoDataUpload."""
+        with app.app_context():
+            job_started_at = perf_counter()
+            upload = db.session.get(GeoDataUpload, upload_id)
+            if not upload:
+                current_app.logger.error("GeoDataUpload %s not found.", upload_id)
+                return
 
-                try:
-                    current_app.logger.info(
-                        "GeoDataUpload %s processing started (filename=%s, file_type=%s).",
-                        upload.id,
-                        upload.filename,
-                        upload.file_type,
-                    )
-                    read_url = DocumentServiceClient.get_presigned_read_url(upload.raw_s3_key)
+            try:
+                current_app.logger.info(
+                    "GeoDataUpload %s processing started (filename=%s, file_type=%s).",
+                    upload.id,
+                    upload.filename,
+                    upload.file_type,
+                )
+                read_url = DocumentServiceClient.get_presigned_read_url(upload.raw_s3_key)
 
-                    with tempfile.TemporaryDirectory() as tmpdir:
-                        local_path = os.path.join(tmpdir, os.path.basename(upload.raw_s3_key))
-                        DocumentServiceClient.download_via_presigned_url(read_url, local_path)
+                with tempfile.TemporaryDirectory() as tmpdir:
+                    local_path = os.path.join(tmpdir, os.path.basename(upload.raw_s3_key))
+                    DocumentServiceClient.download_via_presigned_url(read_url, local_path)
 
-                        # Update file size in KB if it's currently 0.0 (or unknown)
-                        if not upload.file_size_kb or upload.file_size_kb == 0.0:
-                            upload.file_size_kb = round(os.path.getsize(local_path) / 1024, 2)
-                            db.session.commit()
+                    # Update file size in KB if it's currently 0.0 (or unknown)
+                    if not upload.file_size_kb or upload.file_size_kb == 0.0:
+                        upload.file_size_kb = round(os.path.getsize(local_path) / 1024, 2)
+                        db.session.commit()
 
-                        if not cls._validate_or_fail(upload, local_path):
-                            return
+                    if not cls._validate_or_fail(upload, local_path):
+                        return
 
-                        # Keep generated tier files under the same temporary
-                        # directory so they stay available until the presigned
-                        # uploads finish, then are removed with the source file.
-                        result = process_geo_file_with_timeout(local_path, tmpdir)
-                        resource_usage = result.get("resource_usage", {})
-                        cls._upload_processed_tiers(upload, result)
+                    # Keep generated tier files under the same temporary
+                    # directory so they stay available until the presigned
+                    # uploads finish, then are removed with the source file.
+                    result = process_geo_file_with_timeout(local_path, tmpdir)
+                    resource_usage = result.get("resource_usage", {})
+                    cls._upload_processed_tiers(upload, result)
 
-                    metadata = result["metadata"]
-                    upload.feature_count = metadata["feature_count"]
-                    upload.geometry_type = metadata["geometry_type"]
-                    upload.crs_original = metadata["crs_original"]
-                    upload.bbox = metadata["bbox"]
-                    upload.status = "ready"
-                    db.session.commit()
-                    current_app.logger.info(
-                        "GeoDataUpload %s processing completed in %sms "
-                        "(feature_count=%s, geometry_type=%s, resource_usage=%s).",
-                        upload_id,
-                        _elapsed_ms(job_started_at),
-                        metadata["feature_count"],
-                        metadata["geometry_type"],
-                        resource_usage,
-                    )
+                metadata = result["metadata"]
+                upload.feature_count = metadata["feature_count"]
+                upload.geometry_type = metadata["geometry_type"]
+                upload.crs_original = metadata["crs_original"]
+                upload.bbox = metadata["bbox"]
+                upload.status = "ready"
+                db.session.commit()
+                current_app.logger.info(
+                    "GeoDataUpload %s processing completed in %sms "
+                    "(feature_count=%s, geometry_type=%s, resource_usage=%s).",
+                    upload_id,
+                    _elapsed_ms(job_started_at),
+                    metadata["feature_count"],
+                    metadata["geometry_type"],
+                    resource_usage,
+                )
 
-                except Exception as exc:  # pylint: disable=broad-except # noqa: B902
-                    current_app.logger.exception("Error processing GeoDataUpload %s: %s", upload_id, exc)
-                    cls._mark_upload_failed(upload_id, exc)
+            except Exception as exc:  # pylint: disable=broad-except # noqa: B902
+                current_app.logger.exception("Error processing GeoDataUpload %s: %s", upload_id, exc)
+                cls._mark_upload_failed(upload_id, exc)
 
     @classmethod
-    def _spawn_processing_thread(cls, app, upload_id: int) -> None:
-        """Spawn a daemon thread to process the given upload."""
-        thread = threading.Thread(
-            target=cls._process_upload_in_background,
-            args=(app, upload_id),
-        )
-        thread.daemon = True
-        thread.start()
+    def _submit_processing_job(cls, app, upload_id: int) -> None:
+        """Submit the upload to the bounded in-process GIS worker pool."""
+        future = _GEO_EXECUTOR.submit(cls._process_upload_in_background, app, upload_id)
+        future.add_done_callback(_log_processing_job_failure)
 
     # -- CRUD ----------------------------------------------------------------
 
@@ -251,7 +257,7 @@ class GeoService:
         db.session.add(upload)
         db.session.commit()
 
-        cls._spawn_processing_thread(app, upload.id)
+        cls._submit_processing_job(app, upload.id)
         return upload
 
     @classmethod
@@ -403,5 +409,5 @@ class GeoService:
         upload.validation_errors = None
         db.session.commit()
 
-        cls._spawn_processing_thread(app, upload.id)
+        cls._submit_processing_job(app, upload.id)
         return upload

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -54,16 +54,6 @@ def _elapsed_ms(started_at: float) -> int:
     return round((perf_counter() - started_at) * 1000)
 
 
-def _file_size_bytes(file_path: str) -> int:
-    """Return a file size for logging without exposing temporary file paths."""
-    return os.path.getsize(file_path)
-
-
-def _tier_size_bytes(result: Dict[str, Any], tier: str) -> int:
-    """Return generated tier size for logging."""
-    return _file_size_bytes(result["tiers"][tier])
-
-
 class GeoService:
     """Service class for geospatial upload management."""
 
@@ -80,15 +70,8 @@ class GeoService:
             current_app.logger.info("GeoDataUpload %s validation skipped by configuration.", upload.id)
             return True
 
-        started_at = perf_counter()
-        current_app.logger.info("GeoDataUpload %s validation started.", upload.id)
         is_valid, errors, summary = validate_geo_file(local_path)
         if is_valid:
-            current_app.logger.info(
-                "GeoDataUpload %s validation passed in %sms.",
-                upload.id,
-                _elapsed_ms(started_at),
-            )
             return True
 
         current_app.logger.warning(
@@ -150,27 +133,12 @@ class GeoService:
         """Upload processed tiers to S3 and record their keys on the upload."""
         for tier in ("preview", "standard"):
             s3_key = f"geo/processed/{upload.id}/{tier}.geojson"
-            started_at = perf_counter()
-            current_app.logger.info(
-                "GeoDataUpload %s uploading %s tier to %s (%s bytes).",
-                upload.id,
-                tier,
-                s3_key,
-                _tier_size_bytes(result, tier),
-            )
             write_url, actual_s3_key = DocumentServiceClient.get_presigned_write_url(s3_key)
             DocumentServiceClient.upload_file_via_presigned_url(write_url, result["tiers"][tier])
             if tier == "preview":
                 upload.preview_s3_key = actual_s3_key
             else:
                 upload.standard_s3_key = actual_s3_key
-            current_app.logger.info(
-                "GeoDataUpload %s uploaded %s tier to %s in %sms.",
-                upload.id,
-                tier,
-                actual_s3_key,
-                _elapsed_ms(started_at),
-            )
 
     @staticmethod
     def _mark_upload_failed(upload_id: int, exc: Exception) -> None:
@@ -185,7 +153,6 @@ class GeoService:
                 upload.status = "failed"
                 upload.error_message = str(exc)
                 db.session.commit()
-                current_app.logger.info("Successfully marked GeoDataUpload %s as failed.", upload_id)
             else:
                 current_app.logger.error("Could not re-fetch GeoDataUpload %s after rollback.", upload_id)
         except Exception as fallback_exc:  # pylint: disable=broad-except # noqa: B902
@@ -208,31 +175,16 @@ class GeoService:
 
                 try:
                     current_app.logger.info(
-                        "GeoDataUpload %s processing started (filename=%s, file_type=%s, "
-                        "raw_s3_key=%s, configured_concurrency=%s).",
+                        "GeoDataUpload %s processing started (filename=%s, file_type=%s).",
                         upload.id,
                         upload.filename,
                         upload.file_type,
-                        upload.raw_s3_key,
-                        GEO_MAX_CONCURRENT_JOBS,
                     )
                     read_url = DocumentServiceClient.get_presigned_read_url(upload.raw_s3_key)
 
                     with tempfile.TemporaryDirectory() as tmpdir:
                         local_path = os.path.join(tmpdir, os.path.basename(upload.raw_s3_key))
-                        step_started_at = perf_counter()
-                        current_app.logger.info(
-                            "GeoDataUpload %s downloading raw GIS file from %s.",
-                            upload.id,
-                            upload.raw_s3_key,
-                        )
                         DocumentServiceClient.download_via_presigned_url(read_url, local_path)
-                        current_app.logger.info(
-                            "GeoDataUpload %s downloaded raw GIS file in %sms (%s bytes).",
-                            upload.id,
-                            _elapsed_ms(step_started_at),
-                            _file_size_bytes(local_path),
-                        )
 
                         # Update file size in KB if it's currently 0.0 (or unknown)
                         if not upload.file_size_kb or upload.file_size_kb == 0.0:
@@ -245,18 +197,8 @@ class GeoService:
                         # Keep generated tier files under the same temporary
                         # directory so they stay available until the presigned
                         # uploads finish, then are removed with the source file.
-                        step_started_at = perf_counter()
-                        current_app.logger.info("GeoDataUpload %s conversion started.", upload.id)
                         result = process_geo_file_with_timeout(local_path, tmpdir)
-                        current_app.logger.info(
-                            "GeoDataUpload %s conversion completed in %sms "
-                            "(preview_bytes=%s, standard_bytes=%s, resource_usage=%s).",
-                            upload.id,
-                            _elapsed_ms(step_started_at),
-                            _tier_size_bytes(result, "preview"),
-                            _tier_size_bytes(result, "standard"),
-                            result.get("resource_usage", {}),
-                        )
+                        resource_usage = result.get("resource_usage", {})
                         cls._upload_processed_tiers(upload, result)
 
                     metadata = result["metadata"]
@@ -268,13 +210,12 @@ class GeoService:
                     db.session.commit()
                     current_app.logger.info(
                         "GeoDataUpload %s processing completed in %sms "
-                        "(feature_count=%s, geometry_type=%s, crs_original=%s, bbox=%s).",
+                        "(feature_count=%s, geometry_type=%s, resource_usage=%s).",
                         upload_id,
                         _elapsed_ms(job_started_at),
                         metadata["feature_count"],
                         metadata["geometry_type"],
-                        metadata["crs_original"],
-                        metadata["bbox"],
+                        resource_usage,
                     )
 
                 except Exception as exc:  # pylint: disable=broad-except # noqa: B902
@@ -284,14 +225,12 @@ class GeoService:
     @classmethod
     def _spawn_processing_thread(cls, app, upload_id: int) -> None:
         """Spawn a daemon thread to process the given upload."""
-        current_app.logger.info("GeoDataUpload %s background processing thread starting.", upload_id)
         thread = threading.Thread(
             target=cls._process_upload_in_background,
             args=(app, upload_id),
         )
         thread.daemon = True
         thread.start()
-        current_app.logger.info("GeoDataUpload %s background processing thread started.", upload_id)
 
     # -- CRUD ----------------------------------------------------------------
 
@@ -312,14 +251,6 @@ class GeoService:
         db.session.add(upload)
         db.session.commit()
 
-        current_app.logger.info(
-            "GeoDataUpload %s created (filename=%s, file_type=%s, file_size_kb=%s, raw_s3_key=%s).",
-            upload.id,
-            filename,
-            file_type,
-            file_size_kb,
-            s3_key,
-        )
         cls._spawn_processing_thread(app, upload.id)
         return upload
 

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -20,251 +20,21 @@ Handles all geospatial business logic including:
 """
 from __future__ import annotations
 
-import json
 import logging
-import math
-import multiprocessing
 import os
 import tempfile
 import threading
-import zipfile
-import glob
 from datetime import datetime, timedelta, timezone
-from queue import Empty
 from typing import Any, Dict
-import pandas as pd
-import geopandas as gpd
 
 from submit_api.models import GeoDataUpload, Item as ItemModel, Submission as SubmissionModel, db
 from submit_api.models.submission import SubmissionType
 from submit_api.services.document_service_client import DocumentServiceClient
+from submit_api.services.geo.ogr_converter import process_geo_file_with_timeout
 from submit_api.services.geo.validator import validate_geo_file
 
 
 logger = logging.getLogger(__name__)
-COLOR_PALETTE = [
-    ("#FF00FF", "#8B008B"),  # Neon Magenta
-    ("#00FFFF", "#008B8B"),  # Neon Cyan
-    ("#FF1493", "#C71585"),  # Deep Pink
-    ("#39FF14", "#008000"),  # Neon Green
-    ("#FF4500", "#B22222"),  # Orange Red
-    ("#9400D3", "#4B0082"),  # Dark Violet
-    ("#FFFF00", "#B8860B"),  # Bright Yellow
-    ("#FF007F", "#80003F"),  # Rose
-    ("#00FF00", "#006400"),  # Lime
-    ("#8A2BE2", "#483D8B"),  # Blue Violet
-]
-
-
-# ---------------------------------------------------------------------------
-# Raw GeoJSON conversion helpers
-# ---------------------------------------------------------------------------
-
-def _is_json_serializable(val: Any) -> bool:
-    """Return True if val can be serialised to JSON."""
-    try:
-        json.dumps(val)
-        return True
-    except (TypeError, OverflowError):
-        return False
-
-
-def _read_shp_data(shp_file: str, index: int) -> gpd.GeoDataFrame:
-    """Read a single shapefile and assign colors."""
-    gdf = gpd.read_file(shp_file)
-
-    # Assign distinct color per feature rather than per layer
-    fill_colors, stroke_colors = [], []
-    for idx in range(len(gdf)):
-        f_col, s_col = COLOR_PALETTE[(idx + index) % len(COLOR_PALETTE)]
-        fill_colors.append(f_col)
-        stroke_colors.append(s_col)
-
-    gdf["layer_color"] = fill_colors
-    gdf["stroke_color"] = stroke_colors
-    gdf["layer_name"] = os.path.basename(shp_file)
-    return gdf
-
-
-def _read_zip_layers(local_path: str) -> gpd.GeoDataFrame:
-    """Read all .shp layers from a zip file and merge them."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        with zipfile.ZipFile(local_path, "r") as zip_ref:
-            zip_ref.extractall(temp_dir)
-
-        # Recursively find all .shp files
-        shp_files = glob.glob(os.path.join(temp_dir, "**", "*.shp"), recursive=True)
-
-        if not shp_files:
-            raise ValueError("No .shp files found inside the zip archive.")
-
-        # Sort to ensure consistent coloring order
-        shp_files.sort()
-        gdfs = [
-            _read_shp_data(shp_file, i)
-            for i, shp_file in enumerate(shp_files)
-        ]
-
-        if not gdfs:
-            raise ValueError("Failed to read any geospatial layers from the zip file.")
-
-        if len(gdfs) == 1:
-            return gdfs[0]
-
-        base_crs = gdfs[0].crs
-        aligned_gdfs = []
-        for gdf in gdfs:
-            if gdf.crs != base_crs and base_crs is not None and gdf.crs is not None:
-                aligned_gdfs.append(gdf.to_crs(base_crs))
-            else:
-                aligned_gdfs.append(gdf)
-        return gpd.GeoDataFrame(pd.concat(aligned_gdfs, ignore_index=True), crs=base_crs)
-
-
-def _generate_tier(
-    df: gpd.GeoDataFrame, simplification: float, max_features: int | None = None
-) -> bytes:
-    """Simplify and down-sample a GeoDataFrame, returning UTF-8 GeoJSON bytes."""
-    work_df = df.copy()
-
-    # Ensure we start with valid geometries
-    work_df = work_df[work_df.geometry.notnull() & ~work_df.geometry.is_empty]
-
-    if max_features and len(work_df) > max_features:
-        work_df = work_df.sample(n=max_features, random_state=42)
-
-    # Only simplify if a non-zero factor is provided
-    if simplification and simplification > 0:
-        work_df.geometry = work_df.geometry.simplify(simplification, preserve_topology=True)
-        # Re-drop any geometries that became empty after simplification
-        work_df = work_df[work_df.geometry.notnull() & ~work_df.geometry.is_empty]
-
-    return work_df.to_json().encode("utf-8")
-
-
-def _ensure_wgs84(gdf: gpd.GeoDataFrame) -> gpd.GeoDataFrame:
-    """Ensure the GeoDataFrame is in WGS-84 (EPSG:4326)."""
-    if gdf.crs is None:
-        logger.warning("No CRS found in file (missing .prj?). Assuming EPSG:4326.")
-        gdf = gdf.set_crs("EPSG:4326")
-    elif not gdf.crs.equals("EPSG:4326"):
-        logger.info("Reprojecting from %s to EPSG:4326", gdf.crs)
-        gdf = gdf.to_crs("EPSG:4326")
-
-    # Drop any geometries that failed to reproject (can happen if coords are out of range)
-    original_count = len(gdf)
-    gdf = gdf[gdf.geometry.notnull() & ~gdf.geometry.is_empty]
-    if len(gdf) < original_count:
-        logger.info("Dropped %d null/empty geometries after reprojection", original_count - len(gdf))
-
-    return gdf
-
-
-def _get_bbox(gdf: gpd.GeoDataFrame) -> list[float]:
-    """Calculate a safe WGS-84 bounding box for the GeoDataFrame."""
-    if gdf.empty:
-        return [0.0, 0.0, 0.0, 0.0]
-
-    bounds = gdf.total_bounds  # [minx, miny, maxx, maxy]
-    # Handle NaN in bounds
-    bbox = []
-    for i, val in enumerate(bounds):
-        if not math.isfinite(val):
-            # fallback to a sensible default if any coordinate is NaN
-            logger.warning("Invalid coordinate detected in bounds: %s. Using default bbox.", val)
-            return [-180.0, -90.0, 180.0, 90.0]
-
-        if i % 2 == 0:  # X (longitude)
-            bbox.append(float(max(-180, min(180, val))))
-        else:  # Y (latitude)
-            bbox.append(float(max(-90, min(90, val))))
-    return bbox
-
-
-def _load_gdf(local_path: str) -> gpd.GeoDataFrame:
-    """Load a GeoDataFrame from a .shp or .zip file."""
-    is_zip = local_path.lower().endswith(".zip")
-    is_shp = local_path.lower().endswith(".shp")
-
-    # SHAPE_RESTORE_SHX tells GDAL to reconstruct the missing .shx index
-    _prev = os.environ.get("SHAPE_RESTORE_SHX")
-    if is_shp:
-        os.environ["SHAPE_RESTORE_SHX"] = "YES"
-
-    try:
-        if is_zip:
-            return _read_zip_layers(local_path)
-
-        try:
-            gpd.read_file(local_path)
-        except (IOError, ValueError, RuntimeError) as exc:
-            if is_shp:
-                raise ValueError(
-                    "Failed to read .shp file. Please ensure all sidecar files (.shx, .dbf, .prj) "
-                    "are included by uploading them together in a .zip archive."
-                ) from exc
-            raise exc
-
-        return _read_shp_data(local_path, 0)
-    finally:
-        if is_shp:
-            if _prev is None:
-                os.environ.pop("SHAPE_RESTORE_SHX", None)
-            else:
-                os.environ["SHAPE_RESTORE_SHX"] = _prev
-
-
-def process_geo_file(local_path: str) -> Dict[str, Any]:
-    """Process a geospatial file into preview/standard tiers plus metadata.
-
-    Args:
-        local_path: Local filesystem path to a .shp or .zip file.
-
-    Returns:
-        dict with keys ``tiers`` (dict of bytes keyed by tier name) and
-        ``metadata`` (feature_count, geometry_type, crs_original, bbox).
-    """
-    gdf = _load_gdf(local_path)
-
-    crs_original = str(gdf.crs.to_string()) if gdf.crs else "Unknown"
-
-    # Drop null / empty geometries
-    original_count = len(gdf)
-    gdf = gdf[gdf.geometry.notnull() & ~gdf.geometry.is_empty]
-    logger.info("Dropped %d null or empty geometries", original_count - len(gdf))
-
-    gdf = _ensure_wgs84(gdf)
-
-    feature_count = len(gdf)
-    geometry_type = gdf.geom_type.mode().iloc[0] if not gdf.empty else "Unknown"
-    bbox = _get_bbox(gdf)
-
-    # Drop columns that cannot be serialised to JSON
-    cols_to_drop = []
-    if not gdf.empty:
-        for col in gdf.columns:
-            if col == "geometry":
-                continue
-            sample = gdf[col].dropna().iloc[0] if not gdf[col].dropna().empty else None
-            if sample is not None and not _is_json_serializable(sample):
-                cols_to_drop.append(col)
-    if cols_to_drop:
-        logger.info("Dropped non-serialisable columns: %s", cols_to_drop)
-        gdf = gdf.drop(columns=cols_to_drop)
-
-    logger.info("Generating tiers…")
-    return {
-        "tiers": {
-            "preview": _generate_tier(gdf, 0.000001, 10_000),
-            "standard": _generate_tier(gdf, 0),
-        },
-        "metadata": {
-            "feature_count": feature_count,
-            "geometry_type": str(geometry_type),
-            "crs_original": crs_original,
-            "bbox": bbox,
-        },
-    }
 
 
 # ---------------------------------------------------------------------------
@@ -274,69 +44,6 @@ def process_geo_file(local_path: str) -> Dict[str, Any]:
 # Max number of concurrent geospatial processing jobs to prevent resource exhaustion (RAM/CPU/DB)
 GEO_MAX_CONCURRENT_JOBS = int(os.environ.get("GEO_MAX_CONCURRENT_JOBS", 3))
 _GEO_SEMAPHORE = threading.Semaphore(GEO_MAX_CONCURRENT_JOBS)
-
-# Hard wall-clock limit for converting a single file. A malformed or overly large
-# file can make geopandas spin indefinitely, leaving the upload stuck in
-# 'processing' forever. When exceeded, the worker process is forcibly killed and
-# the upload is marked as failed. Configurable via GEO_PROCESSING_TIMEOUT_SECONDS.
-GEO_PROCESSING_TIMEOUT_SECONDS = int(os.environ.get("GEO_PROCESSING_TIMEOUT_SECONDS", 60))
-
-
-def _process_geo_file_worker(local_path: str, result_queue: "multiprocessing.Queue") -> None:
-    """Child-process entry point: run process_geo_file and push the outcome onto the queue.
-
-    Runs in a separate process so a runaway conversion can be terminated by the
-    parent. The result dict (GeoJSON bytes + metadata) is picklable; exceptions
-    are stringified because arbitrary exception types may not be.
-    """
-    try:
-        result_queue.put(("ok", process_geo_file(local_path)))
-    except Exception as exc:  # pylint: disable=broad-except # noqa: B902
-        result_queue.put(("error", str(exc)))
-
-
-def process_geo_file_with_timeout(
-    local_path: str, timeout_seconds: int = GEO_PROCESSING_TIMEOUT_SECONDS
-) -> Dict[str, Any]:
-    """Run process_geo_file in a child process, enforcing a hard wall-clock timeout.
-
-    Raises:
-        TimeoutError: if processing exceeds ``timeout_seconds`` (the child is killed).
-        RuntimeError: if the child process fails or dies without producing a result.
-    """
-    ctx = multiprocessing.get_context()
-    result_queue: "multiprocessing.Queue" = ctx.Queue()
-    proc = ctx.Process(
-        target=_process_geo_file_worker,
-        args=(local_path, result_queue),
-        daemon=True,
-    )
-    proc.start()
-
-    try:
-        # Block until the child publishes a result or the timeout elapses. Reading
-        # from the queue before join() avoids a deadlock when the result is large.
-        status, payload = result_queue.get(timeout=timeout_seconds)
-    except Empty as exc:
-        logger.warning(
-            "Geospatial processing exceeded %ss for %s; terminating worker process.",
-            timeout_seconds, local_path,
-        )
-        proc.terminate()
-        proc.join(timeout=5)
-        if proc.is_alive():
-            proc.kill()
-        raise TimeoutError(
-            f"Processing timed out after {timeout_seconds} seconds and was stopped."
-        ) from exc
-    finally:
-        result_queue.close()
-
-    proc.join(timeout=5)
-
-    if status == "error":
-        raise RuntimeError(payload)
-    return payload
 
 
 class GeoService:
@@ -418,7 +125,7 @@ class GeoService:
         for tier in ("preview", "standard"):
             s3_key = f"geo/processed/{upload.id}/{tier}.geojson"
             write_url, actual_s3_key = DocumentServiceClient.get_presigned_write_url(s3_key)
-            DocumentServiceClient.upload_via_presigned_url(write_url, result["tiers"][tier])
+            DocumentServiceClient.upload_file_via_presigned_url(write_url, result["tiers"][tier])
             if tier == "preview":
                 upload.preview_s3_key = actual_s3_key
             else:
@@ -472,7 +179,7 @@ class GeoService:
                         if not cls._validate_or_fail(upload, local_path):
                             return
 
-                        result = process_geo_file_with_timeout(local_path)
+                        result = process_geo_file_with_timeout(local_path, tmpdir)
                         cls._upload_processed_tiers(upload, result)
 
                     metadata = result["metadata"]

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -233,7 +233,7 @@ class GeoService:
                 cls._mark_upload_failed(upload_id, exc)
 
     @classmethod
-    def _submit_processing_job(cls, app, upload_id: int) -> None:
+    def submit_processing_job(cls, app, upload_id: int) -> None:
         """Submit the upload to the bounded in-process GIS worker pool."""
         future = _GEO_EXECUTOR.submit(cls._process_upload_in_background, app, upload_id)
         future.add_done_callback(_log_processing_job_failure)
@@ -257,7 +257,7 @@ class GeoService:
         db.session.add(upload)
         db.session.commit()
 
-        cls._submit_processing_job(app, upload.id)
+        cls.submit_processing_job(app, upload.id)
         return upload
 
     @classmethod
@@ -409,5 +409,5 @@ class GeoService:
         upload.validation_errors = None
         db.session.commit()
 
-        cls._submit_processing_job(app, upload.id)
+        cls.submit_processing_job(app, upload.id)
         return upload

--- a/submit-api/src/submit_api/services/geo/processor.py
+++ b/submit-api/src/submit_api/services/geo/processor.py
@@ -54,10 +54,16 @@ _GEO_EXECUTOR = ThreadPoolExecutor(
 
 def _log_processing_job_failure(future) -> None:
     """Log unexpected worker-pool failures that escaped normal upload handling."""
-    try:
-        future.result()
-    except Exception:  # pylint: disable=broad-except
-        logger.exception("Unhandled GeoDataUpload processing worker error.")
+    if future.cancelled():
+        logger.warning("GeoDataUpload processing worker was cancelled.")
+        return
+
+    exception = future.exception()
+    if exception:
+        logger.error(
+            "Unhandled GeoDataUpload processing worker error.",
+            exc_info=(type(exception), exception, exception.__traceback__),
+        )
 
 
 def _elapsed_ms(started_at: float) -> int:

--- a/submit-api/src/submit_api/services/geo/validator.py
+++ b/submit-api/src/submit_api/services/geo/validator.py
@@ -27,16 +27,15 @@ Fiona is used for streaming so the entire feature set is never held in memory.
 """
 from __future__ import annotations
 
-import glob
 import logging
 import os
 import tempfile
-import zipfile
 
 import fiona
 from shapely.geometry import shape
 from shapely.validation import explain_validity
 
+from submit_api.services.geo.archive import find_shapefiles, safe_extract_zip
 from submit_api.services.geo.validation_rules import (
     ALLOWED_VALUES,
     CASE_INSENSITIVE,
@@ -243,12 +242,8 @@ def validate_geo_file(local_path: str) -> _Result:
 
     if local_path.lower().endswith(".zip"):
         with tempfile.TemporaryDirectory() as tmpdir:
-            with zipfile.ZipFile(local_path, "r") as zf:
-                zf.extractall(tmpdir)
-
-            shp_files = sorted(
-                glob.glob(os.path.join(tmpdir, "**", "*.shp"), recursive=True)
-            )
+            safe_extract_zip(local_path, tmpdir)
+            shp_files = find_shapefiles(tmpdir)
 
             if not shp_files:
                 err = {

--- a/submit-api/src/submit_api/services/submission/__init__.py
+++ b/submit-api/src/submit_api/services/submission/__init__.py
@@ -452,8 +452,7 @@ class SubmissionService:
 
         result = []
         for upload in triggered_uploads:
-            # pylint: disable=protected-access
-            GeoService._spawn_processing_thread(app, upload.id)
+            GeoService.submit_processing_job(app, upload.id)
             result.append({'id': upload.id, 'filename': upload.filename})
 
         return result

--- a/submit-api/tests/unit/services/test_document_service_client.py
+++ b/submit-api/tests/unit/services/test_document_service_client.py
@@ -3,6 +3,9 @@ from __future__ import annotations
 
 from unittest.mock import Mock, patch
 
+import pytest
+import requests
+
 from submit_api.services.document_service_client import DocumentServiceClient
 
 
@@ -20,3 +23,25 @@ def test_upload_file_via_presigned_url_streams_file(tmp_path):
     assert kwargs["headers"] == {"Content-Type": "application/octet-stream"}
     assert kwargs["data"].name == str(file_path)
     response.raise_for_status.assert_called_once()
+
+
+def test_upload_file_via_presigned_url_sanitizes_http_error(tmp_path):
+    """Failed presigned uploads should not expose the signed URL in logs/errors."""
+    file_path = tmp_path / "preview.geojson"
+    file_path.write_text('{"type":"FeatureCollection","features":[]}', encoding="utf-8")
+
+    response = Mock()
+    response.status_code = 403
+    response.raise_for_status.side_effect = requests.HTTPError(
+        "403 Client Error: Forbidden for url: https://storage.example/upload?Signature=secret",
+        response=response,
+    )
+
+    with patch("submit_api.services.document_service_client.requests.put", return_value=response):
+        with pytest.raises(requests.HTTPError) as exc_info:
+            DocumentServiceClient.upload_file_via_presigned_url(
+                "https://storage.example/upload?Signature=secret",
+                str(file_path),
+            )
+
+    assert str(exc_info.value) == "Presigned file upload failed with HTTP status 403"

--- a/submit-api/tests/unit/services/test_document_service_client.py
+++ b/submit-api/tests/unit/services/test_document_service_client.py
@@ -17,6 +17,6 @@ def test_upload_file_via_presigned_url_streams_file(tmp_path):
         DocumentServiceClient.upload_file_via_presigned_url("https://storage.example/upload", str(file_path))
 
     kwargs = put.call_args.kwargs
-    assert kwargs["headers"] == {"Content-Type": "application/geo+json"}
+    assert kwargs["headers"] == {"Content-Type": "application/octet-stream"}
     assert kwargs["data"].name == str(file_path)
     response.raise_for_status.assert_called_once()

--- a/submit-api/tests/unit/services/test_document_service_client.py
+++ b/submit-api/tests/unit/services/test_document_service_client.py
@@ -1,0 +1,22 @@
+"""Unit tests for DocumentServiceClient upload helpers."""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from submit_api.services.document_service_client import DocumentServiceClient
+
+
+def test_upload_file_via_presigned_url_streams_file(tmp_path):
+    """Processed GeoJSON uploads are streamed from disk instead of passed as bytes."""
+    file_path = tmp_path / "preview.geojson"
+    file_path.write_text('{"type":"FeatureCollection","features":[]}', encoding="utf-8")
+    response = Mock()
+    response.raise_for_status = Mock()
+
+    with patch("submit_api.services.document_service_client.requests.put", return_value=response) as put:
+        DocumentServiceClient.upload_file_via_presigned_url("https://storage.example/upload", str(file_path))
+
+    kwargs = put.call_args.kwargs
+    assert kwargs["headers"] == {"Content-Type": "application/geo+json"}
+    assert kwargs["data"].name == str(file_path)
+    response.raise_for_status.assert_called_once()

--- a/submit-api/tests/unit/services/test_geo_archive.py
+++ b/submit-api/tests/unit/services/test_geo_archive.py
@@ -1,0 +1,38 @@
+"""Unit tests for safe geospatial archive extraction."""
+from __future__ import annotations
+
+import zipfile
+
+import pytest
+
+from submit_api.services.geo.archive import find_shapefiles, safe_extract_zip
+
+
+def test_safe_extract_zip_rejects_path_traversal(tmp_path):
+    """Zip members cannot write outside the extraction directory."""
+    archive_path = tmp_path / "bad.zip"
+    with zipfile.ZipFile(archive_path, "w") as zip_ref:
+        zip_ref.writestr("../outside.shp", "bad")
+
+    with pytest.raises(ValueError, match="Unsafe path"):
+        safe_extract_zip(str(archive_path), str(tmp_path / "extract"))
+
+
+def test_safe_extract_zip_rejects_large_expanded_size(tmp_path):
+    """Expanded zip size is checked before files are written."""
+    archive_path = tmp_path / "large.zip"
+    with zipfile.ZipFile(archive_path, "w") as zip_ref:
+        zip_ref.writestr("layer.shp", "x" * 20)
+
+    with pytest.raises(ValueError, match="too large"):
+        safe_extract_zip(str(archive_path), str(tmp_path / "extract"), max_total_size=10)
+
+
+def test_find_shapefiles_enforces_count_limit(tmp_path):
+    """Zip uploads cannot contain an unbounded number of shapefiles."""
+    (tmp_path / "one.shp").write_text("one", encoding="utf-8")
+    (tmp_path / "nested").mkdir()
+    (tmp_path / "nested" / "two.shp").write_text("two", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="too many shapefiles"):
+        find_shapefiles(str(tmp_path), max_shapefiles=1)

--- a/submit-api/tests/unit/services/test_geo_processor.py
+++ b/submit-api/tests/unit/services/test_geo_processor.py
@@ -1,0 +1,19 @@
+"""Unit tests for geospatial processing orchestration."""
+from __future__ import annotations
+
+from unittest.mock import Mock, patch
+
+from submit_api.services.geo import processor
+from submit_api.services.geo.processor import GeoService
+
+
+def test_submit_processing_job_uses_bounded_executor():
+    """Geo uploads are submitted to the shared worker pool instead of a raw thread."""
+    app = Mock()
+    future = Mock()
+
+    with patch.object(processor._GEO_EXECUTOR, "submit", return_value=future) as submit:
+        GeoService._submit_processing_job(app, 42)
+
+    submit.assert_called_once_with(GeoService._process_upload_in_background, app, 42)
+    future.add_done_callback.assert_called_once_with(processor._log_processing_job_failure)

--- a/submit-api/tests/unit/services/test_geo_processor.py
+++ b/submit-api/tests/unit/services/test_geo_processor.py
@@ -13,7 +13,7 @@ def test_submit_processing_job_uses_bounded_executor():
     future = Mock()
 
     with patch.object(processor._GEO_EXECUTOR, "submit", return_value=future) as submit:
-        GeoService._submit_processing_job(app, 42)
+        GeoService.submit_processing_job(app, 42)
 
     submit.assert_called_once_with(GeoService._process_upload_in_background, app, 42)
     future.add_done_callback.assert_called_once_with(processor._log_processing_job_failure)

--- a/submit-api/tests/unit/services/test_ogr_converter.py
+++ b/submit-api/tests/unit/services/test_ogr_converter.py
@@ -1,0 +1,88 @@
+"""Unit tests for the disk-based OGR converter."""
+from __future__ import annotations
+
+import json
+from unittest.mock import patch
+
+from submit_api.services.geo import ogr_converter
+
+
+def _feature(feature_id: int) -> dict:
+    return {
+        "type": "Feature",
+        "properties": {"id": feature_id},
+        "geometry": {"type": "Point", "coordinates": [feature_id, feature_id]},
+    }
+
+
+def _write_geojson(path, features: list[dict]) -> None:
+    path.write_text(
+        json.dumps({"type": "FeatureCollection", "features": features}),
+        encoding="utf-8",
+    )
+
+
+def test_merge_geojson_files_streams_features_into_one_collection(tmp_path):
+    """Multiple layer outputs are merged into one FeatureCollection."""
+    first = tmp_path / "first.geojson"
+    second = tmp_path / "second.geojson"
+    output = tmp_path / "merged.geojson"
+    _write_geojson(first, [_feature(1)])
+    _write_geojson(second, [_feature(2)])
+
+    ogr_converter._merge_geojson_files([str(first), str(second)], str(output))
+
+    merged = json.loads(output.read_text(encoding="utf-8"))
+    assert merged["type"] == "FeatureCollection"
+    assert [feature["properties"]["id"] for feature in merged["features"]] == [1, 2]
+
+
+def test_convert_source_to_standard_reprojects_known_crs(tmp_path):
+    """Known source CRS uses -t_srs so coordinates are transformed to WGS84."""
+    output_path = tmp_path / "standard.geojson"
+
+    with patch.object(ogr_converter, "_get_source_info", return_value=("InputLayer", "EPSG:3005")), \
+            patch.object(ogr_converter, "_run_command") as run_command, \
+            patch.object(ogr_converter, "_check_output_size"):
+        crs = ogr_converter._convert_source_to_standard("/tmp/input.shp", str(output_path), 0)
+
+    cmd = run_command.call_args.args[0]
+    assert crs == "EPSG:3005"
+    assert "-t_srs" in cmd
+    assert "EPSG:4326" in cmd
+    assert "-a_srs" not in cmd
+    assert "layer_color" in cmd[cmd.index("-sql") + 1]
+    assert "input.shp" in cmd[cmd.index("-sql") + 1]
+
+
+def test_convert_source_to_standard_assigns_unknown_crs(tmp_path):
+    """Missing source CRS keeps the existing assumption that coordinates are WGS84."""
+    output_path = tmp_path / "standard.geojson"
+
+    with patch.object(ogr_converter, "_get_source_info", return_value=("InputLayer", "Unknown")), \
+            patch.object(ogr_converter, "_run_command") as run_command, \
+            patch.object(ogr_converter, "_check_output_size"):
+        crs = ogr_converter._convert_source_to_standard("/tmp/input.shp", str(output_path), 0)
+
+    cmd = run_command.call_args.args[0]
+    assert crs == "Unknown"
+    assert "-a_srs" in cmd
+    assert "EPSG:4326" in cmd
+    assert "-t_srs" not in cmd
+
+
+def test_convert_standard_to_preview_simplifies_wgs84_geojson(tmp_path):
+    """Preview conversion runs against the already converted WGS84 GeoJSON layer."""
+    standard_path = tmp_path / "standard.geojson"
+    preview_path = tmp_path / "preview.geojson"
+
+    with patch.object(ogr_converter, "_run_command") as run_command, \
+            patch.object(ogr_converter, "_check_output_size"):
+        ogr_converter._convert_standard_to_preview(str(standard_path), str(preview_path), 100)
+
+    cmd = run_command.call_args.args[0]
+    assert "-simplify" in cmd
+    assert str(ogr_converter.PREVIEW_SIMPLIFICATION) in cmd
+    assert "LIMIT 100" in cmd[cmd.index("-sql") + 1]
+    assert str(preview_path) in cmd
+    assert str(standard_path) in cmd

--- a/submit-web/src/utils/constants.ts
+++ b/submit-web/src/utils/constants.ts
@@ -23,7 +23,7 @@ export const DEFAULT_MAX_FILE_SIZE_MB = 500;
 
 // Geospatial files (.shp/.zip) are capped lower because processing large
 // files is expensive and can time out. This limit applies to geospatial only.
-export const GEO_MAX_FILE_SIZE_MB = 20;
+export const GEO_MAX_FILE_SIZE_MB = 100;
 export const GEO_MAX_FILE_SIZE_BYTES = GEO_MAX_FILE_SIZE_MB * 1024 * 1024;
 
 export const EXTENSION_TO_MIME_TYPE_MAP: Record<string, string[]> = {

--- a/submit-web/src/utils/constants.ts
+++ b/submit-web/src/utils/constants.ts
@@ -23,7 +23,7 @@ export const DEFAULT_MAX_FILE_SIZE_MB = 500;
 
 // Geospatial files (.shp/.zip) are capped lower because processing large
 // files is expensive and can time out. This limit applies to geospatial only.
-export const GEO_MAX_FILE_SIZE_MB = 100;
+export const GEO_MAX_FILE_SIZE_MB = 20;
 export const GEO_MAX_FILE_SIZE_BYTES = GEO_MAX_FILE_SIZE_MB * 1024 * 1024;
 
 export const EXTENSION_TO_MIME_TYPE_MAP: Record<string, string[]> = {


### PR DESCRIPTION
Replaces in-memory GeoPandas GIS conversion with disk-based ogr2ogr conversion for shapefile uploads, 
It should reduce memory pressure and preserving generated preview/standard GeoJSON outputs.

Changes

- Added safe zip extraction for shapefile archives.
- Added GDAL/ogr2ogr based conversion with WGS84 reprojection, preview simplification, metadata, and styling fields.
- Streamed generated GeoJSON files through presigned uploads instead of buffering them in memory.
- Added Docker GDAL build dependencies for API image support.
- Added focused unit coverage for archive safety, converter command behavior, and file upload flow.