### PR TITLE
SUBMIT-833 Create EnforceableBanner component and update display logic

### DIFF
--- a/submit-web/src/components/App/Submission/EnforceableBanner/EnforceableBanner.tsx
+++ b/submit-web/src/components/App/Submission/EnforceableBanner/EnforceableBanner.tsx
@@ -1,0 +1,70 @@
+import { ReactNode } from "react";
+import { BCDesignTokens } from "epic.theme";
+import { Typography } from "@mui/material";
+import GppGoodOutlinedIcon from "@mui/icons-material/GppGoodOutlined";
+import { SuccessBox } from "@/components/Shared/Layouts/SuccessBox";
+import WarningBox from "@/components/Shared/Layouts/WarningBox";
+import { EnforceableBannerType } from "./useEnforceableBanner";
+
+type EnforceableBannerProps = {
+  bannerType: EnforceableBannerType;
+  /** Text (or custom node) shown in the "Enforceable" banner. */
+  enforceableText: ReactNode;
+  /** Text (or custom node) shown in the "Not Enforceable" banner. */
+  notEnforceableText: ReactNode;
+};
+
+/**
+ * Renders the "Enforceable" / "Not Enforceable" banner based on the
+ * bannerType produced by useEnforceableBanner. Renders nothing when
+ * bannerType is "none".
+ */
+export const EnforceableBanner = ({
+  bannerType,
+  enforceableText,
+  notEnforceableText,
+}: EnforceableBannerProps) => {
+  if (bannerType === "enforceable") {
+    return (
+      <SuccessBox
+        sx={{
+          mb: BCDesignTokens.layoutMarginMedium,
+          py: BCDesignTokens.layoutPaddingXsmall,
+          px: BCDesignTokens.layoutPaddingSmall,
+          display: "flex",
+          flexDirection: "row",
+          alignItems: "center",
+          width: "fit-content",
+        }}
+      >
+        <GppGoodOutlinedIcon fontSize="large" />
+        <Typography
+          variant="body2"
+          color={BCDesignTokens.typographyColorPrimary}
+        >
+          {enforceableText}
+        </Typography>
+      </SuccessBox>
+    );
+  }
+
+  if (bannerType === "not-enforceable") {
+    return (
+      <WarningBox
+        sx={{
+          mb: BCDesignTokens.layoutMarginMedium,
+          py: BCDesignTokens.layoutPaddingSmall,
+        }}
+      >
+        <Typography
+          variant="body2"
+          color={BCDesignTokens.typographyColorPrimary}
+        >
+          {notEnforceableText}
+        </Typography>
+      </WarningBox>
+    );
+  }
+
+  return null;
+};

--- a/submit-web/src/components/App/Submission/EnforceableBanner/useEnforceableBanner.ts
+++ b/submit-web/src/components/App/Submission/EnforceableBanner/useEnforceableBanner.ts
@@ -126,12 +126,6 @@ export const useStaffEnforceableBanner = ({
       emptyEligibleSetBannerType: "not-enforceable",
     });
 
-    console.log("bannerType", bannerType);
-    console.log(
-      "currentPackageVersion?.is_latest",
-      currentPackageVersion?.is_latest,
-    );
-
     if (bannerType === "not-enforceable" && currentPackageVersion?.is_latest) {
       bannerType = "none";
     }

