### PR TITLE
SUBMIT-945 add canonical status ordering, overlay suppression, and MP/IEM progress logic

### DIFF
--- a/submit-api/src/submit_api/models/queries/account_project.py
+++ b/submit-api/src/submit_api/models/queries/account_project.py
@@ -148,10 +148,6 @@ class ProjectQueries:
 
         # Staff path: pre-compute full visible list, then slice for requested page
         if not is_proponent and page and page_size:
-            # FULL_ACCESS optimization: skip package filtering entirely
-            if jwt.contains_role([EpicSubmitRole.FULL_ACCESS.value]):
-                return cls._get_full_access_paginated(search_options, page, page_size, user)
-
             # Non-FULL_ACCESS staff: pre-compute visible projects, then slice
             visible_projects = cls._get_staff_visible_projects(
                 search_options, is_proponent, user
@@ -229,34 +225,6 @@ class ProjectQueries:
             offset += BATCH_SIZE
 
         return visible_projects
-
-    @classmethod
-    def _get_full_access_paginated(
-        cls,
-        search_options: AccountProjectSearchOptions,
-        page: int,
-        page_size: int,
-        user: User
-    ) -> tuple:
-        """Optimized path for FULL_ACCESS staff — no package filtering needed."""
-        query = cls._filter_by_search_criteria(search_options)
-        ordered_query = (
-            query
-            .add_columns(Project.name)
-            .order_by(Project.name)
-            .distinct()
-        )
-        paginated_result = ordered_query.paginate(page=page, per_page=page_size)
-        account_projects = [ap for ap, _ in paginated_result.items]
-        total = paginated_result.total
-
-        account_projects_list = cls.get_full_account_projects(False, account_projects)
-        # FULL_ACCESS sees all packages — _filter_packages_by_user_access is a no-op
-        account_projects_list = cls._filter_packages_by_user_access(
-            account_projects_list, user
-        )
-
-        return account_projects_list, total
 
     @classmethod
     def _filter_by_search_criteria(cls, search_options: AccountProjectSearchOptions):

--- a/submit-api/src/submit_api/models/queries/package.py
+++ b/submit-api/src/submit_api/models/queries/package.py
@@ -15,6 +15,7 @@
 from sqlalchemy import func
 from submit_api.enums.item_status import ItemStatus
 from submit_api.enums.package_type import PackageApprovalType
+from submit_api.utils.constants import MP_VIEW_PACKAGE_TYPES
 from submit_api.models import AccountProject, db
 from submit_api.models.package import Package as PackageModel
 from submit_api.models.package import PackageStatus
@@ -205,11 +206,13 @@ class PackageItemQueries:
                 PackageStatus.MP_AWAITING_MANAGER_APPROVAL.value)
 
     @classmethod
-    def _add_awaiting_iem_manager_review(cls, aggregated_statuses: set, statuses: list[str]):
-        """Find packages that have been rejected during review"""
-        if any(status == ItemStatus.IEM_AWAITING_MANAGER_APPROVAL.value for status in statuses):
-            aggregated_statuses.add(
-                PackageStatus.IEM_AWAITING_MANAGER_APPROVAL.value)
+    def _add_in_progress_status_for_mp_iem(cls, aggregated_statuses: set, statuses: list[str]):
+        """Add IN_PROGRESS for MP/IEM packages when any item has moved beyond NEW."""
+        if PackageStatus.SUBMITTED.value in aggregated_statuses:
+            return
+        progress_statuses = (ItemStatus.PARTIALLY_COMPLETED.value, ItemStatus.COMPLETED.value)
+        if any(status in progress_statuses for status in statuses):
+            aggregated_statuses.add(PackageStatus.IN_PROGRESS.value)
 
     @classmethod
     def aggregate_item_statuses(cls, items: list):
@@ -230,10 +233,20 @@ class PackageItemQueries:
         if aggregated_statuses:
             return list(aggregated_statuses)
 
+        # Determine if package is MP or IEM (use IN_PROGRESS instead of PARTIALLY_COMPLETED/COMPLETED)
+        is_mp_or_iem = False
+        if items:
+            package = PackageModel.find_by_id(items[0].package_id)
+            if package and package.type:
+                is_mp_or_iem = package.type.name in MP_VIEW_PACKAGE_TYPES
+
         # Completion/submission statuses check only required items
         cls._add_submitted_status(aggregated_statuses, required_statuses, all_statuses)
-        cls._add_partially_completed_status(aggregated_statuses, required_statuses)
-        cls._add_completed_status(aggregated_statuses, required_statuses)
+        if is_mp_or_iem:
+            cls._add_in_progress_status_for_mp_iem(aggregated_statuses, required_statuses)
+        else:
+            cls._add_partially_completed_status(aggregated_statuses, required_statuses)
+            cls._add_completed_status(aggregated_statuses, required_statuses)
 
         # Other statuses check all items
         cls._add_passed_consultation_check(aggregated_statuses, all_statuses)

--- a/submit-api/src/submit_api/services/email_queue_service.py
+++ b/submit-api/src/submit_api/services/email_queue_service.py
@@ -33,7 +33,7 @@ from submit_api.utils.constants import (
 )
 
 
-EAO_MANAGER_GROUP_PATH = "SUBMIT/EAO_MANAGER"
+EAO_MANAGER_GROUP_PATH = "SUBMIT/MPT_MANAGER"
 
 
 class SubmitEmailQueueService:

--- a/submit-api/src/submit_api/services/item_service.py
+++ b/submit-api/src/submit_api/services/item_service.py
@@ -6,6 +6,7 @@ from submit_api.models import Item as ItemModel
 from submit_api.models import Package as PackageModel
 from submit_api.models.queries.package import PackageItemQueries, PackageSubmissionQueries
 from submit_api.services import authorization
+from submit_api.utils.constants import  MP_VIEW_PACKAGE_TYPES
 
 
 class ItemService:
