### PR TITLE
SUBMIT-896 Fix removal of early engagement submission files

### DIFF
--- a/submit-web/src/components/App/SubmissionItem/AdditionalInformation/ProponentView/index.tsx
+++ b/submit-web/src/components/App/SubmissionItem/AdditionalInformation/ProponentView/index.tsx
@@ -94,7 +94,12 @@ export const AdditionalInformationProponentView = () => {
 
   const handleCompleteForm = (formData: AdditionalInformationForm) => {
     if (!formData.uploadDocuments?.length) {
-      saveSubmission(formData, submissionItem?.status);
+      saveSubmission(
+        formData,
+        submissionItem?.status != SUBMISSION_ITEM_STATUS.COMPLETED.value
+          ? submissionItem?.status
+          : SUBMISSION_ITEM_STATUS.PARTIALLY_COMPLETED.value,
+      );
     } else {
       saveSubmission(formData, SUBMISSION_ITEM_STATUS.COMPLETED.value);
     }

--- a/submit-web/src/components/App/SubmissionItem/EPSubmission/EPProponentView/index.tsx
+++ b/submit-web/src/components/App/SubmissionItem/EPSubmission/EPProponentView/index.tsx
@@ -103,7 +103,9 @@ export const EngagementPlanProponentView = () => {
     if (!formData.engagementPlan?.length) {
       saveSubmission(
         formData,
-        SUBMISSION_ITEM_STATUS.PARTIALLY_COMPLETED.value,
+        submissionItem?.status != SUBMISSION_ITEM_STATUS.COMPLETED.value
+          ? submissionItem?.status
+          : SUBMISSION_ITEM_STATUS.PARTIALLY_COMPLETED.value,
       );
     } else {
       saveSubmission(formData, SUBMISSION_ITEM_STATUS.COMPLETED.value);
@@ -112,7 +114,7 @@ export const EngagementPlanProponentView = () => {
 
   const saveSubmission = async (
     _formData: EngagementPlanSubmissionForm,
-    status: SubmissionItemStatus,
+    status?: SubmissionItemStatus,
   ) => {
     try {
       setIsBackdropOpen(true);

--- a/submit-web/src/components/App/SubmissionItem/GeoSpatialInformation/GeoSpatialProponentView.tsx
+++ b/submit-web/src/components/App/SubmissionItem/GeoSpatialInformation/GeoSpatialProponentView.tsx
@@ -145,7 +145,12 @@ export const GeoSpatialProponentView = () => {
 
   const handleCompleteForm = (formData: GeoSpatialSubmissionForm) => {
     if (!formData.geospatial?.length) {
-      saveSubmission(formData, submissionItem?.status);
+      saveSubmission(
+        formData,
+        submissionItem?.status != SUBMISSION_ITEM_STATUS.COMPLETED.value
+          ? submissionItem?.status
+          : SUBMISSION_ITEM_STATUS.PARTIALLY_COMPLETED.value,
+      );
     } else {
       saveSubmission(formData, SUBMISSION_ITEM_STATUS.COMPLETED.value);
     }

--- a/submit-web/src/components/App/SubmissionItem/IPDSubmission/IPDProponentView/index.tsx
+++ b/submit-web/src/components/App/SubmissionItem/IPDSubmission/IPDProponentView/index.tsx
@@ -97,7 +97,12 @@ export const IPDSubmissionProponentView = () => {
 
   const handleCompleteForm = (formData: IPDSubmissionForm) => {
     if (!formData.ipd?.length) {
-      saveSubmission(formData, submissionItem?.status);
+      saveSubmission(
+        formData,
+        submissionItem?.status != SUBMISSION_ITEM_STATUS.COMPLETED.value
+          ? submissionItem?.status
+          : SUBMISSION_ITEM_STATUS.PARTIALLY_COMPLETED.value,
+      );
     } else {
       saveSubmission(formData, SUBMISSION_ITEM_STATUS.COMPLETED.value);
     }


### PR DESCRIPTION
Tickets: [SUBMIT-896](https://eao-dst.atlassian.net/browse/SUBMIT-896) Error message when trying to "save & exit" after deleting the only file in the section.

**Issue**
- Previously we updated the submission to allow items to "Save & Exit" when no required files are present. An edge case was still throwing an error when a user adds a file, clicks "Save & Exit", and then returns to the submission item and removes the file and then tries to "Save & Exit" again.
- The cause of the bug is that on the first save, the submission has a status of `COMPLETED`. When we remove the file, we were passing the previous submission status of `COMPLETED`, however now it was missing the required document.

**Fix**
- When a submission has a status of `COMPLETED`, but is missing a required doc, we pass `PARTIALLY_COMPLETED`.


[SUBMIT-896]: https://eao-dst.atlassian.net/browse/SUBMIT-896?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