--- a/submit-web/src/components/App/Submission/EnforceableBanner/useEnforceableBanner.ts
+++ b/submit-web/src/components/App/Submission/EnforceableBanner/useEnforceableBanner.ts
@@ -1,0 +1,141 @@
+import { useMemo } from "react";
+import { PackageVersion } from "@/models/Package";
+
+export type EnforceableBannerType = "enforceable" | "not-enforceable" | "none";
+
+type EnforceableBannerParams = {
+  packageVersions?: PackageVersion[];
+  currentPackageVersion?: PackageVersion;
+};
+
+type EnforceableBannerResult = {
+  /** Which banner (if any) applies to the current package version. */
+  bannerType: EnforceableBannerType;
+  /** True if bannerType !== "none" -- convenient for layout decisions like
+   * collapsing margin above the banner slot. */
+  hasBanner: boolean;
+};
+
+/**
+ * Shared "eligible version" rule underlying both the proponent and staff
+ * hooks below.
+ *
+ * A version is "eligible" if it is either approved (is_approved) or
+ * enforceable (is_enforceable). Whichever eligible version is most recent
+ * gets "enforceable"; every other version gets "not-enforceable". If there
+ * are no eligible versions at all, the result falls back to
+ * `emptyEligibleSetBannerType` (defaults to "none").
+ *
+ * This single rule reproduces every case in the spec:
+ * - No enforceable, no approved versions -> set is empty -> falls back to
+ *   `emptyEligibleSetBannerType` for every version (see the two hooks below
+ *   for how proponent vs. staff differ here).
+ * - No enforceable, one approved version -> "enforceable" on it,
+ *   "not-enforceable" on everything else.
+ * - No enforceable, multiple approved versions -> "enforceable" on the
+ *   latest approved version, "not-enforceable" on the rest.
+ * - One enforceable, no approved versions -> "enforceable" on the
+ *   enforceable version, "not-enforceable" on the rest.
+ * - One enforceable, one or many approved versions -> "enforceable" on
+ *   whichever of (approved | enforceable) is most recent, "not-enforceable"
+ *   on the rest of that set and on every non-eligible version.
+ * - Multiple enforceable versions is not expected to happen; if it does, we
+ *   fall back to the same "most recent eligible" rule and log a warning
+ *   rather than throwing.
+ *
+ * NOTE: this assumes `packageVersions` is ordered from most recent to least
+ * recent, as returned by useGetPackageVersionsByOriginalPackageId.
+ */
+const getBaseBannerType = ({
+  packageVersions,
+  currentPackageVersion,
+  emptyEligibleSetBannerType = "none",
+}: EnforceableBannerParams & {
+  emptyEligibleSetBannerType?: EnforceableBannerType;
+}): EnforceableBannerType => {
+  if (!packageVersions || !currentPackageVersion) return "none";
+
+  const enforceableVersions = packageVersions.filter((pv) => pv.is_enforceable);
+
+  if (enforceableVersions.length > 1) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      "useEnforceableBanner: multiple enforceable versions found for this package; this should not be possible.",
+    );
+  }
+
+  const eligibleVersions = packageVersions.filter(
+    (pv) => pv.is_approved || pv.is_enforceable,
+  );
+
+  if (eligibleVersions.length === 0) return emptyEligibleSetBannerType;
+
+  // Array is ordered most-recent-first, so the first match is the most
+  // recent eligible (approved | enforceable) version.
+  const mostRecentEligible = eligibleVersions[0];
+
+  return currentPackageVersion.id === mostRecentEligible.id
+    ? "enforceable"
+    : "not-enforceable";
+};
+
+/**
+ * Proponent-facing enforceable banner state -- see getBaseBannerType for the
+ * full rule breakdown.
+ */
+export const useEnforceableBanner = ({
+  packageVersions,
+  currentPackageVersion,
+}: EnforceableBannerParams): EnforceableBannerResult => {
+  return useMemo(() => {
+    const bannerType = getBaseBannerType({
+      packageVersions,
+      currentPackageVersion,
+    });
+
+    return { bannerType, hasBanner: bannerType !== "none" };
+  }, [packageVersions, currentPackageVersion]);
+};
+
+/**
+ * Staff-facing enforceable banner state. Differs from the proponent view in
+ * two ways:
+ *
+ * 1. If a package has no eligible (approved | enforceable) versions at all
+ *    -- e.g. a package type with no approval workflow, or one that simply
+ *    hasn't been approved/enforced yet -- staff still treats every version
+ *    as "not-enforceable" rather than showing no banner. Proponents aren't
+ *    told a version is "not enforceable" if nothing has ever been
+ *    enforceable, but staff need to see which versions have been superseded
+ *    regardless.
+ * 2. If the *current* package version is also the most recent version
+ *    overall (currentPackageVersion.is_latest) and the above would result
+ *    in "not-enforceable" -- i.e. this version simply hasn't been
+ *    reviewed/approved/rejected yet, it's just awaiting review -- staff
+ *    sees no banner at all instead. Older superseded/rejected versions
+ *    still show "not-enforceable" as normal.
+ */
+export const useStaffEnforceableBanner = ({
+  packageVersions,
+  currentPackageVersion,
+}: EnforceableBannerParams): EnforceableBannerResult => {
+  return useMemo(() => {
+    let bannerType = getBaseBannerType({
+      packageVersions,
+      currentPackageVersion,
+      emptyEligibleSetBannerType: "not-enforceable",
+    });
+
+    console.log("bannerType", bannerType);
+    console.log(
+      "currentPackageVersion?.is_latest",
+      currentPackageVersion?.is_latest,
+    );
+
+    if (bannerType === "not-enforceable" && currentPackageVersion?.is_latest) {
+      bannerType = "none";
+    }
+
+    return { bannerType, hasBanner: bannerType !== "none" };
+  }, [packageVersions, currentPackageVersion]);
+};

