### PR TITLE
Fix submit email payload configuration

### DIFF
--- a/deployment/charts/submit-api/templates/configmap.yaml
+++ b/deployment/charts/submit-api/templates/configmap.yaml
@@ -17,3 +17,8 @@ data:
   INSTANCE_ADMIN_GROUP: {{ .Values.auth.keycloak.instanceAdminGroup }}
   CONNECT_TIMEOUT: "{{ .Values.python.connectTimeout }}"
   CORS_ORIGIN: "{{ .Values.cors.origin }}"
+  BASE_APP_URL: {{ .Values.web.url }}
+  BC_SERVICE_CARD_URL: {{ .Values.bcServiceCard.url }}
+  LEGISLATIVE_TIMEZONE: {{ .Values.timezone }}
+  SENDER_EMAIL: {{ .Values.sender.email }}
+  STAFF_SUPPORT_MAIL_ID: {{ .Values.sender.email }}

--- a/deployment/charts/submit-api/templates/deployment.yaml
+++ b/deployment/charts/submit-api/templates/deployment.yaml
@@ -177,6 +177,31 @@ spec:
                 configMapKeyRef:
                   name: {{ .Release.Name }}
                   key: CORS_ORIGIN
+            - name: BASE_APP_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}
+                  key: BASE_APP_URL
+            - name: BC_SERVICE_CARD_URL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}
+                  key: BC_SERVICE_CARD_URL
+            - name: LEGISLATIVE_TIMEZONE
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}
+                  key: LEGISLATIVE_TIMEZONE
+            - name: SENDER_EMAIL
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}
+                  key: SENDER_EMAIL
+            - name: STAFF_SUPPORT_MAIL_ID
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ .Release.Name }}
+                  key: STAFF_SUPPORT_MAIL_ID
           resources:
             limits:
               cpu: {{ .Values.resources.cpu.limit }}

--- a/deployment/charts/submit-api/values.yaml
+++ b/deployment/charts/submit-api/values.yaml
@@ -50,3 +50,14 @@ python:
   connectTimeout: 60
 cors:
   origin: "https://dev.submit.eao.gov.bc.ca,"
+
+web:
+  url: https://dev.submit.eao.gov.bc.ca
+
+sender:
+  email: EAO.ManagementPlanSupport@gov.bc.ca
+
+bcServiceCard:
+  url: https://id.gov.bc.ca
+
+timezone: US/Pacific

--- a/submit-api/sample.env
+++ b/submit-api/sample.env
@@ -24,6 +24,10 @@ JWT_OIDC_CACHING_ENABLED=True
 JWT_OIDC_JWKS_CACHE_TIMEOUT=3000000
 
 SITE_URL=http://localhost:3000
+BASE_APP_URL=http://localhost:3000
+SENDER_EMAIL=EAO.ManagementPlanSupport@gov.bc.ca
+STAFF_SUPPORT_MAIL_ID=EAO.ManagementPlanSupport@gov.bc.ca
+LEGISLATIVE_TIMEZONE=US/Pacific
 KEYCLOAK_BASE_URL=https://localhost:8080
 KEYCLOAK_URL_REALM=submit
 

--- a/submit-api/src/submit_api/config.py
+++ b/submit-api/src/submit_api/config.py
@@ -94,8 +94,12 @@ class _Config():  # pylint: disable=too-few-public-methods
 
     DOCUMENT_SERVICE_URL = _get_config("DOCUMENT_SERVICE_URL")
 
-    BASE_APP_URL = os.getenv('BASE_APP_URL')
+    BASE_APP_URL = os.getenv('BASE_APP_URL', os.getenv('SITE_URL', ''))
     SIGNUP_URL_PATH = os.getenv('SIGNUP_URL_PATH')
