### PR TITLE
SUBMIT-882 Add modal to revoke invitation

### DIFF
--- a/submit-api/src/submit_api/models/invitations.py
+++ b/submit-api/src/submit_api/models/invitations.py
@@ -7,7 +7,7 @@ from __future__ import annotations
 import uuid
 from datetime import datetime, timezone, UTC
 
-from sqlalchemy import Column, ForeignKey, String, Integer, TIMESTAMP, ARRAY, Boolean, func, and_
+from sqlalchemy import Column, ForeignKey, String, Integer, TIMESTAMP, ARRAY, Boolean, func
 from sqlalchemy.dialects.postgresql import JSON
 from sqlalchemy.ext.hybrid import hybrid_property
 from sqlalchemy.orm import relationship
@@ -106,13 +106,12 @@ class Invitations(BaseModel):
 
     @classmethod
     def get_active_by_account_id(cls, account_id: int, project_ids: list = None):
-        """Get pending and revoked (non-expired) invitations for an account, optionally filtered by project ids."""
+        """Get pending invitations for an account, optionally filtered by project ids."""
         query = cls.query.filter(
             cls.account_id == account_id,
             # The list should excluded expired and revoked invitations
             # pylint: disable=invalid-unary-operand-type
-            ~(and_(cls.is_expired, cls.status == InvitationStatus.REVOKED.value)),
-            cls.status.in_([InvitationStatus.PENDING.value, InvitationStatus.REVOKED.value])
+            cls.status.in_([InvitationStatus.PENDING.value])
         )
         if project_ids:
             query = query.filter(cls.project_ids.op('@>')(project_ids))

--- a/submit-web/src/components/App/UserManagement/entity/UserTableRow.tsx
+++ b/submit-web/src/components/App/UserManagement/entity/UserTableRow.tsx
@@ -1,30 +1,34 @@
-import { PlainTableCell } from "@/components/Shared/Table/common";
-import {
-  TableRow,
-  Typography,
-  Box,
-  CircularProgress,
-  Tooltip,
-} from "@mui/material";
-import { SubmitLink } from "@/components/Shared/Text/SubmitLink";
 import UserStatusChip from "@/components/App/UserStatusChip";
-import { AccountUserWithRole } from "@/models/AccountUser";
-import { roleDetails, USER_MANAGEMENT_ROLE } from "@/models/Role";
-import { useNavigate } from "@tanstack/react-router";
-import { useUserStore } from "./userStore";
+import ConfirmationModal from "@/components/Shared/Modals/ConfirmationModal";
 import { notify } from "@/components/Shared/Snackbar/snackbarStore";
-import { InvitationStatus } from "@/models/Invitation";
+import { PlainTableCell } from "@/components/Shared/Table/common";
+import { SubmitLink } from "@/components/Shared/Text/SubmitLink";
 import {
   useResendInvitation,
   useRevokeInvitation,
 } from "@/hooks/api/useInvitations";
-import { When } from "react-if";
-import { BCDesignTokens } from "epic.theme";
+import { AccountUserWithRole } from "@/models/AccountUser";
+import { InvitationStatus } from "@/models/Invitation";
+import { roleDetails, USER_MANAGEMENT_ROLE } from "@/models/Role";
 import InfoIcon from "@mui/icons-material/Info";
+import {
+  Box,
+  CircularProgress,
+  TableRow,
+  Tooltip,
+  Typography,
+} from "@mui/material";
+import { useNavigate } from "@tanstack/react-router";
+import { BCDesignTokens } from "epic.theme";
+import { When } from "react-if";
+import { useUserStore } from "./userStore";
+import { useModal } from "@/components/Shared/Modals/modalStore";
 
 export default function UserTableRow({ user }: { user: AccountUserWithRole }) {
   const { setSelectedUser } = useUserStore();
   const navigate = useNavigate();
+  const { setOpen: setOpenModal, setClose: setCloseModal } = useModal();
+
   const { mutate: resendInvitation, isPending: isResending } =
     useResendInvitation({
       onSuccess: () => {
@@ -50,9 +54,35 @@ export default function UserTableRow({ user }: { user: AccountUserWithRole }) {
     user?.role?.role_name ===
     USER_MANAGEMENT_ROLE.SPECIFIC_SUBMISSION_CONTRIBUTOR;
 
+  const openRevokeModal = () => {
+    setOpenModal(
+      <ConfirmationModal
+        onConfirm={() => {
+          revokeInvite();
+        }}
+        title="Revoke Invitation"
+        description={
+          <>
+            <Typography variant="body1">
+              This action will revoke access to EPIC.submit. The invitation link
+              sent in the email to this user will be disabled and the user will
+              be deleted from the system. Once access is revoked, if you want to
+              invite the user again, you will have to create a new invitation by
+              clicking the “+ Add New User” button.
+            </Typography>
+            <Typography variant="body1" sx={{ mt: 2 }}>
+              Please confirm you want to revoke this invitation.
+            </Typography>
+          </>
+        }
+        confirmText="Confirm"
+      />,
+    );
+  };
+
   const onUserClick = () => {
     if (isPending) {
-      revokeInvite();
+      openRevokeModal();
       return;
     }
     setSelectedUser(user);
@@ -67,6 +97,7 @@ export default function UserTableRow({ user }: { user: AccountUserWithRole }) {
 
   const revokeInvite = () => {
     deleteInvitation(user.invitation_id);
+    setCloseModal();
   };
 
   return (
@@ -136,7 +167,11 @@ export default function UserTableRow({ user }: { user: AccountUserWithRole }) {
             )}
             <When condition={isPending}>
               <SubmitLink onClick={onUserClick}>
-                {isRevoking ? <CircularProgress size={15} /> : "Revoke User"}
+                {isRevoking ? (
+                  <CircularProgress size={15} />
+                ) : (
+                  "Revoke Invitation"
+                )}
               </SubmitLink>
             </When>
             <When condition={!isPending}>


### PR DESCRIPTION
Tickets: [SUBMIT-882](https://eao-dst.atlassian.net/browse/SUBMIT-882) ENTITY - Can't revive revoked status collaborator / project admin

**Description**
- Change action link text from Revoke User to Revoke Invitation.
- Added modal for confirmation.
- On revocation, the user does not display in the list of users.
- Once revoked, the admin can add back the user via "Add New User".


[SUBMIT-882]: https://eao-dst.atlassian.net/browse/SUBMIT-882?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