--- a/submit-web/src/components/App/Submission/VersionGroup.tsx
+++ b/submit-web/src/components/App/Submission/VersionGroup.tsx
@@ -92,20 +92,20 @@ export default function VersionGroup({
 
   const { mutate: createNewPackageVersion, isPending: isCreatingPackage } =
     useCreateNewPackageVersion({
-    onSuccess: (newPackage) => {
-      notify.success("New package created successfully");
+      onSuccess: (newPackage) => {
+        notify.success("New package created successfully");
 
-      // Invalidate the old package so it's refetched when revisited
-      queryClient.invalidateQueries({
-        queryKey: [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
-      });
+        // Invalidate the old package so it's refetched when revisited
+        queryClient.invalidateQueries({
+          queryKey: [QUERY_KEY.SUBMISSION_PACKAGE, packageId],
+        });
 
-      loadNewPackage(newPackage.id);
-    },
-    onError: () => {
-      notify.error("Failed to create new package");
-    },
-  });
+        loadNewPackage(newPackage.id);
+      },
+      onError: () => {
+        notify.error("Failed to create new package");
+      },
+    });
 
   function handleUpdatePackageId(newPackageId: number) {
     reset();
@@ -158,13 +158,16 @@ export default function VersionGroup({
     );
   };
 
-  const last_approved_package_version = packageVersions?.find(
+  const latestApprovedPackageVersion = packageVersions?.find(
     (packageVersion) =>
       packageVersion.is_approved || packageVersion.is_enforceable,
   );
 
   const isLatestVersion = useMemo(() => {
-    return calculateIsLatestVersion(packageVersions, currentPackageVersion.version);
+    return calculateIsLatestVersion(
+      packageVersions,
+      currentPackageVersion.version,
+    );
   }, [packageVersions, currentPackageVersion.version]);
 
   const canProponentCreateVersion = useMemo(() => {
@@ -222,7 +225,7 @@ export default function VersionGroup({
           + Create New
         </Button>
       )}
-      
+
       {!hideVersions &&
         packageVersions?.map((packageVersion) => (
           <Button
@@ -235,7 +238,7 @@ export default function VersionGroup({
             }}
             onClick={() => handleUpdatePackageId(packageVersion.package_id)}
             startIcon={
-              packageVersion.id === last_approved_package_version?.id ? (
+              packageVersion.id === latestApprovedPackageVersion?.id ? (
                 <GppGoodOutlinedIcon />
               ) : undefined
             }

--- a/submit-web/src/hooks/api/usePackages.ts
+++ b/submit-web/src/hooks/api/usePackages.ts
@@ -194,22 +194,11 @@ const getPackageVersionsByOriginalPackageId = ({
 };
 
 const addIsLatestFlag = (versions: PackageVersion[]): PackageVersion[] => {
-  // Find the latest approved version
-  const latestApprovedVersion = versions.find((pv) => pv.is_approved);
-
-  // Find the latest unapproved version that's newer than latest approved
-  let latestUnapprovedNewerThanApproved: PackageVersion | undefined;
-  if (latestApprovedVersion) {
-    latestUnapprovedNewerThanApproved = versions.find(
-      (pv) => !pv.is_approved && pv.version > latestApprovedVersion.version,
-    );
-  }
-
+  if (versions.length === 0) return versions;
+  const maxVersion = Math.max(...versions.map((pv) => pv.version));
   return versions.map((pv) => ({
     ...pv,
-    is_latest:
-      pv.id === latestApprovedVersion?.id ||
-      pv.id === latestUnapprovedNewerThanApproved?.id,
+    is_latest: pv.version === maxVersion,
   }));
 };
 

--- a/submit-web/src/hooks/useStaffSubmissionPage.ts
+++ b/submit-web/src/hooks/useStaffSubmissionPage.ts
@@ -119,21 +119,6 @@ export function useStaffSubmissionPage({
     (pv) => pv.package_id === submissionPackageId,
   );
 
-  const isLatestApprovedPackageVersion =
-    currentPackageVersion?.is_latest && currentPackageVersion?.is_approved;
-
-  const isNewerThanLastApprovedButNotApproved =
-    currentPackageVersion?.is_latest && !currentPackageVersion?.is_approved;
-
-  const isRejectedOrReplaced =
-    (!approval_type &&
-      packageVersions?.at(0)?.package_id !== submissionPackageId &&
-      !currentPackageVersion?.is_approved) ||
-    (currentPackageVersion?.is_approved && !isLatestApprovedPackageVersion);
-
-  const displaySubmissionBanner =
-    isLatestApprovedPackageVersion || isRejectedOrReplaced;
-
   const isReadyForAcknowledgement = useMemo(
     () =>
       submissionPackage?.status.includes(
@@ -198,16 +183,14 @@ export function useStaffSubmissionPage({
   }, [updatingPackageState, refusingPackage]);
 
   return {
+    packageVersions,
+    currentPackageVersion,
     accountProject,
     submissionPackage,
     isFetching,
     updatePackageState,
     refusePackage,
     isLoading,
-    isLatestApprovedPackageVersion,
-    isNewerThanLastApprovedButNotApproved,
-    isRejectedOrReplaced,
-    displaySubmissionBanner,
     canAcknowledge,
     showAcknowledgeButton,
     showApproveButtons,

--- a/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -1,12 +1,31 @@
-import {
-  createFileRoute,
-  Navigate,
-  useNavigate,
-  useParams,
-} from "@tanstack/react-router";
-import { BCDesignTokens } from "epic.theme";
-import { PageGrid } from "@/components/Shared/PageGrid";
+import { PackageStatusChipStack } from "@/components/App/PackageStatusChip/PackageStatusChipStack";
+import { ApprovalBanner } from "@/components/App/Submission/ApprovalBanner";
+import { EnforceableBanner } from "@/components/App/Submission/EnforceableBanner/EnforceableBanner";
+import { useEnforceableBanner } from "@/components/App/Submission/EnforceableBanner/useEnforceableBanner";
 import { InfoBox } from "@/components/App/Submission/InfoBox";
+import ItemsTable from "@/components/App/Submission/ItemsTable";
+import { UnaddressedSectionsModal } from "@/components/App/Submission/Modals/UnaddressedSectionsModal";
+import WithdrawSubmissionModal from "@/components/App/Submission/Modals/WithdrawSubmissionModal";
+import { usePackageTableStore } from "@/components/App/Submission/packageTableStore";
+import { RevisionRequiredBanner } from "@/components/App/Submission/RevisionRequiredBanner";
+import { SubmissionTitle } from "@/components/App/Submission/SubmissionTitle";
+import { SubmissionSuccessBox } from "@/components/App/Submission/SuccessBox";
+import { isSubmissionItemReadyToSubmit } from "@/components/App/Submission/utils";
+import WithdrawalBanner from "@/components/App/Submission/WithdrawalBanner";
+import { ProponentUpdateRequestPanel } from "@/components/App/SubmissionItem/ProponentUpdateRequestPanel";
+import type {
+  PreviousRequest,
+  SentRequest,
+} from "@/components/App/SubmissionItem/SectionUpdateRequestPanel/types";
+import { ContentBox } from "@/components/Shared/Layouts/ContentBox";
+import WarningBox from "@/components/Shared/Layouts/WarningBox";
+import { LoadingButton as Button } from "@/components/Shared/LoadingButton";
+import { SubmitLoaderBackdrop } from "@/components/Shared/Overlays/SubmitLoaderBackdrop";
+import { PageGrid } from "@/components/Shared/PageGrid";
+import PermissionsGate from "@/components/Shared/PermissionGate";
+import { notify } from "@/components/Shared/Snackbar/snackbarStore";
+import BarTitle from "@/components/Shared/Text/BarTitle";
+import { GeoUpload, useGetGeoUploads } from "@/hooks/api/useGeo";
 import {
   useGetPackageVersionsByOriginalPackageId,
   useGetSubmissionPackage,
@@ -14,49 +33,31 @@ import {
   useWithdrawPackage,
 } from "@/hooks/api/usePackages";
 import { useGetAccountProject } from "@/hooks/api/useProjects";
-import { PACKAGE_STATUS, SubmissionPackageType } from "@/models/Package";
-import { LoadingButton as Button } from "@/components/Shared/LoadingButton";
-import { notify } from "@/components/Shared/Snackbar/snackbarStore";
-import { Unless, When } from "react-if";
-import { PackageStatusChipStack } from "@/components/App/PackageStatusChip/PackageStatusChipStack";
-import { usePackageTableStore } from "@/components/App/Submission/packageTableStore";
+import { useSaveProponentNote } from "@/hooks/api/useUpdateRequests";
 import { useMounted } from "@/hooks/common";
-import { isSubmissionItemReadyToSubmit } from "@/components/App/Submission/utils";
-import { Box, Grid, Link, Typography } from "@mui/material";
-import { ContentBox } from "@/components/Shared/Layouts/ContentBox";
-import ItemsTable from "@/components/App/Submission/ItemsTable";
+import { useDocumentChangeTracking } from "@/hooks/useDocumentChangeTracking";
+import { useManagementPlanName } from "@/hooks/useManagementPlanName";
+import { useSubmissionBannerState } from "@/hooks/useSubmissionBannerState";
+import { useSubmitAvailability } from "@/hooks/useSubmitAvailability";
+import { PACKAGE_STATUS, SubmissionPackageType } from "@/models/Package";
+import { ACCOUNT_USER_PERMISSIONS } from "@/models/Role";
+import { SUBMISSION_TYPE } from "@/models/Submission";
 import {
   UPDATE_REQUEST_STATUS,
   UPDATE_REQUEST_TYPE,
 } from "@/models/UpdateRequest";
-import BarTitle from "@/components/Shared/Text/BarTitle";
-import PermissionsGate from "@/components/Shared/PermissionGate";
-import { ACCOUNT_USER_PERMISSIONS } from "@/models/Role";
-import GppGoodOutlinedIcon from "@mui/icons-material/GppGoodOutlined";
-import { SuccessBox } from "@/components/Shared/Layouts/SuccessBox";
-import { SubmissionSuccessBox } from "@/components/App/Submission/SuccessBox";
-import WarningBox from "@/components/Shared/Layouts/WarningBox";
-import { useManagementPlanName } from "@/hooks/useManagementPlanName";
-import { SubmitLoaderBackdrop } from "@/components/Shared/Overlays/SubmitLoaderBackdrop";
-import { SubmissionTitle } from "@/components/App/Submission/SubmissionTitle";
-import { useGetGeoUploads, GeoUpload } from "@/hooks/api/useGeo";
-import { ProponentUpdateRequestPanel } from "@/components/App/SubmissionItem/ProponentUpdateRequestPanel";
-import type {
-  SentRequest,
-  PreviousRequest,
-} from "@/components/App/SubmissionItem/SectionUpdateRequestPanel/types";
-import { UnaddressedSectionsModal } from "@/components/App/Submission/Modals/UnaddressedSectionsModal";
-import WithdrawSubmissionModal from "@/components/App/Submission/Modals/WithdrawSubmissionModal";
-import WithdrawalBanner from "@/components/App/Submission/WithdrawalBanner";
-import { useDocumentChangeTracking } from "@/hooks/useDocumentChangeTracking";
 import { getUnaddressedUpdateRequestSections } from "@/utils/updateRequestHelpers";
-import { useSaveProponentNote } from "@/hooks/api/useUpdateRequests";
-import { useSubmitAvailability } from "@/hooks/useSubmitAvailability";
-import { useState, useMemo } from "react";
-import { SUBMISSION_TYPE } from "@/models/Submission";
-import { useSubmissionBannerState } from "@/hooks/useSubmissionBannerState";
-import { ApprovalBanner } from "@/components/App/Submission/ApprovalBanner";
-import { RevisionRequiredBanner } from "@/components/App/Submission/RevisionRequiredBanner";
+import GppGoodOutlinedIcon from "@mui/icons-material/GppGoodOutlined";
+import { Box, Grid, Link, Typography } from "@mui/material";
+import {
+  createFileRoute,
+  Navigate,
+  useNavigate,
+  useParams,
+} from "@tanstack/react-router";
+import { BCDesignTokens } from "epic.theme";
+import { useMemo, useState } from "react";
+import { Unless, When } from "react-if";
 
 export const Route = createFileRoute(
   "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
@@ -108,12 +109,10 @@ export default function SubmissionPage() {
     (pv) => pv.package_id === submissionPackageId,
   );
 
-  const hasAnyEnforceablePackageVersion = packageVersions?.some(
-    (pv) => pv.is_approved || pv.is_enforceable,
-  );
-
-  const isLatestApprovedPackageVersion =
-    currentPackageVersion?.is_latest && currentPackageVersion?.is_approved;
+  const { bannerType, hasBanner } = useEnforceableBanner({
+    packageVersions,
+    currentPackageVersion,
+  });
 
   const {
     mutate: updateStateSubmissionPackage,
@@ -490,9 +489,7 @@ export default function SubmissionPage() {
                   display: "flex",
                   alignItems: "center",
                   justifyContent: "space-between",
-                  mb: hasAnyEnforceablePackageVersion
-                    ? 0
-                    : BCDesignTokens.layoutMarginXlarge,
+                  mb: hasBanner ? 0 : BCDesignTokens.layoutMarginXlarge,
                 }}
               >
                 <BarTitle title={managementPlanName} />
@@ -509,50 +506,11 @@ export default function SubmissionPage() {
                   />
                 </Box>
               </Box>
-              <When
-                condition={
-                  submissionPackage.enforceable ||
-                  Boolean(isLatestApprovedPackageVersion)
-                }
-              >
-                <SuccessBox
-                  sx={{
-                    mb: BCDesignTokens.layoutMarginMedium,
-                    py: BCDesignTokens.layoutPaddingXsmall,
-                    px: BCDesignTokens.layoutPaddingSmall,
-                    display: "flex",
-                    flexDirection: "row",
-                    alignItems: "center",
-                    width: "fit-content",
-                  }}
-                >
-                  <GppGoodOutlinedIcon fontSize="large" />
-                  <Typography
-                    variant="body2"
-                    color={BCDesignTokens.typographyColorPrimary}
-                  >
-                    This submission is the version the EAO has finalized for
-                    implementation.
-                  </Typography>
-                </SuccessBox>
-              </When>
-              <When
-                condition={
-                  !submissionPackage.enforceable &&
-                  !isLatestApprovedPackageVersion &&
-                  hasAnyEnforceablePackageVersion
-                }
-              >
-                <WarningBox
-                  sx={{
-                    mb: BCDesignTokens.layoutMarginMedium,
-                    py: BCDesignTokens.layoutPaddingSmall,
-                  }}
-                >
-                  <Typography
-                    variant="body2"
-                    color={BCDesignTokens.typographyColorPrimary}
-                  >
+              <EnforceableBanner
+                bannerType={bannerType}
+                enforceableText="This submission is the version the EAO has finalized for implementation."
+                notEnforceableText={
+                  <>
                     Please Note: This submission is not considered enforceable.
                     Please refer to the Submission Package with this icon
                     <GppGoodOutlinedIcon
@@ -560,9 +518,9 @@ export default function SubmissionPage() {
                       sx={{ verticalAlign: "middle" }}
                     />
                     for the enforceable version.
-                  </Typography>
-                </WarningBox>
-              </When>
+                  </>
+                }
+              />
               <InfoBox submissionPackage={submissionPackage} />
               {/* PROPONENT VIEW: Update Requests Panel with Figma design */}
               <ProponentUpdateRequestPanel
@@ -627,14 +585,12 @@ export default function SubmissionPage() {
                     Your {submissionPackage.type.title} has not been approved.
                     To submit a new {submissionPackage.type.title} package,
                     select Package {packageVersions?.at(0)?.version} above,
-                    upload your documents, and click the &quot;Submit to EAO&quot;
-                    button.
+                    upload your documents, and click the &quot;Submit to
+                    EAO&quot; button.
                   </Typography>
                   <Typography variant="body1" mt="20px">
                     If you have any questions, please contact the EAO at{" "}
-                    <Link href={`mailto:${contactEmail}`}>
-                      {contactEmail}
-                    </Link>
+                    <Link href={`mailto:${contactEmail}`}>{contactEmail}</Link>
                   </Typography>
                 </WarningBox>
               </When>

--- a/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
+++ b/submit-web/src/routes/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/index.tsx
@@ -1,5 +1,30 @@
+import { PackageStatusChipStack } from "@/components/App/PackageStatusChip/PackageStatusChipStack";
+import { EnforceableBanner } from "@/components/App/Submission/EnforceableBanner/EnforceableBanner";
+import { useStaffEnforceableBanner } from "@/components/App/Submission/EnforceableBanner/useEnforceableBanner";
+import { InfoBox } from "@/components/App/Submission/InfoBox";
+import ItemsTable from "@/components/App/Submission/ItemsTable";
+import AcknowledgeSubmissionModal from "@/components/App/Submission/Modals/AcknowledgeSubmissionModal";
+import ApproveSubmissionModal from "@/components/App/Submission/Modals/ApproveSubmissionModal";
+import RefuseSubmissionModal from "@/components/App/Submission/Modals/RefuseSubmissionModal";
+import { usePackageTableStore } from "@/components/App/Submission/packageTableStore";
+import { SubmissionTitle } from "@/components/App/Submission/SubmissionTitle";
+import { SectionUpdateRequestPanel } from "@/components/App/SubmissionItem/SectionUpdateRequestPanel";
 import { ContentBox } from "@/components/Shared/Layouts/ContentBox";
+import { LoadingButton as Button } from "@/components/Shared/LoadingButton";
+import { SubmitLoaderBackdrop } from "@/components/Shared/Overlays/SubmitLoaderBackdrop";
+import { PageGrid } from "@/components/Shared/PageGrid";
+import BarTitle from "@/components/Shared/Text/BarTitle";
+import { useMounted } from "@/hooks/common";
+import { useManagementPlanName } from "@/hooks/useManagementPlanName";
+import { useStaffSubmissionPage } from "@/hooks/useStaffSubmissionPage";
+import { useUpdateRequests } from "@/hooks/useUpdateRequests";
+import {
+  NON_WITHDRAWABLE_UPDATE_REQUEST_PACKAGE_TYPES,
+  PACKAGE_STATUS,
+  SubmissionPackageType,
+} from "@/models/Package";
 import { Box, Grid, Typography } from "@mui/material";
+import { useQueryClient } from "@tanstack/react-query";
 import {
   createFileRoute,
   Navigate,
@@ -7,33 +32,6 @@ import {
   useParams,
 } from "@tanstack/react-router";
 import { BCDesignTokens } from "epic.theme";
-import { PageGrid } from "@/components/Shared/PageGrid";
-import { InfoBox } from "@/components/App/Submission/InfoBox";
-import { LoadingButton as Button } from "@/components/Shared/LoadingButton";
-import { PackageStatusChipStack } from "@/components/App/PackageStatusChip/PackageStatusChipStack";
-import { usePackageTableStore } from "@/components/App/Submission/packageTableStore";
-import { useQueryClient } from "@tanstack/react-query";
-import ItemsTable from "@/components/App/Submission/ItemsTable";
-import { useMounted } from "@/hooks/common";
-import BarTitle from "@/components/Shared/Text/BarTitle";
-import { SuccessBox } from "@/components/Shared/Layouts/SuccessBox";
-import { When } from "react-if";
-import GppGoodOutlinedIcon from "@mui/icons-material/GppGoodOutlined";
-import WarningBox from "@/components/Shared/Layouts/WarningBox";
-import { useManagementPlanName } from "@/hooks/useManagementPlanName";
-import { SubmitLoaderBackdrop } from "@/components/Shared/Overlays/SubmitLoaderBackdrop";
-import { SubmissionTitle } from "@/components/App/Submission/SubmissionTitle";
-import { SectionUpdateRequestPanel } from "@/components/App/SubmissionItem/SectionUpdateRequestPanel";
-import {
-  NON_WITHDRAWABLE_UPDATE_REQUEST_PACKAGE_TYPES,
-  SubmissionPackageType,
-  PACKAGE_STATUS,
-} from "@/models/Package";
-import AcknowledgeSubmissionModal from "@/components/App/Submission/Modals/AcknowledgeSubmissionModal";
-import { useUpdateRequests } from "@/hooks/useUpdateRequests";
-import { useStaffSubmissionPage } from "@/hooks/useStaffSubmissionPage";
-import ApproveSubmissionModal from "@/components/App/Submission/Modals/ApproveSubmissionModal";
-import RefuseSubmissionModal from "@/components/App/Submission/Modals/RefuseSubmissionModal";
 
 export const Route = createFileRoute(
   "/staff/_staffLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout/",
@@ -57,15 +55,14 @@ export default function SubmissionPage() {
   const accountProjectId = Number(accountProjectIdParam);
 
   const {
+    packageVersions,
+    currentPackageVersion,
     accountProject,
     submissionPackage,
     isFetching,
     updatePackageState,
     refusePackage,
     isLoading,
-    isLatestApprovedPackageVersion,
-    isRejectedOrReplaced,
-    displaySubmissionBanner,
     canAcknowledge,
     showAcknowledgeButton,
     showApproveButtons,
@@ -75,6 +72,11 @@ export default function SubmissionPage() {
     submissionPackageId,
     accountProjectId,
     queryClient,
+  });
+
+  const { bannerType, hasBanner } = useStaffEnforceableBanner({
+    packageVersions,
+    currentPackageVersion,
   });
 
   const {
@@ -216,9 +218,7 @@ export default function SubmissionPage() {
                   display: "flex",
                   alignItems: "flex-start",
                   justifyContent: "space-between",
-                  mb: displaySubmissionBanner
-                    ? 0
-                    : BCDesignTokens.layoutMarginXlarge,
+                  mb: hasBanner ? 0 : BCDesignTokens.layoutMarginXlarge,
                 }}
               >
                 <BarTitle title={managementPlanName} />
@@ -235,53 +235,11 @@ export default function SubmissionPage() {
                   />
                 </Box>
               </Box>
-              <When
-                condition={
-                  submissionPackage.enforceable ||
-                  Boolean(isLatestApprovedPackageVersion)
-                }
-              >
-                <SuccessBox
-                  sx={{
-                    mb: BCDesignTokens.layoutMarginMedium,
-                    py: BCDesignTokens.layoutPaddingXsmall,
-                    px: BCDesignTokens.layoutPaddingSmall,
-                    display: "flex",
-                    flexDirection: "row",
-                    alignItems: "center",
-                    width: "fit-content",
-                  }}
-                >
-                  <GppGoodOutlinedIcon fontSize="large" />
-                  <Typography
-                    variant="body2"
-                    color={BCDesignTokens.typographyColorPrimary}
-                  >
-                    This submission is the version the EAO has finalized for
-                    implementation.
-                  </Typography>
-                </SuccessBox>
-              </When>
-              <When
-                condition={
-                  !submissionPackage.enforceable && isRejectedOrReplaced
-                }
-              >
-                <WarningBox
-                  sx={{
-                    mb: BCDesignTokens.layoutMarginMedium,
-                    py: BCDesignTokens.layoutPaddingSmall,
-                  }}
-                >
-                  <Typography
-                    variant="body2"
-                    color={BCDesignTokens.typographyColorPrimary}
-                  >
-                    This version has failed review, or has been replaced with a
-                    newer version.
-                  </Typography>
-                </WarningBox>
-              </When>
+              <EnforceableBanner
+                bannerType={bannerType}
+                enforceableText="This submission is the version the EAO has finalized for implementation."
+                notEnforceableText="This version has failed review, or has been replaced with a newer version."
+              />
               <InfoBox submissionPackage={submissionPackage} />
               <Box
                 sx={{
@@ -350,7 +308,7 @@ export default function SubmissionPage() {
                     loading={isLoading}
                   >
                     {submissionPackage?.type.name ===
-                      SubmissionPackageType.ADDITIONAL_INFORMATION ? (
+                    SubmissionPackageType.ADDITIONAL_INFORMATION ? (
                       <>
                         Acknowledge Submission <i>(optional)</i>
                       </>


### PR DESCRIPTION
Ticket: [SUBMIT-833](https://eao-dst.atlassian.net/browse/SUBMIT-833) EAO - MP - Add the option to mark plan as current enforceable version event if it fails MP review

**Description**
- Fixes bug where the approved banner was incorrectly displayed.
- Refactors into a shared `EnforceableBanner` component that is re-used for both proponent and staff.
- Also creates a custom `useEnforceableBanner` hook to simplify and make re-usable the banner display logic.

[SUBMIT-833]: https://eao-dst.atlassian.net/browse/SUBMIT-833?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