+    BC_SERVICE_CARD_URL = os.getenv('BC_SERVICE_CARD_URL', 'https://id.gov.bc.ca')
+    LEGISLATIVE_TIMEZONE = os.getenv('LEGISLATIVE_TIMEZONE', 'US/Pacific')
+    SENDER_EMAIL = os.getenv('SENDER_EMAIL')
+    STAFF_SUPPORT_MAIL_ID = os.getenv('STAFF_SUPPORT_MAIL_ID', '')
 
     INVITATION_EXPIRY_DAYS = int(os.getenv('INVITATION_EXPIRY_DAYS', '7'))  # Default to 7 days
 

--- a/submit-api/src/submit_api/services/consultation_record_service.py
+++ b/submit-api/src/submit_api/services/consultation_record_service.py
@@ -83,7 +83,7 @@ class ConsultationRecordService:
                 session=session
             )
         cls._create_rejection_email_queue(
-            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE)
+            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE, session)
         item.status = ItemStatus.UNDER_CONSULTATION_CHECK.value
         session.add(item)
         session.flush()
@@ -119,6 +119,6 @@ class ConsultationRecordService:
             f"Update request created for new package {data.get('package_id')}.")
 
     @classmethod
-    def _create_rejection_email_queue(cls, package_id, template_name):
+    def _create_rejection_email_queue(cls, package_id, template_name, session):
         """Create an email queue record for an update request."""
-        SubmitEmailQueueService.queue_package_email(package_id, template_name)
+        SubmitEmailQueueService.queue_package_email(package_id, template_name, session=session)

--- a/submit-api/src/submit_api/services/email_queue_service.py
+++ b/submit-api/src/submit_api/services/email_queue_service.py
@@ -200,6 +200,12 @@ class SubmitEmailQueueService:
 
     @staticmethod
     def _payload(sender: str, recipients: list[str], subject: str, body_args: dict) -> dict:
+        if not sender:
+            raise BadRequestError("Email sender is required")
+        if not recipients:
+            raise BadRequestError("At least one email recipient is required")
+        if not subject:
+            raise BadRequestError("Email subject is required")
         return {
             'sender': sender,
             'recipients': recipients,
@@ -241,8 +247,14 @@ class SubmitEmailQueueService:
 
     @staticmethod
     def _get_base_url() -> str:
-        base_url = current_app.config.get('BASE_APP_URL') or current_app.config.get('WEB_URL')
-        return base_url.rstrip('/') if base_url else ''
+        base_url = (
+            current_app.config.get('BASE_APP_URL') or
+            current_app.config.get('WEB_URL') or
+            current_app.config.get('SITE_URL')
+        )
+        if not base_url:
+            raise BadRequestError("BASE_APP_URL is required to build email links")
+        return base_url.rstrip('/')
 
     @staticmethod
     def _build_signup_url(token: str) -> str:

--- a/submit-api/src/submit_api/services/email_queue_service.py
+++ b/submit-api/src/submit_api/services/email_queue_service.py
@@ -252,9 +252,7 @@ class SubmitEmailQueueService:
             current_app.config.get('WEB_URL') or
             current_app.config.get('SITE_URL')
         )
-        if not base_url:
-            raise BadRequestError("BASE_APP_URL is required to build email links")
-        return base_url.rstrip('/')
+        return base_url.rstrip('/') if base_url else ''
 
     @staticmethod
     def _build_signup_url(token: str) -> str:

--- a/submit-api/src/submit_api/services/iem_service.py
+++ b/submit-api/src/submit_api/services/iem_service.py
@@ -27,7 +27,7 @@ class IEMTermsOfEngagementService:
         cls._log_iem_rejection_activity(item, session)
         ManagementPlanService.deactivate_update_requests(item.package_id, session)
         cls._create_rejection_email_queue(
-            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE)
+            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE, session)
         current_app.logger.info(
             f"IEM form rejected for item {item.id}.")
         return item
@@ -87,6 +87,6 @@ class IEMTermsOfEngagementService:
             f"Activity logged for iem approval for package {package.id}.")
 
     @classmethod
-    def _create_rejection_email_queue(cls, package_id, template_name):
+    def _create_rejection_email_queue(cls, package_id, template_name, session):
         """Create an email queue record for an update request."""
