### PR TITLE
SUBMIT-914 hide actions for CR & MP

### DIFF
--- a/submit-web/src/components/App/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/App/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
@@ -14,7 +14,7 @@ import EmptyRow from "@/components/App/Projects/ProjectTable/EmptyRow";
 import { SubmissionItemTableRowProps } from "@/components/App/Submission/SubmissionItemTableRow";
 import { useQueryClient } from "@tanstack/react-query";
 import { getSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
-import { SubmissionPackage, SubmissionPackageType, PACKAGE_STATUS } from "@/models/Package";
+import { SubmissionPackage, SubmissionPackageType } from "@/models/Package";
 import {
   SubmitPrimaryRowTableCell,
   SubmitTablePrimaryRow,
@@ -26,6 +26,7 @@ import {
   UPDATE_REQUEST_STATUS,
 } from "@/models/UpdateRequest";
 import { SUBMISSION_TYPE } from "@/models/Submission";
+import { useSubmitAvailability } from "@/hooks/useSubmitAvailability";
 
 export default function ProponentSubmissionItemTableRow({
   item,
@@ -40,9 +41,6 @@ export default function ProponentSubmissionItemTableRow({
   const { id, submissions, status, type_id } = item;
 
   const isIPD = packageType.name === SubmissionPackageType.IPD;
-
-  const isFormSubmission =
-    item.type.submission_method === SubmissionItemMethod.FORM_SUBMISSION;
 
   const name = useMemo(() => {
     return getSubmissionItemLabel(item.type.name);
@@ -68,16 +66,7 @@ export default function ProponentSubmissionItemTableRow({
     );
   }, [submissionPackage, type_id]);
 
-  const isPackageAcknowledged = useMemo(() => {
-    return submissionPackage?.status.includes(PACKAGE_STATUS.ACKNOWLEDGED.value) || false;
-  }, [submissionPackage]);
-
-  const isPackagedReachedEnd = useMemo(() => {
-    return submissionPackage?.status.includes(PACKAGE_STATUS.APPROVED.value) ||
-      submissionPackage?.status.includes(PACKAGE_STATUS.REJECTED.value) ||
-      submissionPackage?.status.includes(PACKAGE_STATUS.NOT_APPROVED.value) ||
-      submissionPackage?.status.includes(PACKAGE_STATUS.ACCEPTED.value);
-  }, [submissionPackage]);
+  const { isSubmitDisabled } = useSubmitAvailability(submissionPackage);
 
   const hasAccountProjectWork = Boolean(
     submissionPackage?.account_project_work?.id,
@@ -89,12 +78,7 @@ export default function ProponentSubmissionItemTableRow({
       item.submissions?.find((submission) => submission.is_updated)
     );
   }, [item.submissions]);
-  const showActionLabels = useMemo(() => {
-    return !isPackagedReachedEnd && (isFormSubmission ||
-      !submissionPackage?.submitted_on ||
-      (isPackageAcknowledged && hasOpenUpdateRequest) ||
-      !isPackageAcknowledged)
-  }, [hasOpenUpdateRequest, isPackageAcknowledged, isFormSubmission, submissionPackage, isPackagedReachedEnd]);
+
   const actionLabel = has_document ? "Add/Edit Files" : "Fill/Edit Form";
 
   const onActionClick = () => {
@@ -147,7 +131,7 @@ export default function ProponentSubmissionItemTableRow({
             paddingRight: "2% !important",
           }}
         >
-          <When condition={showActionLabels}>
+          <When condition={!isSubmitDisabled}>
             <Typography
               variant="body2"
               data-testid={`submission-item-action-${name}`}

--- a/submit-web/src/hooks/useSubmitAvailability.ts
+++ b/submit-web/src/hooks/useSubmitAvailability.ts
@@ -1,0 +1,86 @@
+import { useMemo } from "react";
+import { PACKAGE_STATUS, SubmissionPackage } from "@/models/Package";
+import { UPDATE_REQUEST_STATUS } from "@/models/UpdateRequest";
+import { SUBMISSION_STATUS } from "@/models/Submission";
+
+interface SubmitAvailability {
+  isSubmitDisabled: boolean;
+  isPackageWithdrawn: boolean;
+  isPackageSubmitted: boolean;
+  isPackageAcknowledged: boolean;
+  hasUpdatedItems: boolean;
+  pendingRequests: SubmissionPackage["update_requests"];
+  openRequests: SubmissionPackage["update_requests"];
+}
+
+export function useSubmitAvailability(
+  submissionPackage: SubmissionPackage | undefined,
+): SubmitAvailability {
+  const isPackageSubmitted = Boolean(submissionPackage?.submitted_on);
+
+  const isPackageAcknowledged = Boolean(
+    submissionPackage?.status.includes(PACKAGE_STATUS.ACKNOWLEDGED.value),
+  );
+
+  const isPackageWithdrawn = Boolean(
+    submissionPackage?.status.includes(PACKAGE_STATUS.WITHDRAWN.value),
+  );
+
+  const pendingRequests = useMemo(
+    () =>
+      submissionPackage?.update_requests.filter(
+        (req) =>
+          req.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
+          req.active,
+      ) || [],
+    [submissionPackage?.update_requests],
+  );
+
+  const openRequests = useMemo(
+    () =>
+      submissionPackage?.update_requests.filter(
+        (req) =>
+          req.status === UPDATE_REQUEST_STATUS.OPEN.value && req.active,
+      ) || [],
+    [submissionPackage?.update_requests],
+  );
+
+  const hasUpdatedItems = Boolean(
+    submissionPackage?.items.some((item) =>
+      item.submissions.some(
+        (submission) =>
+          submission.is_updated &&
+          submission.status === SUBMISSION_STATUS.PENDING,
+      ),
+    ),
+  );
+
+  const isSubmitDisabled = useMemo(() => {
+    if (hasUpdatedItems) return false;
+
+    // Disable if package is submitted with no pending/open requests
+    return (
+      (isPackageSubmitted &&
+        pendingRequests.length === 0 &&
+        openRequests.length === 0) ||
+      // Disable if package is acknowledged with no open requests
+      (isPackageAcknowledged && openRequests.length === 0)
+    );
+  }, [
+    isPackageSubmitted,
+    pendingRequests.length,
+    openRequests.length,
+    isPackageAcknowledged,
+    hasUpdatedItems,
+  ]);
+
+  return {
+    isSubmitDisabled,
+    isPackageWithdrawn,
+    isPackageSubmitted,
+    isPackageAcknowledged,
+    hasUpdatedItems,
+    pendingRequests,
+    openRequests,
+  };
+}

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -53,8 +53,9 @@ import WithdrawalBanner from "@/components/App/Submission/WithdrawalBanner";
 import { useDocumentChangeTracking } from "@/hooks/useDocumentChangeTracking";
 import { getUnaddressedUpdateRequestSections } from "@/utils/updateRequestHelpers";
 import { useSaveProponentNote } from "@/hooks/api/useUpdateRequests";
+import { useSubmitAvailability } from "@/hooks/useSubmitAvailability";
 import { useState, useMemo } from "react";
-import { SUBMISSION_TYPE, SUBMISSION_STATUS } from "@/models/Submission";
+import { SUBMISSION_TYPE } from "@/models/Submission";
 
 export const Route = createFileRoute(
   "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
@@ -383,7 +384,14 @@ export default function SubmissionPage() {
     item.submissions.some((s) => s.type === SUBMISSION_TYPE.DOCUMENT),
   );
 
-  const isPackageSubmitted = Boolean(submissionPackage?.submitted_on);
+  const {
+    isSubmitDisabled,
+    isPackageWithdrawn,
+    isPackageSubmitted,
+    isPackageAcknowledged,
+    pendingRequests,
+    openRequests,
+  } = useSubmitAvailability(submissionPackage);
 
   const isFirstSubmission =
     submissionPackage?.status.includes(PACKAGE_STATUS.SUBMITTED.value) ||
@@ -394,57 +402,6 @@ export default function SubmissionPage() {
       updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
       updateRequest.active &&
       updateRequest.type === UPDATE_REQUEST_TYPE.REVIEW.value,
-  );
-
-  const pendingRequests =
-    submissionPackage?.update_requests.filter(
-      (updateRequest) =>
-        updateRequest.status === UPDATE_REQUEST_STATUS.PENDING_REVIEW.value &&
-        updateRequest.active,
-    ) || [];
-
-  const openRequests =
-    submissionPackage?.update_requests.filter(
-      (updateRequest) =>
-        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
-        updateRequest.active,
-    ) || [];
-
-  const isPackageAcknowledged = submissionPackage?.status.includes(
-    PACKAGE_STATUS.ACKNOWLEDGED.value,
-  );
-
-  // Check if there are any updated items that need to be submitted
-  const hasUpdatedItems = submissionPackage?.items.some((item) =>
-    item.submissions.some(
-      (submission) =>
-        submission.is_updated &&
-        submission.status === SUBMISSION_STATUS.PENDING,
-    ),
-  );
-
-  const isSubmitDisabled = useMemo(() => {
-    if (hasUpdatedItems) {
-      return false;
-    }
-    // Disable if package is submitted with no pending/open requests
-    return (
-      (isPackageSubmitted &&
-        pendingRequests.length === 0 &&
-        openRequests.length === 0) ||
-      // Disable if package is acknowledged with no open requests
-      (isPackageAcknowledged && openRequests.length === 0)
-    );
-  }, [
-    isPackageSubmitted,
-    pendingRequests.length,
-    openRequests.length,
-    isPackageAcknowledged,
-    hasUpdatedItems,
-  ]);
-
-  const isPackageWithdrawn = submissionPackage?.status.includes(
-    PACKAGE_STATUS.WITHDRAWN.value,
   );
 
   const isWithdrawDisabled = useMemo(() => {


### PR DESCRIPTION
[https://eao-dst.atlassian.net/browse/SUBMIT-914](https://eao-dst.atlassian.net/browse/SUBMIT-914)
extract submission availability logic into useSubmitAvailability hook

Extract package status checks (submitted, acknowledged, withdrawn),
update request filtering (pending/open), and submit-disabled logic
from the SubmissionPage and ProponentSubmissionItemTableRow into a
shared useSubmitAvailability hook.

This eliminates duplicated status logic across components and provides
a single source of truth for determining when submission actions
should be hidden or disabled.