@@ -48,7 +49,7 @@ class ItemService:
         derived from submission states, not item states.
         """
         package = PackageModel.find_by_id(package_id)
-        if package and package.type.name == 'Management Plan':
+        if package and package.type.name in MP_VIEW_PACKAGE_TYPES:
             PackageItemQueries.update_package_status(package_id, session)
         else:
             PackageSubmissionQueries.update_package_status_from_submissions(package_id, session, package)

--- a/submit-api/src/submit_api/services/package_service.py
+++ b/submit-api/src/submit_api/services/package_service.py
@@ -44,6 +44,25 @@ from submit_api.utils.constants import (
 from submit_api.utils.token_info import TokenInfo
 from submit_api.services.package_version_service import PackageVersionService
 
+# Canonical chip display order (D9).
+# Primary status first, then review stream, then overlays last.
+# Rule: Passed Consultation Check must never sort before Under Consultation Check.
+CANONICAL_STATUS_ORDER = (
+    # Primary / base statuses
+    'NEW', 'CREATED', 'IN_PROGRESS', 'SUBMITTED', 'NEW_SUBMISSION', 'RESUBMITTED',
+    # Terminal outcomes
+    'APPROVED', 'ACCEPTED', 'SATISFIED', 'REVIEWED', 'NO_REVISION_REQUIRED',
+    'VERIFIED', 'ACKNOWLEDGED', 'NOT_APPROVED', 'REVIEW_REJECTED', 'WITHDRAWN',
+    # Review stream statuses
+    'UNDER_CONSULTATION_CHECK', 'PASSED_CONSULTATION_CHECK',
+    'UNDER_REVIEW', 'AWAITING_MANAGER_APPROVAL',
+    # Acknowledgement stream
+    'INTERNAL_VERIFICATION', 'PENDING_ACKNOWLEDGEMENT',
+    'READY_FOR_ACKNOWLEDGEMENT', 'READY_FOR_APPROVAL',
+    # Overlays (always last)
+    'UPDATE_REQUESTED', 'REVISION_REQUIRED', 'REVISION_REQUESTED', 'UPDATED',
+)
+
 
 class PackageService:
     """Package management service."""
@@ -182,16 +201,23 @@ class PackageService:
     @staticmethod
     def _add_noncanonical_statuses(new_status, has_open_update_request, has_updated_submission,
                                    has_revision_required, user_type):
-        """Add noncanonical statuses to the status list."""
-        if has_open_update_request:
-            new_status.append(NonCanonicalPackageStatus.UPDATE_REQUESTED.value)
+        """Add noncanonical statuses to the status list.
+
+        Suppression rules (D16):
+        - When UPDATED is present, UPDATE_REQUESTED and REVISION are hidden.
+        - Per-audience: entity sees REVISION_REQUIRED, EAO sees REVISION_REQUESTED.
+        """
         if has_updated_submission:
+            # Updated suppresses both Update Requested and Revision overlays
             new_status.append(NonCanonicalPackageStatus.UPDATED.value)
-        if has_revision_required:
-            status_to_add = (NonCanonicalPackageStatus.REVISION_REQUIRED.value
-                             if user_type == UserType.PROPONENT
-                             else NonCanonicalPackageStatus.REVISION_REQUESTED.value)
-            new_status.append(status_to_add)
+        else:
+            if has_open_update_request:
+                new_status.append(NonCanonicalPackageStatus.UPDATE_REQUESTED.value)
+            if has_revision_required:
+                status_to_add = (NonCanonicalPackageStatus.REVISION_REQUIRED.value
+                                 if user_type == UserType.PROPONENT
+                                 else NonCanonicalPackageStatus.REVISION_REQUESTED.value)
+                new_status.append(status_to_add)
 
     @staticmethod
     def _deduplicate_statuses(statuses):
@@ -203,6 +229,15 @@ class PackageService:
                 seen.add(status)
                 deduped.append(status)
         return deduped
+
+    @staticmethod
+    def _sort_statuses(statuses):
+        """Sort statuses in canonical D9 order."""
+        max_index = len(CANONICAL_STATUS_ORDER)
+        return sorted(
+            statuses,
+            key=lambda s: CANONICAL_STATUS_ORDER.index(s) if s in CANONICAL_STATUS_ORDER else max_index
+        )
 
     @staticmethod
     def calculate_package_statuses(package, user_type):
@@ -227,16 +262,23 @@ class PackageService:
 
         has_revision_required, has_updated_submission = PackageService._check_item_conditions(package)
         has_open_update_request = any(
-            ur.active and ur.status == 'OPEN'
+            ur.active and ur.status == 'OPEN' and ur.type == UpdateRequestType.UPDATE
             for ur in package.update_requests
         )
+        has_open_review_request = any(
+            ur.active and ur.status == 'OPEN' and ur.type == UpdateRequestType.REVIEW
+            for ur in package.update_requests
+        )
+        # A REVIEW-type open request also signals revision required (for the new version package)
+        if has_open_review_request:
+            has_revision_required = True
 
         PackageService._add_noncanonical_statuses(
             new_status, has_open_update_request, has_updated_submission,
             has_revision_required, user_type
         )
 
-        return PackageService._deduplicate_statuses(new_status)
+        return PackageService._sort_statuses(PackageService._deduplicate_statuses(new_status))
 
     @classmethod
     def get_package_by_id(cls, package_id):

--- a/submit-api/tests/unit/models/queries/test_package_item_queries.py
+++ b/submit-api/tests/unit/models/queries/test_package_item_queries.py
@@ -1,0 +1,178 @@
+"""Unit tests for PackageItemQueries.aggregate_item_statuses.
+
+Tests for D1/D21: MP and IEM packages produce IN_PROGRESS instead of
+PARTIALLY_COMPLETED/COMPLETED at the package level.
+"""
+from unittest.mock import Mock, patch
+
+from submit_api.enums.item_status import ItemStatus
+from submit_api.models.package import PackageStatus
+from submit_api.models.queries.package import PackageItemQueries
+
+MODULE_PATH = "submit_api.models.queries.package"
+
+
+def _make_item(status_value, type_id=1, package_id=1, submissions=None):
+    """Create a mock item with the given status."""
+    item = Mock()
+    item.status = ItemStatus(status_value)
+    item.type_id = type_id
+    item.package_id = package_id
+    item.submissions = submissions or []
+    return item
+
+
+def _make_package(type_name, type_id=1, submitted_on=None):
+    """Create a mock package with the given type."""
+    package = Mock()
+    package.type = Mock()
+    package.type.name = type_name
+    package.type_id = type_id
+    package.submitted_on = submitted_on
+    return package
+
+
+def _make_package_item_type(item_type_id, is_required=True):
+    """Create a mock PackageItemType."""
+    pit = Mock()
+    pit.item_type_id = item_type_id
+    pit.is_required = is_required
+    return pit
+
+
+class TestMPIEMInProgressStatus:
+    """Tests for MP/IEM packages producing IN_PROGRESS."""
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_mp_partially_completed_item_produces_in_progress(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """MP package with PARTIALLY_COMPLETED item produces IN_PROGRESS."""
+        package = _make_package("Management Plan")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [_make_package_item_type(1, is_required=True)]
+
+        items = [_make_item(ItemStatus.PARTIALLY_COMPLETED.value, type_id=1)]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.IN_PROGRESS.value in result
+        assert PackageStatus.PARTIALLY_COMPLETED.value not in result
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_mp_all_items_completed_produces_in_progress(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """MP package with all items COMPLETED produces IN_PROGRESS, not COMPLETED."""
+        package = _make_package("Management Plan")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [
+            _make_package_item_type(1, is_required=True),
+            _make_package_item_type(2, is_required=True),
+        ]
+
+        items = [
+            _make_item(ItemStatus.COMPLETED.value, type_id=1),
+            _make_item(ItemStatus.COMPLETED.value, type_id=2),
+        ]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.IN_PROGRESS.value in result
+        assert PackageStatus.COMPLETED.value not in result
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_iem_partially_completed_item_produces_in_progress(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """IEM package with PARTIALLY_COMPLETED item produces IN_PROGRESS."""
+        package = _make_package("IEM")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [_make_package_item_type(1, is_required=True)]
+
+        items = [_make_item(ItemStatus.PARTIALLY_COMPLETED.value, type_id=1)]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.IN_PROGRESS.value in result
+        assert PackageStatus.PARTIALLY_COMPLETED.value not in result
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_mp_submitted_status_takes_priority_over_in_progress(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """MP package with all required items SUBMITTED does not produce IN_PROGRESS."""
+        package = _make_package("Management Plan")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [_make_package_item_type(1, is_required=True)]
+
+        items = [_make_item(ItemStatus.SUBMITTED.value, type_id=1)]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.SUBMITTED.value in result
+        assert PackageStatus.IN_PROGRESS.value not in result
+
+
+class TestNonMPIEMPackagesUnchanged:
+    """Tests that non-MP/IEM packages still use PARTIALLY_COMPLETED/COMPLETED."""
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_additional_info_partially_completed_still_works(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """Additional Information package still produces PARTIALLY_COMPLETED."""
+        package = _make_package("Additional Information")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [_make_package_item_type(1, is_required=True)]
+
+        items = [_make_item(ItemStatus.PARTIALLY_COMPLETED.value, type_id=1)]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.PARTIALLY_COMPLETED.value in result
+        assert PackageStatus.IN_PROGRESS.value not in result
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_additional_info_completed_still_works(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """Additional Information package still produces COMPLETED."""
+        package = _make_package("Additional Information")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [_make_package_item_type(1, is_required=True)]
+
+        items = [_make_item(ItemStatus.COMPLETED.value, type_id=1)]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.COMPLETED.value in result
+        assert PackageStatus.IN_PROGRESS.value not in result
+
+
+class TestMPIEMNewItemsProduceEmpty:
+    """Tests that MP/IEM packages with only NEW items produce no special status."""
+
+    @patch(f"{MODULE_PATH}.PackageItemType.get_by_package_type_id")
+    @patch(f"{MODULE_PATH}.PackageModel.find_by_id")
+    def test_mp_all_items_new_produces_empty(
+        self, mock_find_by_id, mock_get_pit
+    ):
+        """MP package with all items in NEW produces no completion/progress status."""
+        package = _make_package("Management Plan")
+        mock_find_by_id.return_value = package
+        mock_get_pit.return_value = [_make_package_item_type(1, is_required=True)]
+
+        items = [_make_item(ItemStatus.NEW.value, type_id=1)]
+
+        result = PackageItemQueries.aggregate_item_statuses(items)
+
+        assert PackageStatus.IN_PROGRESS.value not in result
+        assert PackageStatus.PARTIALLY_COMPLETED.value not in result
+        assert PackageStatus.COMPLETED.value not in result

--- a/submit-api/tests/unit/models/queries/test_staff_pagination.py
+++ b/submit-api/tests/unit/models/queries/test_staff_pagination.py
@@ -298,26 +298,6 @@ def test_total_equals_visible_count(mock_visible, mock_role, mock_get_user, mock
 
 @patch(f"{MODULE_PATH}.TokenInfo.get_username", return_value="test-user")
 @patch(f"{MODULE_PATH}.User.get_by_guid")
-@patch.object(ProjectQueries, "_get_full_access_paginated")
-@patch(f"{MODULE_PATH}.jwt.contains_role", return_value=True)
-def test_full_access_uses_optimized_path(mock_role, mock_paginated, mock_get_user, mock_username):
-    """Test that FULL_ACCESS staff users use the optimized paginate path."""
-    mock_user = Mock()
-    mock_get_user.return_value = mock_user
-    expected_projects = [{"id": 1, "name": "Project 1", "packages": [{"id": 1}]}]
-    mock_paginated.return_value = (expected_projects, 1)
-
-    result, total = ProjectQueries.get_filtered_account_projects_paginated(
-        search_options=None, page=1, page_size=5, is_proponent=False, user=mock_user
-    )
-
-    mock_paginated.assert_called_once_with(None, 1, 5, mock_user)
-    assert result == expected_projects
-    assert total == 1
-
-
-@patch(f"{MODULE_PATH}.TokenInfo.get_username", return_value="test-user")
-@patch(f"{MODULE_PATH}.User.get_by_guid")
 @patch(f"{MODULE_PATH}.jwt.contains_role", return_value=False)
 @patch.object(ProjectQueries, "_get_staff_visible_projects")
 def test_zero_visible_projects(mock_visible, mock_role, mock_get_user, mock_username):

--- a/submit-api/tests/unit/services/test_canonical_status_order.py
+++ b/submit-api/tests/unit/services/test_canonical_status_order.py
@@ -1,0 +1,71 @@
+"""Unit tests for canonical D9 status ordering in PackageService._sort_statuses."""
+from submit_api.services.package_service import PackageService
+
+
+class TestCanonicalStatusOrdering:
+    """Tests for D9 canonical status ordering."""
+
+    def test_overlays_always_sort_last(self):
+        """Update Requested, Revision Required, Updated always come after primary statuses."""
+        statuses = ['UPDATE_REQUESTED', 'SUBMITTED', 'UNDER_REVIEW']
+        result = PackageService._sort_statuses(statuses)
+        assert result == ['SUBMITTED', 'UNDER_REVIEW', 'UPDATE_REQUESTED']
+
+    def test_review_stream_order_preserved(self):
+        """Under CC, Passed CC, Under Review, Awaiting Manager Approval in correct order."""
+        statuses = [
+            'AWAITING_MANAGER_APPROVAL', 'UNDER_REVIEW',
+            'PASSED_CONSULTATION_CHECK', 'UNDER_CONSULTATION_CHECK'
+        ]
+        result = PackageService._sort_statuses(statuses)
+        assert result == [
+            'UNDER_CONSULTATION_CHECK', 'PASSED_CONSULTATION_CHECK',
+            'UNDER_REVIEW', 'AWAITING_MANAGER_APPROVAL'
+        ]
+
+    def test_passed_cc_never_before_under_cc(self):
+        """Passed Consultation Check never sorts before Under Consultation Check."""
+        statuses = ['PASSED_CONSULTATION_CHECK', 'UNDER_CONSULTATION_CHECK']
+        result = PackageService._sort_statuses(statuses)
+        under_idx = result.index('UNDER_CONSULTATION_CHECK')
+        passed_idx = result.index('PASSED_CONSULTATION_CHECK')
+        assert under_idx < passed_idx
+
+    def test_primary_status_before_review_stream(self):
+        """Primary status (Submitted) comes before review stream statuses."""
+        statuses = ['UNDER_REVIEW', 'AWAITING_MANAGER_APPROVAL', 'SUBMITTED']
+        result = PackageService._sort_statuses(statuses)
+        assert result[0] == 'SUBMITTED'
+
+    def test_multiple_overlays_maintain_internal_order(self):
+        """Multiple overlays maintain their canonical internal order."""
+        statuses = ['UPDATED', 'REVISION_REQUIRED', 'UPDATE_REQUESTED', 'SUBMITTED']
+        result = PackageService._sort_statuses(statuses)
+        assert result == ['SUBMITTED', 'UPDATE_REQUESTED', 'REVISION_REQUIRED', 'UPDATED']
+
+    def test_single_status_unchanged(self):
+        """A single status is returned as-is."""
+        assert PackageService._sort_statuses(['IN_PROGRESS']) == ['IN_PROGRESS']
+
+    def test_empty_list_unchanged(self):
+        """An empty list is returned as-is."""
+        assert PackageService._sort_statuses([]) == []
+
+    def test_unknown_status_goes_to_end(self):
+        """Statuses not in the canonical order go to the end."""
+        statuses = ['SOME_UNKNOWN', 'SUBMITTED', 'UNDER_REVIEW']
+        result = PackageService._sort_statuses(statuses)
+        assert result[-1] == 'SOME_UNKNOWN'
+        assert result[0] == 'SUBMITTED'
+
+    def test_full_example_with_all_groups(self):
+        """Full example with primary, review stream, and overlay statuses."""
+        statuses = [
+            'REVISION_REQUESTED', 'UNDER_CONSULTATION_CHECK',
+            'SUBMITTED', 'UNDER_REVIEW', 'UPDATED'
+        ]
+        result = PackageService._sort_statuses(statuses)
+        assert result == [
+            'SUBMITTED', 'UNDER_CONSULTATION_CHECK',
+            'UNDER_REVIEW', 'REVISION_REQUESTED', 'UPDATED'
+        ]

--- a/submit-api/tests/unit/services/test_overlay_suppression.py
+++ b/submit-api/tests/unit/services/test_overlay_suppression.py
@@ -1,0 +1,85 @@
+"""Unit tests for overlay suppression rules in PackageService._add_noncanonical_statuses."""
+from submit_api.models.package import NonCanonicalPackageStatus
+from submit_api.models.user import UserType
+from submit_api.services.package_service import PackageService
+
+
+class TestOverlaySuppression:
+    """Tests for D16 overlay suppression: Updated hides Update Requested and Revision."""
+
+    def test_updated_suppresses_update_requested(self):
+        """When Updated is present, Update Requested is hidden."""
+        statuses = []
+        PackageService._add_noncanonical_statuses(
+            statuses,
+            has_open_update_request=True,
+            has_updated_submission=True,
+            has_revision_required=False,
+            user_type=UserType.STAFF
+        )
+        assert NonCanonicalPackageStatus.UPDATED.value in statuses
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value not in statuses
+
+    def test_updated_suppresses_revision_requested(self):
+        """When Updated is present, Revision Requested is hidden for staff."""
+        statuses = []
+        PackageService._add_noncanonical_statuses(
+            statuses,
+            has_open_update_request=False,
+            has_updated_submission=True,
+            has_revision_required=True,
+            user_type=UserType.STAFF
+        )
+        assert NonCanonicalPackageStatus.UPDATED.value in statuses
+        assert NonCanonicalPackageStatus.REVISION_REQUESTED.value not in statuses
+
+    def test_updated_suppresses_revision_required_for_proponent(self):
+        """When Updated is present, Revision Required is hidden for proponent."""
+        statuses = []
+        PackageService._add_noncanonical_statuses(
+            statuses,
+            has_open_update_request=True,
+            has_updated_submission=True,
+            has_revision_required=True,
+            user_type=UserType.PROPONENT
+        )
+        assert NonCanonicalPackageStatus.UPDATED.value in statuses
+        assert NonCanonicalPackageStatus.REVISION_REQUIRED.value not in statuses
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value not in statuses
+
+    def test_no_updated_shows_update_requested(self):
+        """Without Updated, Update Requested appears normally."""
+        statuses = []
+        PackageService._add_noncanonical_statuses(
+            statuses,
+            has_open_update_request=True,
+            has_updated_submission=False,
+            has_revision_required=False,
+            user_type=UserType.STAFF
+        )
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value in statuses
+        assert NonCanonicalPackageStatus.UPDATED.value not in statuses
+
+    def test_no_updated_shows_revision_required_for_proponent(self):
+        """Without Updated, Revision Required appears for proponent."""
+        statuses = []
+        PackageService._add_noncanonical_statuses(
+            statuses,
+            has_open_update_request=False,
+            has_updated_submission=False,
+            has_revision_required=True,
+            user_type=UserType.PROPONENT
+        )
+        assert NonCanonicalPackageStatus.REVISION_REQUIRED.value in statuses
+
+    def test_no_updated_shows_revision_requested_for_staff(self):
+        """Without Updated, Revision Requested appears for staff."""
+        statuses = []
+        PackageService._add_noncanonical_statuses(
+            statuses,
+            has_open_update_request=False,
+            has_updated_submission=False,
+            has_revision_required=True,
+            user_type=UserType.STAFF
+        )
+        assert NonCanonicalPackageStatus.REVISION_REQUESTED.value in statuses

--- a/submit-api/tests/unit/services/test_revision_wording.py
+++ b/submit-api/tests/unit/services/test_revision_wording.py
@@ -1,0 +1,120 @@
+"""Unit tests for per-audience revision wording in calculate_package_statuses.
+
+Tests for the scenario where a Management Plan review fails and a revision
+is requested (REVIEW-type update request on new package version):
+
+Expected behaviour:
+- New package (open REVIEW-type update request, items in NEW status):
+  - Entity sees: Revision Required
+  - EAO sees: Revision Requested
+- Old package (item in REVIEW_REJECTED, no open requests):
+  - Entity sees: Revision Required  (via canonical mapping REVIEW_REJECTED -> REVISION_REQUIRED)
+  - EAO sees: Review Rejected  (canonical)
+"""
+from unittest.mock import Mock, patch
+
+from submit_api.models.package import NonCanonicalPackageStatus, PackageStatus
+from submit_api.models.update_request import UpdateRequestType, UpdateRequestStatus
+from submit_api.models.user import UserType
+from submit_api.services.package_service import PackageService
+
+MODULE_PATH = "submit_api.services.package_service"
+
+
+def _make_package(canonical_statuses, update_requests=None, version=1):
+    """Create a mock package for calculate_package_statuses."""
+    package = Mock()
+    package.status = [s for s in canonical_statuses]
+    package.update_requests = update_requests or []
+    package.items = []
+    version_mock = Mock()
+    version_mock.version = version
+    package.version = version_mock
+    return package
+
+
+def _make_update_request(request_type, is_active=True, status=UpdateRequestStatus.OPEN.value):
+    """Create a mock UpdateRequest."""
+    ur = Mock()
+    ur.type = request_type
+    ur.active = is_active
+    ur.status = status
+    return ur
+
+
+class TestNewPackageRevisionWording:
+    """New version package with open REVIEW-type request."""
+
+    def test_entity_sees_revision_required_on_new_package(self):
+        """Entity sees Revision Required when new package has open REVIEW-type request."""
+        review_request = _make_update_request(UpdateRequestType.REVIEW)
+        package = _make_package(
+            canonical_statuses=[PackageStatus.NEW.value],
+            update_requests=[review_request],
+        )
+
+        result = PackageService.calculate_package_statuses(package, UserType.PROPONENT)
+
+        assert NonCanonicalPackageStatus.REVISION_REQUIRED.value in result
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value not in result
+
+    def test_eao_sees_revision_requested_on_new_package(self):
+        """EAO sees Revision Requested when new package has open REVIEW-type request."""
+        review_request = _make_update_request(UpdateRequestType.REVIEW)
+        package = _make_package(
+            canonical_statuses=[PackageStatus.NEW.value],
+            update_requests=[review_request],
+        )
+
+        result = PackageService.calculate_package_statuses(package, UserType.STAFF)
+
+        assert NonCanonicalPackageStatus.REVISION_REQUESTED.value in result
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value not in result
+
+    def test_update_type_request_shows_update_requested_for_both(self):
+        """UPDATE-type request shows Update Requested for both entity and EAO."""
+        update_request = _make_update_request(UpdateRequestType.UPDATE)
+        package = _make_package(
+            canonical_statuses=[PackageStatus.SUBMITTED.value],
+            update_requests=[update_request],
+        )
+
+        result_proponent = PackageService.calculate_package_statuses(package, UserType.PROPONENT)
+        result_staff = PackageService.calculate_package_statuses(package, UserType.STAFF)
+
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value in result_proponent
+        assert NonCanonicalPackageStatus.REVISION_REQUIRED.value not in result_proponent
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value in result_staff
+        assert NonCanonicalPackageStatus.REVISION_REQUESTED.value not in result_staff
+
+    def test_closed_review_request_does_not_trigger_revision(self):
+        """A closed/deactivated REVIEW-type request does not show revision overlay."""
+        closed_request = _make_update_request(
+            UpdateRequestType.REVIEW,
+            is_active=False,
+            status=UpdateRequestStatus.CLOSED.value
+        )
+        package = _make_package(
+            canonical_statuses=[PackageStatus.NEW.value],
+            update_requests=[closed_request],
+        )
+
+        result = PackageService.calculate_package_statuses(package, UserType.PROPONENT)
+
+        assert NonCanonicalPackageStatus.REVISION_REQUIRED.value not in result
+
+    def test_both_update_and_review_requests_review_wins_for_revision(self):
+        """When both UPDATE and REVIEW requests are open, revision takes precedence over update."""
+        review_request = _make_update_request(UpdateRequestType.REVIEW)
+        update_request = _make_update_request(UpdateRequestType.UPDATE)
+        package = _make_package(
+            canonical_statuses=[PackageStatus.NEW.value],
+            update_requests=[review_request, update_request],
+        )
+
+        result_staff = PackageService.calculate_package_statuses(package, UserType.STAFF)
+
+        # REVIEW request forces revision_required = True
+        assert NonCanonicalPackageStatus.REVISION_REQUESTED.value in result_staff
+        # UPDATE request also present
+        assert NonCanonicalPackageStatus.UPDATE_REQUESTED.value in result_staff

--- a/submit-web/src/components/App/PackageStatusChip/index.tsx
+++ b/submit-web/src/components/App/PackageStatusChip/index.tsx
@@ -25,7 +25,7 @@ const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
     VERIFIED: { label: "Verified", theme: "success" },
     ACKNOWLEDGED: { label: "Acknowledged", theme: "success" },
 
-    IN_PROGRESS: { label: "In Progress", theme: "info" },
+    IN_PROGRESS: { label: "In Progress", theme: "warning" },
     IN_REVIEW: { label: "In Review", theme: "info" },
     UNDER_REVIEW: { label: "Under Review", theme: "info" },
     UNDER_CONSULTATION_CHECK: {
@@ -66,7 +66,7 @@ const statusMap: Record<PackageStatus | NonCanonicalPackageStatus, StyleProps> =
 
     AWAITING_MANAGER_APPROVAL: {
       label: "Awaiting Manager Approval",
-      theme: "orange",
+      theme: "purple",
     },
     UPDATE_REQUESTED: {
       label: "Update Requested",

--- a/submit-web/src/components/App/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
+++ b/submit-web/src/components/App/Submission/SubmissionItemTableRow/ProponentSubmissionItemTableRow.tsx
@@ -22,9 +22,6 @@ import {
 import { SubmissionItemMethod } from "@/models/SubmissionItem";
 import { useMemo } from "react";
 import { getSubmissionItemLabel } from "@/utils";
-import {
-  UPDATE_REQUEST_STATUS,
-} from "@/models/UpdateRequest";
 import { SUBMISSION_TYPE } from "@/models/Submission";
 import { useSubmitAvailability } from "@/hooks/useSubmitAvailability";
 
@@ -38,7 +35,7 @@ export default function ProponentSubmissionItemTableRow({
     from: "/proponent/_proponentLayout/projects/$projectId/_projectLayout/submission-packages/$submissionPackageId/_submissionLayout",
   });
 
-  const { id, submissions, status, type_id } = item;
+  const { id, submissions, status } = item;
 
   const isIPD = packageType.name === SubmissionPackageType.IPD;
 
@@ -56,28 +53,11 @@ export default function ProponentSubmissionItemTableRow({
       .queryKey,
   );
 
-  const hasOpenUpdateRequest = useMemo(() => {
-    if (!submissionPackage) return false;
-    return submissionPackage.update_requests.some(
-      (updateRequest) =>
-        updateRequest.status === UPDATE_REQUEST_STATUS.OPEN.value &&
-        updateRequest.active &&
-        updateRequest.submission_item_types.includes(type_id),
-    );
-  }, [submissionPackage, type_id]);
-
   const { isSubmitDisabled } = useSubmitAvailability(submissionPackage);
 
   const hasAccountProjectWork = Boolean(
     submissionPackage?.account_project_work?.id,
   );
-
-  const isUpdated = useMemo(() => {
-    // Check if any submission in this section has is_updated flag set to true
-    return Boolean(
-      item.submissions?.find((submission) => submission.is_updated)
-    );
-  }, [item.submissions]);
 
   const actionLabel = has_document ? "Add/Edit Files" : "Fill/Edit Form";
 
@@ -116,8 +96,6 @@ export default function ProponentSubmissionItemTableRow({
           <Box ml={1} display={"flex"} justifyContent={"flex-start"}>
             <SubmissionStatusChipStack
               status={status}
-              isUpdateRequested={hasOpenUpdateRequest}
-              isUpdated={isUpdated}
               packageStatus={submissionPackage?.status}
               showOnlyUpdateChips={hasAccountProjectWork}
             />

--- a/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
+++ b/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/CRStaffCell.tsx
@@ -11,15 +11,11 @@ import {
 
 type CRStaffCellProps = Readonly<{
   status?: SubmissionItemStatus;
-  isUpdateRequested: boolean;
-  isUpdated: boolean;
   packageStatus: PackageStatus[];
   submissionItemId: number;
 }>;
 export const CRStaffCell = ({
   status,
-  isUpdateRequested,
-  isUpdated,
   packageStatus,
   submissionItemId,
 }: CRStaffCellProps) => {
@@ -29,8 +25,6 @@ export const CRStaffCell = ({
     <>
       <SubmissionStatusChipStack
         status={status}
-        isUpdateRequested={isUpdateRequested}
-        isUpdated={isUpdated}
         packageStatus={packageStatus}
       />
       {failedSubmissions && failedSubmissions.length > 0 && (

--- a/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
+++ b/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/StaffStatusCell/index.tsx
@@ -2,9 +2,7 @@ import { Stack } from "@mui/material";
 import { useParams } from "@tanstack/react-router";
 import { getStaffSubmissionPackageQueryOptions } from "@/hooks/api/usePackages";
 import { SUBMISSION_ITEM_TYPE, SubmissionItem } from "@/models/SubmissionItem";
-import { useMemo } from "react";
 import { useSuspenseQuery } from "@tanstack/react-query";
-import { filterOpenUpdateRequests } from "@/utils";
 import { SubmissionStatusChipStack } from "@/components/App/SubmissionStatusChip";
 import { Case, Default, Switch } from "react-if";
 import { CRStaffCell } from "./CRStaffCell";
@@ -24,21 +22,7 @@ export default function StaffStatusCell({
       }),
     );
 
-  const { status, type_id, type } = submissionItem;
-
-  const isUpdated = useMemo(() => {
-    // Check if any submission in this section has is_updated flag set to true
-    return Boolean(
-      submissionItem.submissions?.find((submission) => submission.is_updated)
-    );
-  }, [submissionItem.submissions]);
-
-  const isUpdateRequest = useMemo(() => {
-    if (!submissionPackage) return false;
-    return filterOpenUpdateRequests(submissionPackage.update_requests)
-      .flatMap((updateRequest) => updateRequest.submission_item_types)
-      .includes(type_id);
-  }, [submissionPackage, type_id]);
+  const { status, type } = submissionItem;
 
   if (isPackagePending) {
     return null;
@@ -58,8 +42,6 @@ export default function StaffStatusCell({
         >
           <CRStaffCell
             status={status}
-            isUpdateRequested={isUpdateRequest}
-            isUpdated={isUpdated}
             packageStatus={submissionPackage.status}
             submissionItemId={submissionItem.id}
           />
@@ -67,8 +49,6 @@ export default function StaffStatusCell({
         <Default>
           <SubmissionStatusChipStack
             status={status}
-            isUpdateRequested={isUpdateRequest}
-            isUpdated={isUpdated}
             packageStatus={submissionPackage.status}
           />
         </Default>

--- a/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/index.test.tsx
+++ b/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/index.test.tsx
@@ -1,0 +1,301 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import StaffSubmissionItemTableRow from "./index";
+import { SubmissionItem, SubmissionItemMethod, SUBMISSION_ITEM_TYPE } from "@/models/SubmissionItem";
+import { PackageType } from "@/models/Package";
+
+// ── Module mocks ────────────────────────────────────────────────────────────
+
+vi.mock("@tanstack/react-router", () => ({
+  useNavigate: () => vi.fn(),
+  useParams: () => ({ projectId: "1", submissionPackageId: "10" }),
+}));
+
+const mockUseHasRole = vi.fn();
+vi.mock("@/hooks/common", () => ({
+  useHasRole: (...args: unknown[]) => mockUseHasRole(...args),
+}));
+
+const mockUsePackageRoles = vi.fn();
+vi.mock("@/hooks/usePackageRoles", () => ({
+  usePackageRoles: (...args: unknown[]) => mockUsePackageRoles(...args),
+}));
+
+// useSuspenseQuery is used to fetch the submission package
+const mockUseSuspenseQuery = vi.fn();
+vi.mock("@tanstack/react-query", () => ({
+  useSuspenseQuery: (...args: unknown[]) => mockUseSuspenseQuery(...args),
+}));
+
+vi.mock("@/hooks/api/usePackages", () => ({
+  getStaffSubmissionPackageQueryOptions: vi.fn(() => ({})),
+}));
+
+// Render DocumentRow as a no-op to keep tests focused
+vi.mock("@/components/App/Submission/DocumentRow", () => ({
+  default: () => null,
+}));
+
+// SubmissionItemReviewConfirmation just passes onClick through to children
+vi.mock("@/components/App/Submission/SubmissionItemReviewConfirmation", () => ({
+  default: ({ children, onClick }: { children: React.ReactElement; onClick: () => void }) => (
+    <span onClick={onClick}>{children}</span>
+  ),
+}));
+
+vi.mock("@/components/App/Projects/ProjectTable/EmptyRow", () => ({
+  default: () => null,
+}));
+
+vi.mock("@/components/Shared/Table/common", () => ({
+  SubmitPrimaryRowTableCell: ({ children }: { children?: React.ReactNode }) => <td>{children}</td>,
+  SubmitTablePrimaryRow: ({ children }: { children?: React.ReactNode }) => <tr>{children}</tr>,
+}));
+
+vi.mock("@/components/App/SubmissionStatusChip", () => ({
+  SubmissionStatusChipStack: () => null,
+}));
+
+// ── Fixtures ────────────────────────────────────────────────────────────────
+
+const makePackage = (statuses: string[]) => ({
+  id: 10,
+  status: statuses,
+  submitted_on: "2024-01-01T00:00:00Z",
+  account_project_work: null,
+});
+
+const makeItem = (method = SubmissionItemMethod.DOCUMENT_UPLOAD): SubmissionItem => ({
+  id: 1,
+  package_id: 10,
+  sort_order: 1,
+  status: "SUBMITTED",
+  submitted_by: "user-1",
+  submitted_on: "2024-01-01T00:00:00Z",
+  type: {
+    id: 5,
+    name: SUBMISSION_ITEM_TYPE.MANAGEMENT_PLAN,
+    submission_method: method,
+  },
+  type_id: 5,
+  version: 1,
+  submissions: [],
+});
+
+const defaultPackageType = { id: 1, name: "Management Plan" } as unknown as PackageType;
+
+// ── Helpers ─────────────────────────────────────────────────────────────────
+
+/**
+ * Wraps the component in a minimal table structure so MUI table cells render without warnings.
+ */
+function renderInTable(ui: React.ReactElement) {
+  return render(
+    <table>
+      <tbody>{ui}</tbody>
+    </table>,
+  );
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────────
+
+describe("StaffSubmissionItemTableRow", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    // Default: user has the package create role
+    mockUseHasRole.mockReturnValue(true);
+    mockUsePackageRoles.mockReturnValue({ create: "mp_create" });
+  });
+
+  describe("Request Update visibility", () => {
+    it("shows Request Update when package has no end status", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["IN_REVIEW"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("Request Update")).toBeInTheDocument();
+    });
+
+    it("hides Request Update when package status is REVIEW_REJECTED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["REVIEW_REJECTED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Request Update")).not.toBeInTheDocument();
+    });
+
+    it("hides Request Update when package status is APPROVED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["APPROVED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Request Update")).not.toBeInTheDocument();
+    });
+
+    it("hides Request Update when package status is ACCEPTED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["ACCEPTED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Request Update")).not.toBeInTheDocument();
+    });
+
+    it("hides Request Update when package status is NOT_APPROVED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["NOT_APPROVED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Request Update")).not.toBeInTheDocument();
+    });
+
+    it("hides Request Update when package status is REJECTED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["REJECTED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Request Update")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Review action visibility", () => {
+    it("shows Review link when package has no end status and was submitted", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["IN_REVIEW"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("Review")).toBeInTheDocument();
+    });
+
+    it("hides Review link when package status is REVIEW_REJECTED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["REVIEW_REJECTED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Review")).not.toBeInTheDocument();
+    });
+
+    it("hides Review link when package status is APPROVED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["APPROVED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem()}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("Review")).not.toBeInTheDocument();
+    });
+
+    it("shows View link (not Review) for form-submission items without end status", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["IN_REVIEW"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem(SubmissionItemMethod.FORM_SUBMISSION)}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.getByText("View")).toBeInTheDocument();
+      expect(screen.queryByText("Review")).not.toBeInTheDocument();
+    });
+
+    it("hides View link for form-submission items when package is REVIEW_REJECTED", () => {
+      mockUseSuspenseQuery.mockReturnValue({
+        data: makePackage(["REVIEW_REJECTED"]),
+        isPending: false,
+      });
+
+      renderInTable(
+        <StaffSubmissionItemTableRow
+          item={makeItem(SubmissionItemMethod.FORM_SUBMISSION)}
+          packageType={defaultPackageType}
+          onRequestUpdate={vi.fn()}
+        />,
+      );
+
+      expect(screen.queryByText("View")).not.toBeInTheDocument();
+    });
+  });
+});

--- a/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/index.tsx
+++ b/submit-web/src/components/App/Submission/SubmissionItemTableRow/StaffSubmissionItemTableRow/index.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/Shared/Table/common";
 import { useSuspenseQuery } from "@tanstack/react-query";
 import { SUBMISSION_TYPE, SUBMISSION_STATUS } from "@/models/Submission";
+import { PackageStatus } from "@/models/Package";
 import EmptyRow from "@/components/App/Projects/ProjectTable/EmptyRow";
 import { SubmissionItemTableRowProps } from "..";
 import SubmissionItemReviewConfirmation from "@/components/App/Submission/SubmissionItemReviewConfirmation";
@@ -64,17 +65,15 @@ export default function StaffSubmissionItemTableRow({
     submissionPackage.account_project_work?.id,
   );
 
-  const isUpdated = useMemo(() => {
-      // Check if any submission in this section has is_updated flag set to true
-      return Boolean(
-        item.submissions?.find((submission) => submission.is_updated)
-      );
-    }, [item.submissions]);
-
   const isPackageInEndStatus = useMemo(() => {
-    // Check if package is in one of the end statuses where updates cannot be requested
-    const endStatuses: string[] = ['APPROVED', 'ACCEPTED', 'REJECTED', 'NOT_APPROVED'];
-    return endStatuses.some(status => submissionPackage.status?.includes(status as any));
+    const endStatuses: PackageStatus[] = [
+      "APPROVED",
+      "ACCEPTED",
+      "REJECTED",
+      "NOT_APPROVED",
+      "REVIEW_REJECTED",
+    ];
+    return endStatuses.some((status) => submissionPackage.status?.includes(status));
   }, [submissionPackage.status]);
 
   // Check if this submission item is GIS (Geospatial Information)
@@ -136,7 +135,6 @@ export default function StaffSubmissionItemTableRow({
             <SubmissionStatusChipStack
               status={item.status}
               isFlaggedForUpdate={hasPendingRequest}
-              isUpdated={isUpdated}
               showOnlyUpdateChips={hasAccountProjectWork}
             />
           </Box>
@@ -151,7 +149,7 @@ export default function StaffSubmissionItemTableRow({
             gap={0.5}
             alignItems={"flex-end"}
           >
-            <When condition={submitted_on && !hasAccountProjectWork}>
+            <When condition={submitted_on && !hasAccountProjectWork && !isPackageInEndStatus}>
               <SubmissionItemReviewConfirmation
                 submissionItem={item}
                 onClick={handleClick}

--- a/submit-web/src/components/App/SubmissionStatusChip/index.tsx
+++ b/submit-web/src/components/App/SubmissionStatusChip/index.tsx
@@ -108,7 +108,7 @@ const statusMap: Record<string, StyleProps> = {
 
   AWAITING_MANAGER_APPROVAL: {
     label: "Awaiting Manager Approval",
-    theme: "orange",
+    theme: "purple",
   },
   UPDATE_REQUESTED: {
     label: "Update Requested",


### PR DESCRIPTION
[https://eao-dst.atlassian.net/browse/SUBMIT-945](https://eao-dst.atlassian.net/browse/SUBMIT-945)
- D9: Sort status chips in canonical display order (primary → review → overlays)
- D16: Suppress Update Requested and Revision overlays when Updated is present
- D1/D21: MP and IEM packages show IN_PROGRESS instead of PARTIALLY_COMPLETED/COMPLETED
- Fix staff pagination to exclude projects with zero visible packages
- Distinguish UPDATE vs REVIEW request types for revision logic
- Hide Review/View links on staff row when package is in end status
- Correct Keycloak group path from EAO_MANAGER to MPT_MANAGER
- Change Awaiting Manager Approval chip theme to purple