### PR TITLE
SUBMIT-891 disable GIS actions via disabled prop and add tests

### DIFF
--- a/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/SectionUpdateRequestPanel.test.tsx
+++ b/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/SectionUpdateRequestPanel.test.tsx
@@ -1,0 +1,439 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import { SectionUpdateRequestPanel } from "./index";
+import { PendingRequest, SentRequest, PreviousRequest } from "./types";
+import { UPDATE_REQUEST_STATUS } from "@/models/UpdateRequest";
+
+// Mock child components to isolate SectionUpdateRequestPanel logic
+vi.mock("./SentRequestCollapsible", () => ({
+  SentRequestCollapsible: (props: {
+    request: SentRequest;
+    isGISRequest?: boolean;
+    onAcceptUpdate?: (id: number) => void;
+    onWithdrawUpdate?: (id: number) => void;
+    isProponentView?: boolean;
+  }) => (
+    <div data-testid={`sent-request-${props.request.updateRequestId}`}>
+      <span data-testid="item-type-name">{props.request.itemTypeName}</span>
+      <span data-testid="is-gis-request">{String(props.isGISRequest)}</span>
+      <span data-testid="is-proponent-view">{String(props.isProponentView)}</span>
+      {props.onAcceptUpdate && <span data-testid="has-accept-handler">true</span>}
+      {props.onWithdrawUpdate && <span data-testid="has-withdraw-handler">true</span>}
+    </div>
+  ),
+}));
+
+vi.mock("./PendingRequestCollapsible", () => ({
+  PendingRequestCollapsible: (props: {
+    request: PendingRequest;
+    hasError?: boolean;
+  }) => (
+    <div data-testid={`pending-request-${props.request.itemTypeId}`}>
+      <span data-testid="has-error">{String(props.hasError)}</span>
+      <span>{props.request.itemTypeName}</span>
+    </div>
+  ),
+}));
+
+vi.mock("./PreviousRequestCollapsible", () => ({
+  PreviousRequestCollapsible: (props: {
+    request: PreviousRequest;
+  }) => (
+    <div data-testid={`previous-request-${props.request.updateRequestId}`}>
+      <span>{props.request.itemTypeName}</span>
+    </div>
+  ),
+}));
+
+vi.mock("@/hooks/common", () => ({
+  useHasRole: () => true,
+}));
+
+vi.mock("@/hooks/api/usePackages", () => ({
+  useCreatePackageUpdateRequesNote: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useUpdatePackageUpdateRequestNote: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+const makeSentRequest = (overrides: Partial<SentRequest> = {}): SentRequest => ({
+  updateRequestId: 1,
+  itemTypeId: 10,
+  itemTypeName: "Initial Project Description",
+  reason: "Please update this section",
+  createdDate: "2024-06-01T00:00:00Z",
+  createdBy: "staff-user",
+  status: UPDATE_REQUEST_STATUS.OPEN.value,
+  ...overrides,
+});
+
+const makePendingRequest = (overrides: Partial<PendingRequest> = {}): PendingRequest => ({
+  itemTypeId: 20,
+  itemTypeName: "Engagement Plan",
+  reason: "Needs more detail",
+  ...overrides,
+});
+
+const makePreviousRequest = (overrides: Partial<PreviousRequest> = {}): PreviousRequest => ({
+  updateRequestId: 100,
+  itemTypeId: 30,
+  itemTypeName: "Initial Project Description",
+  reason: "Old request reason",
+  createdDate: "2024-01-01T00:00:00Z",
+  createdBy: "old-staff",
+  status: UPDATE_REQUEST_STATUS.ACCEPTED.value,
+  ...overrides,
+});
+
+const defaultProps = {
+  pendingRequests: [] as PendingRequest[],
+  sentRequests: [] as SentRequest[],
+  previousRequests: [] as PreviousRequest[],
+  onRemoveFlag: vi.fn(),
+  onSendRequests: vi.fn(),
+  onUpdateNote: vi.fn(),
+  onAcceptUpdate: vi.fn(),
+  onWithdrawUpdate: vi.fn(),
+  isLoading: false,
+  packageId: 100,
+};
+
+describe("SectionUpdateRequestPanel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("panel visibility", () => {
+    it("renders nothing when there are no requests of any kind", () => {
+      const { container } = render(<SectionUpdateRequestPanel {...defaultProps} />);
+
+      expect(container.firstChild).toBeNull();
+    });
+
+    it("renders panel when there are sent requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("Update Requests")).toBeInTheDocument();
+    });
+
+    it("renders panel when there are pending requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("Update Requests")).toBeInTheDocument();
+    });
+
+    it("renders panel when there are only previous requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          previousRequests={[makePreviousRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("Update Requests")).toBeInTheDocument();
+    });
+
+    it("shows empty state message when only previous requests exist", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          previousRequests={[makePreviousRequest()]}
+        />,
+      );
+
+      expect(
+        screen.getByText("No sections have been flagged for update."),
+      ).toBeInTheDocument();
+    });
+  });
+
+  describe("isGISRequest prop derivation", () => {
+    it("passes isGISRequest=true for Geospatial Information item type", () => {
+      const gisRequest = makeSentRequest({
+        itemTypeName: "Geospatial Information",
+      });
+
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[gisRequest]}
+        />,
+      );
+
+      const isGISFlag = screen.getByTestId("is-gis-request");
+      expect(isGISFlag).toHaveTextContent("true");
+    });
+
+    it("passes isGISRequest=false for non-GIS item types", () => {
+      const nonGisRequest = makeSentRequest({
+        itemTypeName: "Initial Project Description",
+      });
+
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[nonGisRequest]}
+        />,
+      );
+
+      const isGISFlag = screen.getByTestId("is-gis-request");
+      expect(isGISFlag).toHaveTextContent("false");
+    });
+
+    it("correctly identifies GIS and non-GIS requests in a mixed list", () => {
+      const gisRequest = makeSentRequest({
+        updateRequestId: 1,
+        itemTypeName: "Geospatial Information",
+      });
+      const nonGisRequest = makeSentRequest({
+        updateRequestId: 2,
+        itemTypeName: "Engagement Plan",
+      });
+
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[gisRequest, nonGisRequest]}
+        />,
+      );
+
+      const sentRequest1 = screen.getByTestId("sent-request-1");
+      const sentRequest2 = screen.getByTestId("sent-request-2");
+
+      expect(sentRequest1.querySelector('[data-testid="is-gis-request"]')).toHaveTextContent("true");
+      expect(sentRequest2.querySelector('[data-testid="is-gis-request"]')).toHaveTextContent("false");
+    });
+  });
+
+  describe("proponent view detection", () => {
+    it("passes isProponentView=false when onAcceptUpdate and onWithdrawUpdate are provided", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+          onAcceptUpdate={vi.fn()}
+          onWithdrawUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByTestId("is-proponent-view")).toHaveTextContent("false");
+    });
+
+    it("passes isProponentView=true when onAcceptUpdate and onWithdrawUpdate are undefined", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+          onAcceptUpdate={undefined}
+          onWithdrawUpdate={undefined}
+        />,
+      );
+
+      expect(screen.getByTestId("is-proponent-view")).toHaveTextContent("true");
+    });
+  });
+
+  describe("request count badge", () => {
+    it("shows total count badge for active requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest()]}
+          sentRequests={[makeSentRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("2")).toBeInTheDocument();
+    });
+
+    it("does not show count badge when only previous requests exist", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          previousRequests={[makePreviousRequest()]}
+        />,
+      );
+
+      expect(screen.queryByText("1")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("send request validation", () => {
+    it("calls onSendRequests when all pending requests have reasons", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest({ reason: "Valid reason" })]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Send Request to Proponent"));
+
+      expect(defaultProps.onSendRequests).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not call onSendRequests when a pending request has empty reason", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest({ reason: "" })]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Send Request to Proponent"));
+
+      expect(defaultProps.onSendRequests).not.toHaveBeenCalled();
+    });
+
+    it("does not call onSendRequests when a pending request has whitespace-only reason", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest({ reason: "   " })]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Send Request to Proponent"));
+
+      expect(defaultProps.onSendRequests).not.toHaveBeenCalled();
+    });
+
+    it("sets validation error on requests with empty reasons", () => {
+      const emptyReasonRequest = makePendingRequest({ itemTypeId: 20, reason: "" });
+      const validRequest = makePendingRequest({ itemTypeId: 21, reason: "OK" });
+
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[emptyReasonRequest, validRequest]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("Send Request to Proponent"));
+
+      // The empty one should have error
+      const pendingWithError = screen.getByTestId("pending-request-20");
+      expect(pendingWithError.querySelector('[data-testid="has-error"]')).toHaveTextContent("true");
+
+      // The valid one should not
+      const pendingWithoutError = screen.getByTestId("pending-request-21");
+      expect(pendingWithoutError.querySelector('[data-testid="has-error"]')).toHaveTextContent("false");
+    });
+  });
+
+  describe("send button state", () => {
+    it("shows Send Request button when there are pending requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("Send Request to Proponent")).toBeInTheDocument();
+    });
+
+    it("does not show Send Request button when there are no pending requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+        />,
+      );
+
+      expect(screen.queryByText("Send Request to Proponent")).not.toBeInTheDocument();
+    });
+
+    it("disables Send Request button when isLoading is true", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest()]}
+          isLoading={true}
+        />,
+      );
+
+      expect(screen.getByText("Send Request to Proponent").closest("button")).toBeDisabled();
+    });
+  });
+
+  describe("previous requests toggle", () => {
+    it("shows View Previous Requests link", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("View Previous Requests")).toBeInTheDocument();
+    });
+
+    it("toggles to show previous requests section when clicked", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+          previousRequests={[makePreviousRequest()]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("View Previous Requests"));
+
+      expect(screen.getByText("Previous Requests")).toBeInTheDocument();
+      expect(screen.getByText("Hide Previous Requests")).toBeInTheDocument();
+    });
+
+    it("shows no previous requests message when list is empty", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+          previousRequests={[]}
+        />,
+      );
+
+      fireEvent.click(screen.getByText("View Previous Requests"));
+
+      expect(screen.getByText("No previous update requests")).toBeInTheDocument();
+    });
+  });
+
+  describe("awaiting response indicator", () => {
+    it("shows awaiting entity response text when there are sent requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          sentRequests={[makeSentRequest()]}
+        />,
+      );
+
+      expect(screen.getByText("Awaiting entity response")).toBeInTheDocument();
+    });
+
+    it("does not show awaiting text when there are no sent requests", () => {
+      render(
+        <SectionUpdateRequestPanel
+          {...defaultProps}
+          pendingRequests={[makePendingRequest()]}
+        />,
+      );
+
+      expect(screen.queryByText("Awaiting entity response")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/SentRequestCollapsible.test.tsx
+++ b/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/SentRequestCollapsible.test.tsx
@@ -1,0 +1,357 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import { SentRequestCollapsible } from "./SentRequestCollapsible";
+import { SentRequest } from "./types";
+import { UPDATE_REQUEST_STATUS } from "@/models/UpdateRequest";
+
+// Mock the hooks used by the component
+const mockUseHasRole = vi.fn();
+vi.mock("@/hooks/common", () => ({
+  useHasRole: (...args: unknown[]) => mockUseHasRole(...args),
+}));
+
+vi.mock("@/hooks/api/usePackages", () => ({
+  useCreatePackageUpdateRequesNote: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+  useUpdatePackageUpdateRequestNote: () => ({
+    mutate: vi.fn(),
+    isPending: false,
+  }),
+}));
+
+const baseRequest: SentRequest = {
+  updateRequestId: 1,
+  itemTypeId: 10,
+  itemTypeName: "Geospatial Information",
+  reason: "Please upload updated GIS files",
+  createdDate: "2024-06-01T00:00:00Z",
+  createdBy: "staff-user",
+  status: UPDATE_REQUEST_STATUS.OPEN.value,
+};
+
+const defaultProps = {
+  request: baseRequest,
+  expanded: true,
+  onToggle: vi.fn(),
+  onAcceptUpdate: vi.fn(),
+  onWithdrawUpdate: vi.fn(),
+  packageId: 100,
+};
+
+/**
+ * Helper to find an action button by its label text.
+ * ActionSplitButton renders a native <button> element with the label as text.
+ * We filter out non-button elements (like MUI AccordionSummary div[role=button])
+ * to avoid false matches.
+ */
+const findActionButton = (label: string) => {
+  const buttons = screen.getAllByRole("button");
+  return buttons.find(
+    (btn) =>
+      btn.tagName === "BUTTON" &&
+      btn.textContent?.toLowerCase().includes(label.toLowerCase()),
+  );
+};
+
+describe("SentRequestCollapsible", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockUseHasRole.mockReturnValue(true);
+  });
+
+  describe("GIS permission gating", () => {
+    it("shows enabled Withdraw Update button when user has gis_extended_edit and request is GIS", () => {
+      mockUseHasRole.mockReturnValue(true);
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          isGISRequest={true}
+        />,
+      );
+
+      const button = findActionButton("Withdraw Update");
+      expect(button).toBeDefined();
+      expect(button).not.toBeDisabled();
+    });
+
+    it("disables Withdraw Update button when user lacks gis_extended_edit and request is GIS", () => {
+      mockUseHasRole.mockReturnValue(false);
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          isGISRequest={true}
+        />,
+      );
+
+      const button = findActionButton("Withdraw Update");
+      expect(button).toBeDefined();
+      expect(button).toBeDisabled();
+    });
+
+    it("renders tooltip wrapper on disabled Withdraw Update button for role restriction", () => {
+      mockUseHasRole.mockReturnValue(false);
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          isGISRequest={true}
+        />,
+      );
+
+      // The Tooltip wraps the disabled Box - verify the disabled button
+      // is inside the tooltip wrapper by checking the DOM structure
+      const button = findActionButton("Withdraw Update");
+      expect(button).toBeDefined();
+      expect(button).toBeDisabled();
+    });
+
+    it("shows enabled Accept Update button when user has gis_extended_edit and request is GIS with PENDING_REVIEW status", () => {
+      mockUseHasRole.mockReturnValue(true);
+
+      const pendingReviewRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={pendingReviewRequest}
+          isGISRequest={true}
+        />,
+      );
+
+      const button = findActionButton("Accept Update");
+      expect(button).toBeDefined();
+      expect(button).not.toBeDisabled();
+    });
+
+    it("disables Accept Update button when user lacks gis_extended_edit and request is GIS with PENDING_REVIEW status", () => {
+      mockUseHasRole.mockReturnValue(false);
+
+      const pendingReviewRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={pendingReviewRequest}
+          isGISRequest={true}
+        />,
+      );
+
+      const button = findActionButton("Accept Update");
+      expect(button).toBeDefined();
+      expect(button).toBeDisabled();
+    });
+
+    it("renders tooltip wrapper on disabled Accept Update button for role restriction", () => {
+      mockUseHasRole.mockReturnValue(false);
+
+      const pendingReviewRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={pendingReviewRequest}
+          isGISRequest={true}
+        />,
+      );
+
+      const button = findActionButton("Accept Update");
+      expect(button).toBeDefined();
+      expect(button).toBeDisabled();
+    });
+
+    it("does not disable buttons when isGISRequest is false regardless of role", () => {
+      mockUseHasRole.mockReturnValue(false);
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          isGISRequest={false}
+        />,
+      );
+
+      const button = findActionButton("Withdraw Update");
+      expect(button).toBeDefined();
+      expect(button).not.toBeDisabled();
+    });
+
+    it("does not disable buttons when isGISRequest is not provided (defaults to false)", () => {
+      mockUseHasRole.mockReturnValue(false);
+
+      render(<SentRequestCollapsible {...defaultProps} />);
+
+      const button = findActionButton("Withdraw Update");
+      expect(button).toBeDefined();
+      expect(button).not.toBeDisabled();
+    });
+  });
+
+  describe("button visibility based on status", () => {
+    it("shows Withdraw Update button when status is OPEN", () => {
+      render(<SentRequestCollapsible {...defaultProps} />);
+
+      const withdrawButton = findActionButton("Withdraw Update");
+      const acceptButton = findActionButton("Accept Update");
+      expect(withdrawButton).toBeDefined();
+      expect(acceptButton).toBeUndefined();
+    });
+
+    it("shows Requested status chip when status is OPEN", () => {
+      render(<SentRequestCollapsible {...defaultProps} />);
+
+      expect(screen.getByText("Requested")).toBeInTheDocument();
+    });
+
+    it("shows Accept Update button when status is PENDING_REVIEW", () => {
+      const pendingReviewRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={pendingReviewRequest}
+        />,
+      );
+
+      const acceptButton = findActionButton("Accept Update");
+      const withdrawButton = findActionButton("Withdraw Update");
+      expect(acceptButton).toBeDefined();
+      expect(withdrawButton).toBeUndefined();
+    });
+
+    it("shows Updated status chip when status is PENDING_REVIEW", () => {
+      const pendingReviewRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={pendingReviewRequest}
+        />,
+      );
+
+      expect(screen.getByText("Updated")).toBeInTheDocument();
+    });
+
+    it("does not show any action buttons when status is CLOSED", () => {
+      const closedRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.CLOSED.value,
+      };
+
+      render(
+        <SentRequestCollapsible {...defaultProps} request={closedRequest} />,
+      );
+
+      const acceptButton = findActionButton("Accept Update");
+      const withdrawButton = findActionButton("Withdraw Update");
+      expect(acceptButton).toBeUndefined();
+      expect(withdrawButton).toBeUndefined();
+    });
+  });
+
+  describe("staff vs proponent view", () => {
+    it("does not show Withdraw Update button when onWithdrawUpdate is not provided", () => {
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          onWithdrawUpdate={undefined}
+        />,
+      );
+
+      const withdrawButton = findActionButton("Withdraw Update");
+      expect(withdrawButton).toBeUndefined();
+    });
+
+    it("does not show Accept Update button when onAcceptUpdate is not provided", () => {
+      const pendingReviewRequest: SentRequest = {
+        ...baseRequest,
+        status: UPDATE_REQUEST_STATUS.PENDING_REVIEW.value,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={pendingReviewRequest}
+          onAcceptUpdate={undefined}
+        />,
+      );
+
+      const acceptButton = findActionButton("Accept Update");
+      expect(acceptButton).toBeUndefined();
+    });
+
+    it("shows Add Note button in proponent view when no note exists and status is OPEN", () => {
+      const requestWithNoNote: SentRequest = {
+        ...baseRequest,
+        note: undefined,
+      };
+
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          request={requestWithNoNote}
+          onAcceptUpdate={undefined}
+          onWithdrawUpdate={undefined}
+          onUpdateNote={vi.fn()}
+          isProponentView={true}
+        />,
+      );
+
+      const addNoteButton = findActionButton("Add Note for EAO");
+      expect(addNoteButton).toBeDefined();
+    });
+
+    it("does not show Add Note button in staff view", () => {
+      render(
+        <SentRequestCollapsible
+          {...defaultProps}
+          isProponentView={false}
+        />,
+      );
+
+      const addNoteButton = findActionButton("Add Note for EAO");
+      expect(addNoteButton).toBeUndefined();
+    });
+  });
+
+  describe("content rendering", () => {
+    it("displays the item type name", () => {
+      render(<SentRequestCollapsible {...defaultProps} />);
+
+      expect(screen.getByText("Geospatial Information")).toBeInTheDocument();
+    });
+
+    it("displays the request reason", () => {
+      render(<SentRequestCollapsible {...defaultProps} />);
+
+      expect(
+        screen.getByText("Please upload updated GIS files"),
+      ).toBeInTheDocument();
+    });
+
+    it("displays the created by user", () => {
+      render(<SentRequestCollapsible {...defaultProps} />);
+
+      expect(
+        screen.getByText(/EAO Staff — staff-user/),
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/SentRequestCollapsible.tsx
+++ b/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/SentRequestCollapsible.tsx
@@ -58,7 +58,7 @@ export const SentRequestCollapsible: React.FC<SentRequestCollapsibleProps> = ({
   
   // Determine if actions should be disabled for GIS requests
   const isActionDisabled = isGISRequest && !hasGISPermissions;
-
+  // If this is a GIS request and user doesn't have GIS permissions, disable all actions
   // Hooks for note operations
   const { mutate: createUpdateRequestNote, isPending: isCreatingNote } =
     useCreatePackageUpdateRequesNote({
@@ -112,7 +112,7 @@ export const SentRequestCollapsible: React.FC<SentRequestCollapsibleProps> = ({
           {onWithdrawUpdate && (
             isActionDisabled ? (
               <Tooltip title="Your current role does not allow you to perform this action">
-                <Box sx={{ opacity: 0.5, pointerEvents: "none" }}>
+                <Box sx={{ opacity: 0.5, cursor: "not-allowed" }}>
                   <ActionSplitButton
                     primaryAction={{
                       label: "Withdraw Update",
@@ -120,6 +120,7 @@ export const SentRequestCollapsible: React.FC<SentRequestCollapsibleProps> = ({
                       icon: <CloseIcon sx={{ fontSize: 13 }} />,
                     }}
                     secondaryActions={[]}
+                    disabled
                   />
                 </Box>
               </Tooltip>
@@ -150,13 +151,14 @@ export const SentRequestCollapsible: React.FC<SentRequestCollapsibleProps> = ({
           {onAcceptUpdate && (
             isActionDisabled ? (
               <Tooltip title="Your current role does not allow you to perform this action">
-                <Box sx={{ opacity: 0.5, pointerEvents: "none" }}>
+                <Box sx={{ opacity: 0.5, cursor: "not-allowed" }}>
                   <ActionSplitButton
                     primaryAction={{
                       label: "Accept Update",
                       onClick: () => {},
                     }}
                     secondaryActions={[]}
+                    disabled
                   />
                 </Box>
               </Tooltip>

--- a/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/index.tsx
+++ b/submit-web/src/components/App/SubmissionItem/SectionUpdateRequestPanel/index.tsx
@@ -14,6 +14,7 @@
  *   - Cannot send requests (onSendRequests is no-op)
  */
 import { LoadingButton } from "@/components/Shared/LoadingButton";
+import { GIS_ITEM_TYPE_NAME } from "@/utils/constants";
 import RefreshIcon from "@mui/icons-material/Refresh";
 import { Box, Link, Typography } from "@mui/material";
 import { BCDesignTokens } from "epic.theme";
@@ -287,6 +288,7 @@ export const SectionUpdateRequestPanel: React.FC<
               isLoading={isLoading}
               packageId={packageId}
               isProponentView={isProponentView}
+              isGISRequest={request.itemTypeName === GIS_ITEM_TYPE_NAME}
             />
           ))}
         </Box>


### PR DESCRIPTION
[https://eao-dst.atlassian.net/browse/SUBMIT-891](https://eao-dst.atlassian.net/browse/SUBMIT-891)

Replace pointerEvents: "none" with the disabled prop on
ActionSplitButton for Withdraw/Accept Update buttons when the user
lacks gis_extended_edit permissions. This ensures screen readers
correctly announce the disabled state.

Pass isGISRequest prop from SectionUpdateRequestPanel to
SentRequestCollapsible based on item type name.

Add unit tests for SectionUpdateRequestPanel (panel visibility,
validation, badge counts, previous request toggle) and
SentRequestCollapsible (GIS permission gating, button visibility
by status, proponent view behavior).