### PR TITLE
SUBMIT-925 Update query for getting active invitations

### DIFF
--- a/submit-api/src/submit_api/models/invitations.py
+++ b/submit-api/src/submit_api/models/invitations.py
@@ -114,7 +114,7 @@ class Invitations(BaseModel):
             cls.status.in_([InvitationStatus.PENDING.value])
         )
         if project_ids:
-            query = query.filter(cls.project_ids.op('@>')(project_ids))
+            query = query.filter(cls.project_ids.op('&&')(project_ids))
         return query.all()
 
     @classmethod


### PR DESCRIPTION
Ticket: [SUBMIT-925](https://eao-dst.atlassian.net/browse/SUBMIT-925) Entity - New users are not showing in the user list (after they are invited, added)

**Description**
Issue: `get_active_by_account_id` used the Postgres array "contains" operator (`@>`) to filter invitations by project ids, which requires an invitation's `project_ids` to be a superset of all requested project ids. This caused valid pending invitations to be excluded once an account had multiple projects, since an invitation scoped to a single project (e.g. {252}) would fail containment against the full account project list (e.g. [252, 272]).

Fix: Replaced `@>` (contains) with `&&` (overlaps) so invitations are returned if their `project_ids` share any project with the requested list.

[SUBMIT-925]: https://eao-dst.atlassian.net/browse/SUBMIT-925?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