-        SubmitEmailQueueService.queue_package_email(package_id, template_name)
+        SubmitEmailQueueService.queue_package_email(package_id, template_name, session=session)

--- a/submit-api/src/submit_api/services/management_plan_service.py
+++ b/submit-api/src/submit_api/services/management_plan_service.py
@@ -34,7 +34,7 @@ class ManagementPlanService:
         cls._log_management_plan_rejection_activity(item, session)
         cls.deactivate_update_requests(item.package_id, session)
         cls._create_rejection_email_queue(
-            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE)
+            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE, session)
         current_app.logger.info(
             f"Management plan form rejected for item {item.id}.")
         return item
@@ -168,7 +168,7 @@ class ManagementPlanService:
         cls._log_management_plan_revision_required_activity(item, session)
         cls.deactivate_update_requests(item.package_id, session)
         cls._create_rejection_email_queue(
-            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE)
+            item.package_id, MANAGEMENT_PLAN_UPDATE_REQUEST_CREATED_EMAIL_TEMPLATE, session)
 
         # Make all package versions not enforceable
         package = PackageModel.find_by_id(item.package_id)
@@ -302,6 +302,6 @@ class ManagementPlanService:
         PackageVersionService.deactivate_update_requests(package_id, session, package)
 
     @classmethod
-    def _create_rejection_email_queue(cls, package_id, template_name):
+    def _create_rejection_email_queue(cls, package_id, template_name, session):
         """Create an email queue record for an update request."""
-        PackageVersionService.create_email_queue(package_id, template_name)
+        PackageVersionService.create_email_queue(package_id, template_name, session=session)

--- a/submit-api/src/submit_api/services/package_service.py
+++ b/submit-api/src/submit_api/services/package_service.py
@@ -341,7 +341,8 @@ class PackageService:
 
             PackageVersionService.create_email_queue(
                 new_package.id,
-                MANAGEMENT_PLAN_RESUBMISSION_REQUEST_EMAIL_TEMPLATE
+                MANAGEMENT_PLAN_RESUBMISSION_REQUEST_EMAIL_TEMPLATE,
+                session=session
             )
             # Set up the submitter information from the original package
             if original_package.submitted_by:

--- a/submit-api/src/submit_api/services/package_version_service.py
+++ b/submit-api/src/submit_api/services/package_version_service.py
@@ -167,6 +167,6 @@ class PackageVersionService:
         session.flush()
 
     @staticmethod
-    def create_email_queue(package_id, template_name):
+    def create_email_queue(package_id, template_name, session=None):
         """Create an email queue record."""
-        SubmitEmailQueueService.queue_package_email(package_id, template_name)
+        SubmitEmailQueueService.queue_package_email(package_id, template_name, session=session)

--- a/submit-api/src/submit_api/services/submission_review_service.py
+++ b/submit-api/src/submit_api/services/submission_review_service.py
@@ -146,7 +146,7 @@ class SubmissionReviewService:
             SubmissionItemType.CONSULTATION_RECORD.value,
         ):
             PackageVersionService.create_email_queue(
-                item.package_id, SUBMISSION_AWAITING_MANAGER_APPROVAL_EMAIL_TEMPLATE
+                item.package_id, SUBMISSION_AWAITING_MANAGER_APPROVAL_EMAIL_TEMPLATE, session=session
             )
         current_app.logger.info(f"Recommendation sent to manager for item {item_id}.")
         return item


### PR DESCRIPTION

Fix Submit email payload creation so submit-api writes complete email queue payloads for Common cron to send.

Changes

Load email sender and Submit web URL config in submit-api.
Wire SENDER_EMAIL, STAFF_SUPPORT_MAIL_ID, BASE_APP_URL, timezone, and BC Services Card URL into the submit-api Helm chart.
Validate sender, recipients, subject, and base URL before creating email queue rows.
Use the active DB session when queuing emails inside transactional review/update flows.